### PR TITLE
fix(datasets): preserve in-vocabulary pad token id across Megatron datasets

### DIFF
--- a/megatron/core/datasets/bert_dataset.py
+++ b/megatron/core/datasets/bert_dataset.py
@@ -10,6 +10,7 @@ from megatron.core.datasets.masked_dataset import (
     MaskedWordPieceDataset,
     MaskedWordPieceDatasetConfig,
 )
+from megatron.core.datasets.megatron_dataset import is_out_of_vocab_token_id
 from megatron.core.datasets.utils import Split
 
 
@@ -157,8 +158,10 @@ class BERTMaskedWordPieceDataset(MaskedWordPieceDataset):
         mask_loss[masked_positions] = 1
 
         # For padded sequences, ensure the embedding layer can map the token ID
-        tokens[tokens == self._pad_token_id] = 0
-        labels[labels == self._pad_token_id] = 0
+        vocab_size = getattr(self.config.tokenizer, "vocab_size", None)
+        if is_out_of_vocab_token_id(self._pad_token_id, vocab_size):
+            tokens[tokens == self._pad_token_id] = 0
+            labels[labels == self._pad_token_id] = 0
 
         return {
             "text": tokens,

--- a/megatron/core/datasets/gpt_dataset.py
+++ b/megatron/core/datasets/gpt_dataset.py
@@ -12,7 +12,7 @@ import torch
 
 from megatron.core.datasets.blended_megatron_dataset_config import BlendedMegatronDatasetConfig
 from megatron.core.datasets.indexed_dataset import IndexedDataset
-from megatron.core.datasets.megatron_dataset import MegatronDataset
+from megatron.core.datasets.megatron_dataset import MegatronDataset, is_out_of_vocab_token_id
 from megatron.core.datasets.object_storage_utils import ObjectStorageConfig, is_object_storage_path
 from megatron.core.datasets.utils import Split
 from megatron.core.safe_globals import safe_numpy_load
@@ -312,8 +312,10 @@ class GPTDataset(MegatronDataset):
         loss_mask[labels == self._pad_token_id] = 0.0
 
         # For padded sequences, ensure the embedding layer can map the token ID
-        tokens[tokens == self._pad_token_id] = 0
-        labels[labels == self._pad_token_id] = 0
+        vocab_size = getattr(self.config.tokenizer, "vocab_size", None)
+        if is_out_of_vocab_token_id(self._pad_token_id, vocab_size):
+            tokens[tokens == self._pad_token_id] = 0
+            labels[labels == self._pad_token_id] = 0
 
         # Batch padding sequence so we mask the loss
         if idx is None:

--- a/megatron/core/datasets/megatron_dataset.py
+++ b/megatron/core/datasets/megatron_dataset.py
@@ -20,6 +20,23 @@ LowLevelDataset = Union[IndexedDataset, Iterable]
 _PAD_TOKEN_ID = -1
 
 
+def is_out_of_vocab_token_id(token_id: int, vocab_size: int | None = None) -> bool:
+    """Check whether a token id cannot be used directly as an embedding index.
+
+    Args:
+        token_id (int): The token id to validate.
+        vocab_size (int | None, optional): The tokenizer vocabulary size, if known.
+
+    Returns:
+        bool: True if token_id is negative or greater than or equal to vocab_size.
+    """
+    if token_id < 0:
+        return True
+    if vocab_size is not None and token_id >= vocab_size:
+        return True
+    return False
+
+
 class MegatronDataset(ABC, torch.utils.data.Dataset):
     """The highest level wrapper class from which all dataset classes should inherit
 

--- a/megatron/core/datasets/t5_dataset.py
+++ b/megatron/core/datasets/t5_dataset.py
@@ -14,6 +14,7 @@ from megatron.core.datasets.masked_dataset import (
     MaskedWordPieceDataset,
     MaskedWordPieceDatasetConfig,
 )
+from megatron.core.datasets.megatron_dataset import is_out_of_vocab_token_id
 from megatron.core.datasets.utils import Split
 from megatron.core.utils import get_te_version
 
@@ -312,9 +313,11 @@ class T5MaskedWordPieceDataset(MaskedWordPieceDataset):
         loss_mask[:length_toks_decoder] = 1
 
         # For padded sequences, ensure the embedding layer can map the token ID
-        encoder_input[encoder_input == self._pad_token_id] = 0
-        decoder_input[decoder_input == self._pad_token_id] = 0
-        decoder_output[decoder_output == self._pad_token_id] = 0
+        vocab_size = getattr(self.config.tokenizer, "vocab_size", None)
+        if is_out_of_vocab_token_id(self._pad_token_id, vocab_size):
+            encoder_input[encoder_input == self._pad_token_id] = 0
+            decoder_input[decoder_input == self._pad_token_id] = 0
+            decoder_output[decoder_output == self._pad_token_id] = 0
 
         return {
             "text_enc": encoder_input,

--- a/tests/unit_tests/data/test_gpt_dataset.py
+++ b/tests/unit_tests/data/test_gpt_dataset.py
@@ -12,6 +12,7 @@ import torch
 
 from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
 from megatron.core.datasets.gpt_dataset import GPTDatasetConfig, MockGPTDataset
+from megatron.core.datasets.megatron_dataset import is_out_of_vocab_token_id
 from megatron.core.datasets.utils import compile_helpers
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.utils import _merge_cu_seqlens_across_micro_batch
@@ -188,6 +189,79 @@ def test_inter_document_masking():
     sample = datasets[0][None]
     assert not torch.any(sample["loss_mask"])
     assert "cu_seqlens" in sample
+
+
+def test_is_out_of_vocab_token_id():
+    assert is_out_of_vocab_token_id(-1) is True
+    assert is_out_of_vocab_token_id(-1, vocab_size=8192) is True
+    assert is_out_of_vocab_token_id(0) is False
+    assert is_out_of_vocab_token_id(0, vocab_size=8192) is False
+    assert is_out_of_vocab_token_id(7, vocab_size=8192) is False
+    assert is_out_of_vocab_token_id(8191, vocab_size=8192) is False
+    assert is_out_of_vocab_token_id(8192, vocab_size=8192) is True
+    assert is_out_of_vocab_token_id(100, vocab_size=None) is False
+
+
+def test_pad_token_id_preservation():
+    if torch.distributed.is_available():
+        Utils.initialize_distributed()
+        if torch.distributed.get_rank() == 0:
+            compile_helpers()
+        torch.distributed.barrier()
+    else:
+        compile_helpers()
+
+    # A valid, non-zero pad token id is in [0, vocab_size), so it must be
+    # preserved in both `tokens` and `labels`. The -1 sentinel is out of
+    # vocabulary and must be remapped to 0 so embedding lookups do not crash.
+    valid_pad_id = 7
+    for pad_id, expected_pad_value in [(valid_pad_id, valid_pad_id), (-1, 0)]:
+        tokenizer = MegatronTokenizer.from_pretrained(
+            metadata_path={"library": "null-text"}, vocab_size=_MOCK_VOCAB_SIZE, pad_id=pad_id
+        )
+
+        config = GPTDatasetConfig(
+            random_seed=1234,
+            sequence_length=1024,
+            split="990,10,0",
+            reset_position_ids=True,
+            reset_attention_mask=True,
+            eod_mask_loss=True,
+            drop_last_partial_validation_sequence=False,
+            add_extra_token_to_sequence=False,
+            tokenizer=tokenizer,
+            mid_level_dataset_surplus=0.005,
+        )
+
+        datasets = BlendedMegatronDatasetBuilder(
+            MockGPTDataset, [0, None, 0], lambda: True, config
+        ).build()
+
+        dataset = datasets[1]
+        assert dataset._pad_token_id == pad_id
+
+        # For the -1 sentinel, no out-of-vocabulary value may survive.
+        # For a valid pad id, no token may be forced to 0.
+        for idx in range(10):
+            sample = dataset[idx]
+            if pad_id == -1:
+                assert torch.all(sample["tokens"] >= 0)
+                assert torch.all(sample["labels"] >= 0)
+            else:
+                assert torch.all(sample["tokens"] != 0)
+                assert torch.all(sample["labels"] != 0)
+
+        # Everything after the last EOD token is padding, so the final partial
+        # sample (with drop_last_partial_validation_sequence=False) exposes
+        # trailing padded positions we can inspect deterministically.
+        sample = dataset[dataset.shuffle_index.argmax()]
+        argmax = sample["labels"].shape[0] - torch.flip(sample["labels"], [0]).argmax() - 1
+        assert argmax < sample["labels"].shape[0] - 1
+
+        # Padded positions must keep the in-vocab pad id (or be remapped to 0
+        # for the sentinel), and the loss mask must be zeroed there in all cases.
+        assert torch.all(sample["labels"][argmax + 1 :] == expected_pad_value)
+        assert torch.all(sample["loss_mask"][argmax + 1 :] == 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #2170.

Preserves in-vocabulary `pad_token_id` in `GPTDataset`, `BERTMaskedWordPieceDataset`, and `T5MaskedWordPieceDataset`, only remapping out-of-vocabulary sentinels (such as `-1` or values `>= vocab_size`) to `0` so embedding lookups succeed without corrupting valid in-vocab token IDs.

### Changes
- Added helper `is_out_of_vocab_token_id(token_id: int, vocab_size: int | None = None) -> bool` in `megatron.core.datasets.megatron_dataset`.
- Gated the remapping to `0` on `is_out_of_vocab_token_id` in:
  - `megatron/core/datasets/gpt_dataset.py`
  - `megatron/core/datasets/bert_dataset.py`
  - `megatron/core/datasets/t5_dataset.py`
- Preserved `loss_mask` behavior across all padding positions.

## Tests
- Added unit tests in `tests/unit_tests/data/test_gpt_dataset.py`:
  - `test_is_out_of_vocab_token_id`: boundaries for negative, valid in-vocab, and out-of-vocab values.
  - `test_pad_token_id_preservation`: validates that a non-zero in-vocab pad id is not overwritten with 0, while the `-1` sentinel is safely remapped to 0 and `loss_mask` remains zeroed.