### PR TITLE
Fix strict checkpoint loading with idle rerun state

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -46,8 +46,11 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 from megatron.core.msc_utils import MultiStorageClientFeature, maybe_msc
 from megatron.core.num_microbatches_calculator import update_num_microbatches
 from megatron.core.optimizer import DistributedOptimizer
-from megatron.core.post_training.modelopt.checkpointing import save_modelopt_state, save_sharded_modelopt_state
-from megatron.core.rerun_state_machine import get_rerun_state_machine
+from megatron.core.post_training.modelopt.checkpointing import (
+    save_modelopt_state,
+    save_sharded_modelopt_state,
+)
+from megatron.core.rerun_state_machine import RerunState, get_rerun_state_machine
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.utils import get_pg_rank, get_pg_size, unwrap_model
 from megatron.training.argument_utils import _default_config_from_args
@@ -2716,11 +2719,19 @@ def load_checkpoint(
             and 'rerun_state_machine' in state_dict
         ):
             rerun_state_machine = get_rerun_state_machine()
-            if rerun_state_machine.validate_state_dict(state_dict['rerun_state_machine']):
+            saved_rerun_state = state_dict['rerun_state_machine']
+            restore_rerun_state = rerun_state_machine.validate_state_dict(saved_rerun_state)
+            idle_rerun_state = (
+                isinstance(saved_rerun_state, dict)
+                and saved_rerun_state.get('state') == RerunState.NOT_RUNNING_YET
+            )
+            # Idle checkpoints still contain a rerun shard for cached save plans.
+            # Include it in strict load requests without resuming a rerun.
+            if restore_rerun_state or idle_rerun_state:
                 gen_sd_rerun_state = rerun_state_machine.state_dict(
                     data_iterator=None, ckpt_format=ckpt_format, force=True
                 )
-                ignore_rerun_state = False
+                ignore_rerun_state = not restore_rerun_state
         if ckpt_world_size != run_world_size or ckpt_tp_pp != run_tp_pp or ckpt_dp != run_dp:
             print_rank_0('Job sharding has changed: Rerun state will be ignored')
 

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -15,6 +15,7 @@ from megatron.core.num_microbatches_calculator import (
     init_num_microbatches_calculator,
     unset_num_microbatches_calculator,
 )
+from megatron.core.rerun_state_machine import RerunMode, RerunState, RerunStateMachine
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -504,6 +505,54 @@ def test_load_checkpoint_override_opt_param_scheduler(
         loaded_iter_none, loaded_flops_none = load_checkpoint([new_model], None, None, strict=True)
         assert loaded_iter_none == iteration
         assert loaded_flops_none == num_floating_point_operations_so_far
+
+
+@pytest.mark.parametrize("load_rerun_mode", [RerunMode.DISABLED, RerunMode.VALIDATE_RESULTS])
+def test_strict_load_idle_rerun_checkpoint(
+    init_model_parallel, tmp_path_dist_ckpt, create_ckpt_load_args, load_rerun_mode
+):
+    """Load an idle rerun shard without treating it as a pending rerun."""
+    args = create_ckpt_load_args
+    args.ckpt_format = 'torch_dist'
+    args.use_dist_ckpt = True
+    args.use_distributed_optimizer = False
+    args.dist_ckpt_strictness = 'raise_all'
+    args.no_save_rng = True
+    args.no_load_rng = True
+    args.no_save_optim = True
+    args.no_load_optim = True
+    args.fp16 = False
+    args.bf16 = False
+    args.save_tokenizer_assets = False
+    args.finetune = False
+    config = TransformerConfig(num_layers=1, kv_channels=1)
+    model = MockModel(config)
+    saved_machine = RerunStateMachine(mode=RerunMode.VALIDATE_RESULTS)
+
+    with TempNamedDir(tmp_path_dist_ckpt / "test_strict_idle_rerun", sync=True) as ckpt_dir:
+        args.save = ckpt_dir
+        args.load = ckpt_dir
+        set_args(args)
+        with mock.patch(
+            'megatron.training.checkpointing.get_rerun_state_machine', return_value=saved_machine
+        ):
+            save_checkpoint(123, [model], None, None, 456)
+
+        loaded_model = MockModel(config)
+        with torch.no_grad():
+            loaded_model.l.weight.zero_()
+        loaded_machine = RerunStateMachine(mode=load_rerun_mode)
+        with mock.patch(
+            'megatron.training.checkpointing.get_rerun_state_machine', return_value=loaded_machine
+        ):
+            iteration, flops = load_checkpoint([loaded_model], None, None, strict=True)
+
+        assert iteration == 123
+        assert flops == 456
+        torch.testing.assert_close(loaded_model.l.weight, model.l.weight, rtol=0, atol=0)
+        assert loaded_machine.state == RerunState.NOT_RUNNING_YET
+        assert loaded_machine.mode == load_rerun_mode
+        assert not loaded_machine.rerun_requested
 
 
 def test_dist_checkpoint_versioning(init_model_parallel, tmp_path_dist_ckpt, create_ckpt_load_args):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fix strict loading of checkpoints saved with idle rerun state.

Normal checkpoints saved with rerun validation enabled contain an idle sentinel so cached save plans stay consistent. The load path currently omits that shard because idle state is not an active rerun, causing `raise_all` strictness to report a missing key.

Include the saved shard in eligible same-topology load requests while keeping it excluded from rerun execution. Strict key validation and the existing release, finetune, and topology checks remain unchanged.

## Testing

Both two-GPU `torch_dist` save/load cases pass after rebasing onto `8d5555c93`, covering enabled and disabled rerun validation in the loading job. They check restored model weights, iteration and FLOP counters, and that the loading job's rerun mode is preserved without starting a rerun. Both cases fail with the missing-shard error when using `checkpointing.py` from that base revision.

The test file passes Black. Full-file formatting reports existing differences in `checkpointing.py` outside this change. NVIDIA CI is still pending maintainer vetting.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: Fixes #7428. Related to #4448 and #4378.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
- Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing. Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
