### PR TITLE
MFSDP v2: exclude duplicate copies of shared parameters from gradient statistics

### DIFF
--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -12,7 +12,7 @@ from ..dist_checkpointing.mapping import ShardedStateDict
 from ..distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
     sync_model_weights_from_main_weights,
 )
-from ..transformer.module import MegatronModule
+from ..transformer.module import MegatronModule, param_is_not_shared
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer
 from .optimizer_config import OptimizerConfig
@@ -38,6 +38,17 @@ def count_replication(tensor: DTensor) -> int:
                 "the reduction must be finalized first."
             )
     return replication
+
+
+def _filter_params_for_norm(params: List[torch.nn.Parameter]) -> List[torch.nn.Parameter]:
+    """Drop the duplicate copy of a tied parameter from a global gradient statistic.
+
+    With PP > 1 the tied embedding/output weight is two distinct parameters on
+    different pipeline stages, and ``LanguageModule`` marks the duplicate
+    ``shared = True``. Mesh replicas (tensor-parallel and generalized-TP included)
+    need no filtering: ``count_replication`` already divides them out.
+    """
+    return [param for param in params if param_is_not_shared(param)]
 
 
 class FullyShardedOptimizer(MixedPrecisionOptimizer):
@@ -152,11 +163,14 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         replaces each DTensor with ``grad._local_tensor`` before it runs, so
         ``get_data_parallel_group_if_dtensor`` always sees plain tensors, returns None,
         and the layout is gone by the time the norm is taken.
+
+        Duplicate copies of tied parameters are dropped by ``_filter_params_for_norm``,
+        so each logical gradient is counted once.
         """
         total_norm_squared = torch.zeros(
             (), dtype=torch.float32, device=torch.cuda.current_device()
         )
-        for parameter in self.get_parameters():
+        for parameter in _filter_params_for_norm(self.get_parameters()):
             # MFSDP v2 reduces into parameter.grad; it never populates decoupled_grad,
             # which is a v1 param-and-grad-buffer concept.
             grad = parameter.grad
@@ -183,9 +197,12 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         DTensor-derived data-parallel group. Counting here keeps MFSDP v2 off that path,
         and matches how ``get_grad_norm`` reduces: each rank contributes its own shard,
         divided by the size of any replicated mesh axis, summed over the grad-stats group.
+
+        Duplicate copies of tied parameters are dropped by ``_filter_params_for_norm``,
+        so each logical gradient is counted once.
         """
         total_zeros = torch.zeros((), dtype=torch.float32, device=torch.cuda.current_device())
-        for parameter in self.get_parameters():
+        for parameter in _filter_params_for_norm(self.get_parameters()):
             grad = parameter.grad
             if grad is None:
                 continue

--- a/tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py
@@ -102,3 +102,30 @@ def test_fused_adam_adapter_accepts_mismatched_grads(distributed_setup):
         not torch.equal(parameter_before, parameter.detach())
         for parameter_before, parameter in zip(params_before_step, model.parameters())
     )
+
+
+def test_filter_params_for_norm_drops_shared_duplicate():
+    """A tied parameter's PP-split duplicate must not count in gradient statistics.
+
+    With PP > 1 the tied embedding/output weight exists as two distinct parameters: the
+    first stage's embedding, and the last stage's duplicate that ``LanguageModule`` marks
+    with ``shared = True``. Both carry the same gradient, so a statistic summed over the
+    grad-stats group would count it twice and report ``sqrt(2)`` too large a norm -- the
+    7.071-instead-of-5 reproduction. ``_filter_params_for_norm`` must keep the unmarked
+    copy and drop the marked one.
+
+    Pure parameter bookkeeping, so this needs no CUDA and no multi-rank setup.
+    """
+    from megatron.core.optimizer.fully_sharded_optimizer import _filter_params_for_norm
+
+    embedding = nn.Parameter(torch.zeros(4, 4))
+    output_weight = nn.Parameter(torch.zeros(4, 4))
+    output_weight.shared = True
+
+    # Identity, not ==: comparing Parameters elementwise would be a tensor op.
+    kept = _filter_params_for_norm([embedding, output_weight])
+    assert len(kept) == 1
+    assert kept[0] is embedding
+    # An unmarked parameter is never dropped, so the filter is inert without a tie.
+    assert _filter_params_for_norm([embedding]) == [embedding]
+    assert _filter_params_for_norm([]) == []


### PR DESCRIPTION
## What

`FullyShardedOptimizer.get_grad_norm()` and `count_zeros()` iterate every optimizer parameter and correct only for *replicated DTensor mesh axes*. With PP > 1 the tied embedding/output weight exists as two distinct parameters — the first-stage embedding, and the last-stage duplicate that `LanguageModule` marks `shared = True` — and both copies are summed in the `all_reduce` over `self.get_grad_stats_parallel_group()`. The reported norm comes out `sqrt(2)` too large and gradients are over-clipped; the `num-zeros` metric is inflated the same way.

This PR adds a module-level `_filter_params_for_norm()` helper and uses it in both statistics, so exactly one copy of a tied parameter is counted. Nothing else in either loop changes: the loop bodies, `count_replication(grad)`, `to_local()`, the `all_reduce`, and the `if grad is None: continue` guard are all exactly as on `main`.

## Scope on `main` today: a prerequisite, not a live bug fix on `main`

**On `main` this filter is currently a no-op**, and it is deliberate that it lands ahead of the relaxation it supports:

- `FullyShardedDataParallelV2._validate_config` still rejects `pipeline_model_parallel_size != 1` — `megatron/core/distributed/fsdp/mcore_fsdp_adapter.py`, the `unsupported_parallelisms` list at line ~730.
- `LanguageModule` only sets the duplicate's `shared = True` marker in the `PP > 1` branch — `megatron/core/models/common/language_module/language_module.py:241-267` (the `PP == 1` path returns early at line 241; `weight.shared = True` is at line 267).

So no caller can produce a `shared = True` parameter under MFSDP v2 on `main`, and the filter is inert there. The double counting becomes reachable as soon as MFSDP v2 supports PP, and that relaxation is part of PR #6486's diff. This is the correctness prerequisite / companion for that work, **not** a fix for a reachable bug on `main` today.

## Motivation

Reviewer @guihong-nv's comment on PR #6486 ([discussion_r3979226842](https://github.com/NVIDIA/Megatron-LM/pull/6486#discussion_r3979226842)):

> Enabling PP introduces duplicate embedding/output weights, but FullyShardedOptimizer.get_grad_norm() counts both copies in its WORLD reduction. Its replication correction only covers DP. A four-rank reproduction returned 7.071 instead of 5, causing excessive gradient clipping. Preserve the shared-parameter marker and exclude duplicate copies from gradient statistics.

## Both statistics are fixed

`count_zeros()` — the `num-zeros` metric — double counts identically, and the same filter fixes it. The two loops keep their own independent `if grad is None: continue` guards: MFSDP v2 reads the gradient DTensor to recover the replicated mesh axes that `count_replication()` divides by, so the filter must not look at the gradient at all.

## What is deliberately *not* filtered

Mesh-replicated axes — **tensor-parallel and generalized-TP replicas included** — are not filtered. Those ranks hold an identical copy *of the same parameter* sharing one DTensor gradient, and `count_replication()` already divides each rank's contribution by the number of ranks holding that shard. The shared-parameter case is different in kind: a separate parameter object on a separate pipeline stage, invisible to the mesh layout, which is why it is the only thing the filter removes. This also keeps this path off global process-group lookups.

## Test

`tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py::test_filter_params_for_norm_drops_shared_duplicate` — pure parameter bookkeeping on **CPU**, no CUDA and no multi-rank setup needed. Parameters are compared by identity (`is`), not `==`, since comparing `Parameter`s elementwise would be a tensor op.

## Verification

Run in a clean worktree off `nvidia/main` @ `5bbf72793`:

- `python -m py_compile` on both files — OK
- `uv run --no-sync ruff check --select F821,F811 --isolated <files>` — All checks passed
- repo-config `uv run --no-sync ruff check <files>` — All checks passed
- `uv run --no-sync isort --check-only <files>` — OK (an import line changed)
- no line, added or pre-existing, exceeds 100 chars in either file
- a real CPU check of the extracted `_filter_params_for_norm` source (exec'd verbatim from the edited file, bound to the real `param_is_not_shared` body copied from `megatron/core/transformer/module.py:26-27`), plus the new test's body run verbatim — all assertions pass on torch 2.4.0 / CPU.

**Not run: `pytest`, and any GPU or multi-rank run.** `import megatron.core.optimizer...` fails on this machine with `AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'` (system torch 2.4.0; the failing import is `megatron/core/inference/quantization/mxfp8_tensor.py`), and it reproduces identically on pristine `nvidia/main` with this change stashed — an environment limitation, not an effect of this PR. No test result is claimed beyond the CPU check above.

## Commit signing limitation

`AGENTS.md` asks for signing with both `-s` and `-S`. This commit carries `-s` (`Signed-off-by: Jack Chang <jianbinc@nvidia.com>`), but **`-S` is impossible on the machine it was authored on**: there is no `gpg` (or `gpg2`) binary on `PATH`, and `commit.gpgsign`, `user.signingkey` and `gpg.format` are all unset. The commit is therefore genuinely unsigned and no signature was faked — flagging it so copy-pr-bot / `/ok to test` expectations are set correctly.
