### PR TITLE
Fix MFSDP v2 parameter metadata preservation

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -56,6 +56,10 @@ try:
         fully_shard,
         fully_shard_context,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module_utils import (
+        restore_parameter_attributes,
+        save_parameter_attributes,
+    )
     from megatron.core.distributed.fsdp.src.megatron_fsdp.utils import (
         all_sharding_strategies_in,
         any_sharding_strategy_in,
@@ -91,8 +95,15 @@ def _materialize_meta_module(module: nn.Module, device: torch.device | None) -> 
             "reset_parameters method."
         )
 
+    # Both _apply() and TE reset_parameters() may replace Parameter objects.
+    attributes = {
+        name: save_parameter_attributes(parameter)
+        for name, parameter in module.named_parameters(recurse=False)
+    }
     module._apply(materialize_tensor, recurse=False)
     reset_parameters()
+    for name, saved_attributes in attributes.items():
+        restore_parameter_attributes(module.get_parameter(name), saved_attributes)
 
 
 def _materialize_owned_meta_modules(module: nn.Module, device: torch.device | None) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module_utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Utilities for resolving parameters within FSDP modules."""
+"""Utilities for parameter ownership and metadata in FSDP modules."""
 
 from torch import nn
 
@@ -22,3 +22,48 @@ def get_parameter_owner(root_module: nn.Module, parameter_fqn: str) -> tuple[nn.
     module_name, separator, parameter_name = parameter_fqn.rpartition(".")
     owner = root_module.get_submodule(module_name) if separator else root_module
     return owner, parameter_name
+
+
+# Preserve model metadata across parameter materialization and replacement.
+# Tensor-subclass storage, autograd hooks, and FSDP runtime state remain specific
+# to each Parameter representation.
+_PARAMETER_ATTRIBUTES = (
+    "requires_grad",
+    "sequence_parallel",
+    "shared",
+    "shared_embedding",
+    "tensor_model_parallel",
+    "partition_dim",
+    "partition_stride",
+    "_tensor_parallel_mode",
+    "allreduce",
+    "grad_norm_group",
+    "is_embedding_or_output_parameter",
+    "is_embedding_parameter",
+    "use_muon",
+    "expert_tp",
+    "is_qkv",
+    "qkv_split_shapes",
+    "skip_backward_post_hook",
+    "is_gtp_weight_remat",
+    "gtp_replica_group",
+    "pad_length",
+    "group",
+)
+
+
+def save_parameter_attributes(parameter: nn.Parameter) -> dict[str, object]:
+    """Snapshot model metadata before materializing or replacing a Parameter.
+
+    Values are shallow-copied: process-group references must retain their identity.
+    Extend the shared attribute list when adding a new model-parameter contract.
+    """
+    return {
+        name: getattr(parameter, name) for name in _PARAMETER_ATTRIBUTES if hasattr(parameter, name)
+    }
+
+
+def restore_parameter_attributes(parameter: nn.Parameter, attributes: dict[str, object]) -> None:
+    """Restore saved model metadata, including explicitly false or None values."""
+    for name, value in attributes.items():
+        setattr(parameter, name, value)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -28,7 +28,11 @@ from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .module_utils import get_parameter_owner
+from .module_utils import (
+    get_parameter_owner,
+    restore_parameter_attributes,
+    save_parameter_attributes,
+)
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -268,12 +272,12 @@ class FsdpParameterGroup:
         fsdp_parameters: list[FsdpParameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
         for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
+            attributes = save_parameter_attributes(parameter)
             unsharded_tensor = self._unsharded_model_weight.get_local_tensor(index)
             if parameter.is_meta:
                 # A meta Parameter cannot set .data to a real tensor because their
                 # TensorImpl types are incompatible, so swap in a materialized Parameter.
-                # This may be problematic if attributes from the original Parameter need
-                # to be copied to the unsharded Parameter.
+                # Restore model metadata below after swapping the tensor state.
                 materialized_parameter = nn.Parameter(
                     unsharded_tensor, requires_grad=parameter.requires_grad
                 )
@@ -281,12 +285,14 @@ class FsdpParameterGroup:
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
+            restore_parameter_attributes(parameter, attributes)
             # Parameter-owned markers must not retain their FSDP module tree.
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
+            restore_parameter_attributes(sharded_parameter, attributes)
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -910,6 +910,32 @@ def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
     torch.testing.assert_close(output, expected_output)
 
 
+def test_fully_shard_preserves_parameter_attributes(distributed_setup):
+    """Sharded parameters should retain the original model metadata."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Linear(8, 8, bias=False, device=device)
+    attributes = {
+        "is_embedding_or_output_parameter": True,
+        "is_embedding_parameter": True,
+        "use_muon": False,
+        "allreduce": False,
+        "sequence_parallel": True,
+        "tensor_model_parallel": True,
+        "partition_dim": 0,
+        "partition_stride": 1,
+        "qkv_split_shapes": None,
+    }
+    for name, value in attributes.items():
+        setattr(model.weight, name, value)
+
+    with fully_shard_context(device=device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    for name, value in attributes.items():
+        assert getattr(model.weight, name) == value, name
+
+
 def test_meta_parameters_shard_to_mesh_device(distributed_setup):
     """A sharded meta model should support initialization and forward."""
     world_size = distributed_setup.world_size


### PR DESCRIPTION
## Summary

  - add shared helpers to save and restore model metadata in MFSDP v2
  - preserve parameter attributes during meta materialization and sharded parameter creation, including embedding/output markers and explicit Muon
    exclusions

  - keep tensor storage, autograd hooks, and FSDP runtime state specific to each parameter representation
  - add a minimal fully_shard UT that verifies parameter attributes are preserved after sharding

  ## Validation

  PYTHONPATH=$PWD uv run python -m torch.distributed.run --nproc-per-node 2 \
    -m pytest -q --capture=fd \
    tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_fully_shard_preserves_parameter_attributes
