### PR TITLE
fix(optimizer): defer throwaway HDO initialization

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -546,6 +546,7 @@ def _get_megatron_optimizer_based_on_param_groups(
                 pin_cpu_grads=config.pin_cpu_grads,
                 pin_cpu_params=config.pin_cpu_params,
                 param_update_in_fp32=True,
+                defer_sub_optimizer_init=config.use_distributed_optimizer,
                 **optimizer_defaults,
             )
             init_state_fn = None

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -52,6 +52,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         pin_cpu_grads: bool = True,
         pin_cpu_params: bool = True,
         overlap_cpu_optimizer_d2h_h2d: bool = True,
+        defer_sub_optimizer_init: bool = False,
         **kwargs,
     ):
         super(HybridDeviceOptimizer, self).__init__(
@@ -77,7 +78,8 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         self.param_update_in_fp32 = param_update_in_fp32
         self.sub_optimizer_kwargs = kwargs
 
-        self._init_sub_optimizers()
+        if not defer_sub_optimizer_init:
+            self._init_sub_optimizers()
         self._register_load_state_dict_hooks()
 
     def _set_sub_optimizer_grads(self):

--- a/tests/unit_tests/test_optimizer_cpu_offloading.py
+++ b/tests/unit_tests/test_optimizer_cpu_offloading.py
@@ -315,7 +315,7 @@ def test_overlap_cpu_optimizer_d2h_h2d_sync_correctness(
         ), f"Weight {k} value mismatch, max error: {(v - ref_params[k]).abs().max()}"
 
 
-def test_distributed_optimizer_with_cpu_offload_and_fp32_marked_param():
+def test_distributed_optimizer_with_cpu_offload_and_fp32_marked_param(monkeypatch):
     """Test that DistributedOptimizer works with HybridDeviceOptimizer (CPU offloading)
     when the model has mark_keep_in_fp32 parameters without raising non-leaf Tensor ValueError.
     """
@@ -352,7 +352,19 @@ def test_distributed_optimizer_with_cpu_offload_and_fp32_marked_param():
             optimizer_offload_fraction=1.0,
         )
 
+        init_count = 0
+        original_init_sub_optimizers = HybridDeviceOptimizer._init_sub_optimizers
+
+        def counted_init_sub_optimizers(optimizer):
+            nonlocal init_count
+            init_count += 1
+            return original_init_sub_optimizers(optimizer)
+
+        monkeypatch.setattr(
+            HybridDeviceOptimizer, '_init_sub_optimizers', counted_init_sub_optimizers
+        )
         optimizer = get_megatron_optimizer(optimizer_config, [ddp_model])
+        assert init_count == 1
 
         inputs = torch.ones(2, 4, device="cuda", dtype=torch.bfloat16)
         output = ddp_model(inputs)


### PR DESCRIPTION

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Avoids allocating CPU parameter copies and FP32 master parameters for the temporary
`HybridDeviceOptimizer` that `DistributedOptimizer` immediately replaces after building
its parameter shards.

## Issue tracking

Linked issue: Fixes #7232

## Details

When CPU optimizer offload and the distributed optimizer are enabled together, the base
HDO currently initializes its sub-optimizers from the unsharded parameter groups. The
distributed optimizer then creates rank-local groups and rebuilds HDO, so the first
materialization is discarded.

This change:

- defers sub-optimizer materialization only when the factory is about to wrap HDO with
  `DistributedOptimizer`;
- deliberately omits the deferral option from `optimizer.defaults`, ensuring the HDO
  rebuilt from shards remains eager;
- extends the existing distributed-offload regression test to assert one HDO
  materialization before completing forward, backward and optimizer step.

Non-distributed HDO construction and the final sharded optimizer keep their existing
eager behavior. Optimizer math, parameter partitioning and checkpoint contents are
unchanged.

## Contribution process

### Pre-checks

- [x] I have added relevant functional coverage to the existing distributed optimizer
  test
- [x] I have added proper typing to my code
- [x] Documentation is not required; this is an internal lifecycle fix with no user-facing
  option
- [x] I have run `tools/autoformat.sh` in check-only mode on my PR

## Validation

- `python3 -m py_compile` on the changed Python files: passed
- Targeted Linux CUDA regression on an H200 (CUDA 13.0, PyTorch 2.13):

```bash
pytest -q tests/unit_tests/test_optimizer_cpu_offloading.py \
  -k distributed_optimizer_with_cpu_offload_and_fp32_marked_param
# 1 passed, 73 deselected
```

  The extended assertion (one HDO materialization before the forward/backward/step
  completes) holds, so the throwaway initialization really is gone on this path.

- Whole-file regression, covering the non-distributed and eager HDO paths this change
  deliberately leaves alone:

```bash
pytest -q tests/unit_tests/test_optimizer_cpu_offloading.py
# 74 passed
```

