### PR TITLE
[QSA 1/4] Add QSA reference indexer and sparse KL loss

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/ops/qsa_stable_topk.py
+++ b/megatron/core/transformer/experimental_attention_variant/ops/qsa_stable_topk.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""The canonical PyTorch definition of the QSA Top-K tie contract.
+
+QSA Top-K is defined by one lexicographic key:
+
+1. score descending (bitwise FP32 comparison, no tolerance);
+2. on bitwise-equal score, block ID ascending.
+
+That contract exists because QSA's score is a sum of ReLUs. Many blocks can be
+tied at exactly zero, so "exact Top-K" is not a single set unless a tie-break is
+defined. ``torch.topk`` does not define which tied elements are returned, so it
+must not decide a QSA route, a KL support mask, or a test expectation.
+
+A stable descending sort of a block-ID-ascending axis *is* that key, and this
+module is the single PyTorch definition that optimized backends must match.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def qsa_stable_topk_indices(scores: torch.Tensor, topk: int) -> torch.Tensor:
+    """Return canonical Top-K indices along the last dimension.
+
+    Args:
+        scores: Tensor of shape ``[..., P]``. Excluded candidates must carry
+            ``-inf`` so they sort below every live candidate while keeping their
+            relative index order.
+        topk: Number of indices to keep.  Must not exceed ``P``.
+
+    Returns:
+        int64 indices ``[..., topk]`` ordered score descending, index ascending.
+    """
+    if topk < 0 or topk > scores.size(-1):
+        raise ValueError(f"topk={topk} is outside [0, {scores.size(-1)}]")
+    # The sort input axis is index-ascending by construction, and ``stable=True``
+    # preserves that order inside every group of bitwise-equal scores, so the
+    # result is exactly (score descending, index ascending).
+    order = torch.sort(scores, dim=-1, descending=True, stable=True).indices
+    return order[..., :topk]
+
+
+__all__ = ["qsa_stable_topk_indices"]

--- a/megatron/core/transformer/experimental_attention_variant/qsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/qsa.py
@@ -1,0 +1,684 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Qwen QSA compressed-block routing and PyTorch correctness references.
+
+QSA scores complete compressed key blocks, selects a fixed number of blocks,
+expands them back to logical token IDs, and appends the current causal tail.
+These helpers favor explicit semantics over kernel performance. They are
+correctness oracles for optimized backends and are intended for tests and
+short sequences.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import NamedTuple
+
+import torch
+from torch import nn
+
+from megatron.core.transformer.experimental_attention_variant.ops.qsa_stable_topk import (
+    qsa_stable_topk_indices,
+)
+
+_PYTORCH_ORACLE_QUERY_CHUNK_SIZE = 16
+
+
+def _validate_qsa_parameters(token_budget: int, compress_ratio: int) -> None:
+    if compress_ratio <= 1:
+        raise ValueError(f"QSA compress_ratio must be greater than one, got {compress_ratio}.")
+    if token_budget <= 0 or token_budget % compress_ratio != 0:
+        raise ValueError(
+            "QSA token_budget must be positive and divisible by compress_ratio, "
+            f"got token_budget={token_budget}, compress_ratio={compress_ratio}."
+        )
+
+
+class QSAIndexerOutput(NamedTuple):
+    """Discrete QSA routes and optional indexer-loss inputs.
+
+    Attributes:
+        routes: Logical token IDs ``[B, S, token_budget + R - 1]`` in int32.
+        block_logits: Differentiable indexer logits ``[B, S, P]``, or ``None``
+            when the indexer is frozen.
+        support_mask: Boolean blocks entering the indexer KL ``[B, S, P]``, or
+            ``None`` when the indexer is frozen.
+    """
+
+    routes: torch.Tensor
+    block_logits: torch.Tensor | None
+    support_mask: torch.Tensor | None
+
+
+def qsa_raw_block_logits(index_query: torch.Tensor, compressed_key: torch.Tensor) -> torch.Tensor:
+    """Return the unscaled block score from the QSA report.
+
+    Args:
+        index_query: Normalized and rotated index queries ``[..., Sq, H, D]``.
+        compressed_key: Normalized and rotated block keys ``[..., P, D]``.
+
+    Returns:
+        ``sum_h relu(<q_i^h, k_b>)`` with shape ``[..., Sq, P]``.
+    """
+    scores = torch.einsum("...qhd,...pd->...qhp", index_query, compressed_key)
+    return torch.relu(scores).sum(dim=-2)
+
+
+def qsa_block_logits(index_query: torch.Tensor, compressed_key: torch.Tensor) -> torch.Tensor:
+    """Return the scaled QSA logits consumed by routing and indexer KL.
+
+    The released implementation divides the head-summed ReLU score by
+    ``sqrt(D_index)``. This positive scale does not change Top-K ordering, but
+    it is part of the student softmax temperature during indexer training.
+
+    Args:
+        index_query: Normalized and rotated index queries ``[..., Sq, H, D]``.
+        compressed_key: Normalized and rotated block keys ``[..., P, D]``.
+
+    Returns:
+        Scaled block logits ``[..., Sq, P]``.
+    """
+    return qsa_raw_block_logits(index_query, compressed_key) / math.sqrt(index_query.size(-1))
+
+
+def compute_block_scores(index_query: torch.Tensor, compressed_key: torch.Tensor) -> torch.Tensor:
+    """Compute differentiable, unmasked QSA block logits.
+
+    Args:
+        index_query: Index queries ``[B, S, H, D]``.
+        compressed_key: Compressed keys ``[B, P, 1, D]``.
+
+    Returns:
+        Block logits ``[B, S, P]``. FP64 is preserved for gradcheck and lower
+        precision inputs are accumulated in FP32.
+    """
+    if index_query.ndim != 4:
+        raise ValueError(f"index_query must be [B, S, H, D], got {tuple(index_query.shape)}.")
+    if compressed_key.ndim != 4 or compressed_key.size(2) != 1:
+        raise ValueError(f"compressed_key must be [B, P, 1, D], got {tuple(compressed_key.shape)}.")
+    if compressed_key.size(0) != index_query.size(0) or compressed_key.size(-1) != index_query.size(
+        -1
+    ):
+        raise ValueError("QSA index query/key batch and head dimensions must match.")
+    compute_dtype = (
+        index_query.dtype if index_query.dtype in (torch.float32, torch.float64) else torch.float32
+    )
+    return qsa_block_logits(
+        index_query.to(compute_dtype), compressed_key[:, :, 0].to(compute_dtype)
+    )
+
+
+def qsa_block_causal_mask(
+    sequence_length: int,
+    num_blocks: int,
+    sequence_lengths: torch.Tensor,
+    *,
+    compress_ratio: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return where each query may score a complete compressed block.
+
+    Args:
+        sequence_length: Physical query length ``S``.
+        num_blocks: Number of compressed blocks ``P``.
+        sequence_lengths: Right-padded logical lengths ``[B]``.
+        compress_ratio: Tokens represented by one block.
+        device: Device for the returned mask.
+
+    Returns:
+        Boolean causal and padding mask ``[B, S, P]``.
+    """
+    if sequence_lengths.ndim != 1:
+        raise ValueError("sequence_lengths must be rank one.")
+    lengths = sequence_lengths.to(device=device, dtype=torch.int64)
+    positions = torch.arange(sequence_length, device=device)
+    block_ids = torch.arange(num_blocks, device=device)
+    visible_blocks = torch.div(positions + 1, compress_ratio, rounding_mode="floor")
+    causal = block_ids.unsqueeze(0) < visible_blocks.unsqueeze(1)
+    available = torch.div(lengths, compress_ratio, rounding_mode="floor")
+    within_length = block_ids.unsqueeze(0) < available.unsqueeze(1)
+    live_rows = positions.unsqueeze(0) < lengths.unsqueeze(1)
+    return causal.unsqueeze(0) & within_length.unsqueeze(1) & live_rows.unsqueeze(-1)
+
+
+def qsa_topk_block_support(
+    block_logits: torch.Tensor, causal_mask: torch.Tensor, *, block_budget: int
+) -> torch.Tensor:
+    """Build the detached Stage-2 KL support from the indexer's Top-K.
+
+    Rows that fit within ``block_budget`` keep every visible block. Sparse rows
+    use the canonical ordering: score descending and block ID ascending for
+    equal scores.
+
+    Args:
+        block_logits: Scaled block logits ``[B, S, P]``.
+        causal_mask: Scorable blocks ``[B, S, P]``.
+        block_budget: Maximum complete blocks in the support.
+
+    Returns:
+        Detached boolean support ``[B, S, P]``.
+    """
+    if block_logits.shape != causal_mask.shape:
+        raise ValueError("block_logits and causal_mask must have the same shape.")
+    if block_budget <= 0:
+        raise ValueError(f"block_budget must be positive, got {block_budget}.")
+    with torch.no_grad():
+        masked = block_logits.detach().masked_fill(~causal_mask, -torch.inf)
+        width = min(block_budget, block_logits.size(-1))
+        chosen = torch.zeros_like(causal_mask)
+        chosen.scatter_(-1, qsa_stable_topk_indices(masked, width), True)
+        visible = causal_mask.sum(dim=-1, keepdim=True)
+        return torch.where(visible > block_budget, causal_mask & chosen, causal_mask)
+
+
+@torch.no_grad()
+def expand_blocks_to_routes(
+    top_blocks: torch.Tensor,
+    valid_blocks: torch.Tensor,
+    query_positions: torch.Tensor,
+    *,
+    compress_ratio: int,
+    block_budget: int,
+    route_width: int,
+) -> torch.Tensor:
+    """Expand selected blocks to token IDs and append the incomplete tail.
+
+    Args:
+        top_blocks: Selected block IDs ``[rows, W]``.
+        valid_blocks: Valid selected slots ``[rows, W]``.
+        query_positions: Logical position of each query row ``[rows]``.
+        compress_ratio: Tokens represented by one block.
+        block_budget: Maximum selected complete blocks.
+        route_width: Fixed output width ``token_budget + compress_ratio - 1``.
+
+    Returns:
+        int32 token routes ``[rows, route_width]`` with ``-1`` padding.
+    """
+    if top_blocks.shape != valid_blocks.shape:
+        raise ValueError("top_blocks and valid_blocks must have the same shape.")
+    device = query_positions.device
+    rows = query_positions.numel()
+    routes = torch.full((rows, route_width), -1, dtype=torch.int32, device=device)
+    block_offsets = torch.arange(compress_ratio, device=device, dtype=torch.int64)
+    tail_offsets = torch.arange(compress_ratio - 1, device=device, dtype=torch.int64)
+    visible_blocks = torch.div(query_positions + 1, compress_ratio, rounding_mode="floor")
+
+    width = top_blocks.size(-1)
+    if width > 0:
+        expanded = top_blocks.unsqueeze(-1) * compress_ratio + block_offsets
+        expanded = expanded.masked_fill(~valid_blocks.unsqueeze(-1), -1)
+        routes[:, : width * compress_ratio] = expanded.flatten(1).to(torch.int32)
+
+    tail_start = visible_blocks * compress_ratio
+    tail_count = query_positions + 1 - tail_start
+    valid_block_count = torch.minimum(visible_blocks, torch.full_like(visible_blocks, block_budget))
+    tail_values = tail_start.unsqueeze(1) + tail_offsets.unsqueeze(0)
+    tail_valid = tail_offsets.unsqueeze(0) < tail_count.unsqueeze(1)
+    if bool(tail_valid.any()):
+        destinations = valid_block_count.unsqueeze(1) * compress_ratio + tail_offsets.unsqueeze(0)
+        row_ids = torch.arange(rows, device=device).unsqueeze(1).expand_as(tail_valid)
+        routes[row_ids[tail_valid], destinations[tail_valid]] = tail_values[tail_valid].to(
+            torch.int32
+        )
+    return routes
+
+
+@torch.no_grad()
+def select_qsa_token_ids(
+    index_query: torch.Tensor,
+    compressed_key: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    *,
+    token_budget: int,
+    compress_ratio: int,
+    query_chunk_size: int = 128,
+    block_logits: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select logical key-token IDs used by QSA sparse attention.
+
+    Complete blocks participate in Top-K. Tokens in the current incomplete
+    block are appended directly, so every valid route remains causal.
+
+    Args:
+        index_query: Index queries ``[B, S, H, D]``.
+        compressed_key: Compressed keys ``[B, P, 1, D]``.
+        sequence_lengths: Right-padded logical lengths ``[B]``.
+        token_budget: Maximum tokens selected from complete blocks.
+        compress_ratio: Tokens represented by one block.
+        query_chunk_size: Query rows scored in one oracle chunk.
+        block_logits: Optional precomputed detached logits ``[B, S, P]``.
+
+    Returns:
+        int32 routes ``[B, S, token_budget + compress_ratio - 1]``.
+    """
+    _validate_qsa_parameters(token_budget, compress_ratio)
+    if index_query.ndim != 4:
+        raise ValueError(f"index_query must be [B, S, H, D], got {tuple(index_query.shape)}.")
+    if compressed_key.ndim != 4 or compressed_key.size(2) != 1:
+        raise ValueError(f"compressed_key must be [B, P, 1, D], got {tuple(compressed_key.shape)}.")
+    batch_size, sequence_length, num_heads, head_dim = index_query.shape
+    if compressed_key.size(0) != batch_size or compressed_key.size(-1) != head_dim:
+        raise ValueError("QSA index query/key batch and head dimensions must match.")
+    if sequence_lengths.shape != (batch_size,):
+        raise ValueError(
+            f"sequence_lengths must have shape [{batch_size}], got {tuple(sequence_lengths.shape)}."
+        )
+    if num_heads <= 0 or head_dim <= 0:
+        raise ValueError("QSA index query head count and dimension must be positive.")
+    if query_chunk_size <= 0:
+        raise ValueError(f"query_chunk_size must be positive, got {query_chunk_size}.")
+    if block_logits is not None and block_logits.shape != (
+        batch_size,
+        sequence_length,
+        compressed_key.size(1),
+    ):
+        raise ValueError("block_logits must have shape [B, S, P].")
+
+    lengths = sequence_lengths.to(device=index_query.device, dtype=torch.int64)
+    if bool(((lengths < 0) | (lengths > sequence_length)).any()):
+        raise ValueError(f"QSA sequence lengths must lie in [0, {sequence_length}].")
+    required_blocks = torch.div(lengths, compress_ratio, rounding_mode="floor")
+    if bool((required_blocks > compressed_key.size(1)).any()):
+        raise ValueError(
+            "compressed_key does not cover all complete logical blocks; "
+            f"need {int(required_blocks.max())}, got {compressed_key.size(1)}."
+        )
+
+    block_budget = token_budget // compress_ratio
+    route_width = token_budget + compress_ratio - 1
+    selected = torch.full(
+        (batch_size, sequence_length, route_width), -1, dtype=torch.int32, device=index_query.device
+    )
+
+    for batch_idx in range(batch_size):
+        logical_length = int(lengths[batch_idx])
+        available_blocks = logical_length // compress_ratio
+        keys = compressed_key[batch_idx, :available_blocks, 0].float()
+
+        for query_start in range(0, logical_length, query_chunk_size):
+            query_end = min(query_start + query_chunk_size, logical_length)
+            query_positions = torch.arange(query_start, query_end, device=index_query.device)
+            visible_blocks = torch.div(query_positions + 1, compress_ratio, rounding_mode="floor")
+            rows = query_end - query_start
+            topk_width = min(block_budget, available_blocks)
+
+            if topk_width > 0:
+                candidate_blocks = torch.arange(topk_width, device=index_query.device)
+                top_blocks = candidate_blocks.unsqueeze(0).expand(rows, -1).clone()
+                valid_blocks = candidate_blocks.unsqueeze(0) < visible_blocks.unsqueeze(1)
+                sparse_rows = visible_blocks > block_budget
+                if bool(sparse_rows.any()):
+                    if block_logits is None:
+                        sparse_query = index_query[batch_idx, query_start:query_end][sparse_rows]
+                        scores = qsa_block_logits(sparse_query.float(), keys)
+                    else:
+                        scores = block_logits[batch_idx, query_start:query_end][sparse_rows][
+                            :, :available_blocks
+                        ].float()
+                    block_ids = torch.arange(available_blocks, device=index_query.device)
+                    sparse_visible = visible_blocks[sparse_rows]
+                    scores.masked_fill_(
+                        block_ids.unsqueeze(0) >= sparse_visible.unsqueeze(1), -torch.inf
+                    )
+                    top_blocks[sparse_rows] = qsa_stable_topk_indices(scores, block_budget)
+                    valid_blocks[sparse_rows] = True
+                selected_blocks, selected_valid = top_blocks, valid_blocks
+            else:
+                selected_blocks = torch.zeros(
+                    (rows, 0), dtype=torch.int64, device=index_query.device
+                )
+                selected_valid = torch.zeros((rows, 0), dtype=torch.bool, device=index_query.device)
+
+            selected[batch_idx, query_start:query_end] = expand_blocks_to_routes(
+                selected_blocks,
+                selected_valid,
+                query_positions,
+                compress_ratio=compress_ratio,
+                block_budget=block_budget,
+                route_width=route_width,
+            )
+    return selected
+
+
+def unfused_qsa_gqa_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    selected_token_ids: torch.Tensor,
+    *,
+    softmax_scale: float | None = None,
+) -> torch.Tensor:
+    """Run a differentiable PyTorch QSA GQA correctness oracle.
+
+    Args:
+        query: Main-attention queries ``[B, Sq, Hq, D]``.
+        key: Main-attention keys ``[B, Skv, Hkv, D]``.
+        value: Main-attention values ``[B, Skv, Hkv, D]``.
+        selected_token_ids: Logical key IDs ``[B, Sq, K]`` with ``-1`` padding.
+        softmax_scale: Score multiplier, defaulting to ``1 / sqrt(D)``.
+
+    Returns:
+        Sparse attention output ``[B, Sq, Hq, D]``.
+    """
+    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+        raise ValueError("QSA query, key, and value must use [B, S, H, D] layout.")
+    if key.shape != value.shape:
+        raise ValueError(
+            f"QSA key and value shapes must match, got {tuple(key.shape)} and {tuple(value.shape)}."
+        )
+    batch_size, query_length, num_query_heads, head_dim = query.shape
+    key_length = key.size(1)
+    num_kv_heads = key.size(2)
+    if key.size(0) != batch_size or key.size(-1) != head_dim:
+        raise ValueError("QSA main query/key batch and head dimensions must match.")
+    if num_kv_heads <= 0 or num_query_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"QSA requires Hq divisible by Hkv, got Hq={num_query_heads}, Hkv={num_kv_heads}."
+        )
+    if selected_token_ids.ndim != 3 or selected_token_ids.shape[:2] != (batch_size, query_length):
+        raise ValueError("selected_token_ids must be [B, Sq, K] matching query.")
+    if bool(((selected_token_ids < -1) | (selected_token_ids >= key_length)).any()):
+        raise ValueError("QSA selected token IDs must be -1 or a valid key position.")
+    if query_length == 0:
+        return torch.empty_like(query)
+
+    scale = head_dim**-0.5 if softmax_scale is None else softmax_scale
+    query_groups = num_query_heads // num_kv_heads
+    grouped_query = query.unflatten(2, (num_kv_heads, query_groups))
+    outputs = []
+
+    for query_start in range(0, query_length, _PYTORCH_ORACLE_QUERY_CHUNK_SIZE):
+        query_end = min(query_start + _PYTORCH_ORACLE_QUERY_CHUNK_SIZE, query_length)
+        chunk_query = grouped_query[:, query_start:query_end]
+        token_ids = selected_token_ids[:, query_start:query_end].long()
+        valid = token_ids >= 0
+        safe_ids = token_ids.clamp_min(0)
+        batch_ids = torch.arange(batch_size, device=query.device).view(batch_size, 1, 1)
+
+        gathered_key = key[batch_ids, safe_ids].permute(0, 1, 3, 2, 4)
+        gathered_value = value[batch_ids, safe_ids].permute(0, 1, 3, 2, 4)
+        scores = torch.einsum("bqhgd,bqhkd->bqhgk", chunk_query.float(), gathered_key.float())
+        scores.mul_(scale)
+        score_valid = valid[:, :, None, None, :]
+        scores.masked_fill_(~score_valid, -torch.inf)
+        has_routes = valid.any(dim=-1)
+        scores = torch.where(has_routes[:, :, None, None, None], scores, torch.zeros_like(scores))
+        probabilities = torch.softmax(scores, dim=-1).masked_fill(~score_valid, 0.0)
+        chunk_output = torch.einsum("bqhgk,bqhkd->bqhgd", probabilities, gathered_value.float())
+        outputs.append(chunk_output.flatten(2, 3).to(query.dtype))
+
+    return torch.cat(outputs, dim=1)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    first, second = x.chunk(2, dim=-1)
+    return torch.cat((-second, first), dim=-1)
+
+
+def _apply_qsa_rope(states: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    rotary_width = cos.size(-1)
+    if rotary_width <= 0 or rotary_width % 2 != 0 or rotary_width > states.size(-1):
+        raise ValueError(
+            "QSA rotary width must be positive, even, and no wider than the index head; "
+            f"got rotary_width={rotary_width}, head_dim={states.size(-1)}."
+        )
+    rotary, passthrough = states[..., :rotary_width], states[..., rotary_width:]
+    rotary = rotary * cos + _rotate_half(rotary) * sin
+    return torch.cat((rotary, passthrough), dim=-1)
+
+
+class QSAZeroCenteredRMSNorm(nn.Module):
+    """Qwen QSA zero-centered RMSNorm used by indexer checkpoints."""
+
+    def __init__(self, hidden_size: int, eps: float, dtype: torch.dtype) -> None:
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Normalize the last dimension and apply zero-centered weight."""
+        output = hidden_states.float()
+        output = output * torch.rsqrt(output.square().mean(dim=-1, keepdim=True) + self.eps)
+        return (output * (1.0 + self.weight.float())).to(hidden_states.dtype)
+
+
+class QSAIndexer(nn.Module):
+    """Qwen QSA block indexer for MCore ``[S, B, H]`` hidden states."""
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_query_heads: int,
+        num_key_heads: int,
+        head_dim: int,
+        compress_ratio: int,
+        token_budget: int,
+        norm_epsilon: float = 1e-6,
+        attention_scaling: float = 1.0,
+        params_dtype: torch.dtype = torch.bfloat16,
+        query_chunk_size: int = 128,
+        qsa_indexer_loss_coeff: float = 0.0,
+        qsa_indexer_use_sparse_loss: bool = True,
+    ) -> None:
+        super().__init__()
+        _validate_qsa_parameters(token_budget, compress_ratio)
+        if hidden_size <= 0 or num_query_heads <= 0 or head_dim <= 0:
+            raise ValueError(
+                "QSA hidden size, query head count, and head dimension must be positive."
+            )
+        if num_key_heads != 1:
+            raise ValueError(f"Qwen QSA requires exactly one index key head, got {num_key_heads}.")
+        if query_chunk_size <= 0:
+            raise ValueError(f"query_chunk_size must be positive, got {query_chunk_size}.")
+        if not isinstance(qsa_indexer_loss_coeff, (int, float)) or isinstance(
+            qsa_indexer_loss_coeff, bool
+        ):
+            raise TypeError(
+                f"qsa_indexer_loss_coeff must be a number, got {qsa_indexer_loss_coeff!r}."
+            )
+        coefficient = float(qsa_indexer_loss_coeff)
+        if not math.isfinite(coefficient) or coefficient < 0.0:
+            raise ValueError(
+                "qsa_indexer_loss_coeff must be finite and non-negative, "
+                f"got {qsa_indexer_loss_coeff!r}."
+            )
+
+        self.hidden_size = hidden_size
+        self.num_query_heads = num_query_heads
+        self.num_key_heads = num_key_heads
+        self.head_dim = head_dim
+        self.compress_ratio = compress_ratio
+        self.token_budget = token_budget
+        self.attention_scaling = attention_scaling
+        self.query_chunk_size = query_chunk_size
+        self.qsa_indexer_loss_coeff = coefficient
+        self.qsa_indexer_use_sparse_loss = bool(qsa_indexer_use_sparse_loss)
+        self.indexer_is_trainable = coefficient > 0.0
+
+        self.index_qk_proj = nn.Linear(
+            hidden_size,
+            (num_query_heads + num_key_heads) * head_dim,
+            bias=False,
+            dtype=params_dtype,
+        )
+        self.q_layernorm = QSAZeroCenteredRMSNorm(head_dim, norm_epsilon, params_dtype)
+        self.k_layernorm = QSAZeroCenteredRMSNorm(head_dim, norm_epsilon, params_dtype)
+        self.requires_grad_(self.indexer_is_trainable)
+
+    def index_states(
+        self, hidden_states: torch.Tensor, rotary_pos_emb: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project, normalize, pool, and rotate QSA index states.
+
+        Keys are average-pooled before RoPE and each block key uses the block's
+        start position. The RoPE tensor controls the rotary prefix width; the
+        remaining index-head channels pass through unchanged.
+
+        Args:
+            hidden_states: Decoder input ``[S, B, hidden_size]``.
+            rotary_pos_emb: Rotary angles ``[S, 1, 1, rotary_width]``.
+
+        Returns:
+            Queries ``[B, S, H, D]`` and compressed keys ``[B, P, 1, D]``.
+        """
+        if hidden_states.ndim != 3 or hidden_states.size(-1) != self.hidden_size:
+            raise ValueError(
+                f"hidden_states must be [S, B, {self.hidden_size}], "
+                f"got {tuple(hidden_states.shape)}."
+            )
+        sequence_length, batch_size, _ = hidden_states.shape
+        if rotary_pos_emb.size(0) < sequence_length:
+            raise ValueError("rotary_pos_emb must cover every input position.")
+
+        qk = self.index_qk_proj(hidden_states)
+        query_width = self.num_query_heads * self.head_dim
+        query, raw_key = torch.split(qk, [query_width, self.head_dim], dim=-1)
+        query = query.view(
+            sequence_length, batch_size, self.num_query_heads, self.head_dim
+        ).permute(1, 0, 2, 3)
+        raw_key = raw_key.view(sequence_length, batch_size, 1, self.head_dim).permute(1, 0, 2, 3)
+        query = self.q_layernorm(query)
+
+        frequencies = rotary_pos_emb.reshape(rotary_pos_emb.size(0), -1)[:sequence_length]
+        cos = (torch.cos(frequencies) * self.attention_scaling).to(query.dtype)
+        sin = (torch.sin(frequencies) * self.attention_scaling).to(query.dtype)
+        query = _apply_qsa_rope(query, cos[None, :, None, :], sin[None, :, None, :])
+
+        num_blocks = sequence_length // self.compress_ratio
+        usable_tokens = num_blocks * self.compress_ratio
+        pooled_key = raw_key[:, :usable_tokens].reshape(
+            batch_size, num_blocks, self.compress_ratio, self.head_dim
+        )
+        pooled_key = pooled_key.float().mean(dim=2).to(raw_key.dtype).unsqueeze(2)
+        pooled_key = self.k_layernorm(pooled_key)
+        block_starts = torch.arange(num_blocks, device=hidden_states.device) * self.compress_ratio
+        pooled_key = _apply_qsa_rope(
+            pooled_key, cos[block_starts][None, :, None, :], sin[block_starts][None, :, None, :]
+        )
+        return query, pooled_key
+
+    def route_and_score(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        sequence_lengths: torch.Tensor | None = None,
+    ) -> QSAIndexerOutput:
+        """Run one projection and return routes plus optional KL inputs.
+
+        A zero loss coefficient keeps the indexer frozen and avoids allocating
+        the quadratic reference logit matrix. A positive coefficient preserves
+        differentiable logits while deriving routes and support from a detached
+        view, so no gradient crosses the discrete Top-K.
+
+        Args:
+            hidden_states: Decoder input ``[S, B, hidden_size]``.
+            rotary_pos_emb: Rotary angles ``[S, 1, 1, rotary_width]``.
+            sequence_lengths: Optional right-padded logical lengths ``[B]``.
+
+        Returns:
+            Routes and optional differentiable KL inputs.
+        """
+        if hidden_states.ndim != 3:
+            raise ValueError(
+                f"route_and_score expects [S, B, hidden_size], got {tuple(hidden_states.shape)}."
+            )
+        sequence_length, batch_size, _ = hidden_states.shape
+        if sequence_lengths is None:
+            sequence_lengths = torch.full(
+                (batch_size,), sequence_length, dtype=torch.int64, device=hidden_states.device
+            )
+
+        if not self.indexer_is_trainable:
+            with torch.no_grad():
+                routes = select_qsa_token_ids(
+                    *self.index_states(hidden_states, rotary_pos_emb),
+                    sequence_lengths,
+                    token_budget=self.token_budget,
+                    compress_ratio=self.compress_ratio,
+                    query_chunk_size=self.query_chunk_size,
+                )
+            return QSAIndexerOutput(routes=routes, block_logits=None, support_mask=None)
+
+        query, pooled_key = self.index_states(hidden_states, rotary_pos_emb)
+        block_logits = compute_block_scores(query, pooled_key)
+        detached_logits = block_logits.detach()
+        with torch.no_grad():
+            routes = select_qsa_token_ids(
+                query,
+                pooled_key,
+                sequence_lengths,
+                token_budget=self.token_budget,
+                compress_ratio=self.compress_ratio,
+                query_chunk_size=self.query_chunk_size,
+                block_logits=detached_logits,
+            )
+            causal_mask = qsa_block_causal_mask(
+                sequence_length,
+                pooled_key.size(1),
+                sequence_lengths,
+                compress_ratio=self.compress_ratio,
+                device=hidden_states.device,
+            )
+            support_mask = (
+                qsa_topk_block_support(
+                    detached_logits,
+                    causal_mask,
+                    block_budget=self.token_budget // self.compress_ratio,
+                )
+                if self.qsa_indexer_use_sparse_loss
+                else causal_mask
+            )
+        return QSAIndexerOutput(routes=routes, block_logits=block_logits, support_mask=support_mask)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: torch.Tensor,
+        sequence_lengths: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return QSA token routes for a non-packed input.
+
+        Args:
+            hidden_states: Decoder input ``[S, B, hidden_size]``.
+            rotary_pos_emb: Rotary angles ``[S, 1, 1, rotary_width]``.
+            sequence_lengths: Optional right-padded logical lengths ``[B]``.
+
+        Returns:
+            int32 routes ``[B, S, token_budget + compress_ratio - 1]``.
+        """
+        if hidden_states.ndim != 3 or hidden_states.size(-1) != self.hidden_size:
+            raise ValueError(
+                f"hidden_states must be [S, B, {self.hidden_size}], "
+                f"got {tuple(hidden_states.shape)}."
+            )
+        sequence_length, batch_size, _ = hidden_states.shape
+        if sequence_lengths is None:
+            sequence_lengths = torch.full(
+                (batch_size,), sequence_length, dtype=torch.int64, device=hidden_states.device
+            )
+        query, pooled_key = self.index_states(hidden_states, rotary_pos_emb)
+        return select_qsa_token_ids(
+            query,
+            pooled_key,
+            sequence_lengths,
+            token_budget=self.token_budget,
+            compress_ratio=self.compress_ratio,
+            query_chunk_size=self.query_chunk_size,
+        )
+
+
+__all__ = [
+    "QSAIndexer",
+    "QSAIndexerOutput",
+    "QSAZeroCenteredRMSNorm",
+    "compute_block_scores",
+    "expand_blocks_to_routes",
+    "qsa_block_logits",
+    "qsa_block_causal_mask",
+    "qsa_raw_block_logits",
+    "qsa_topk_block_support",
+    "select_qsa_token_ids",
+    "unfused_qsa_gqa_attention",
+]

--- a/megatron/core/transformer/experimental_attention_variant/qsa_indexer_loss.py
+++ b/megatron/core/transformer/experimental_attention_variant/qsa_indexer_loss.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""PyTorch reference implementation of the QSA indexer KL objective.
+
+The teacher is detached from core attention. Gradients reach only the indexer
+logits, while Top-K support stays non-differentiable. These helpers materialize
+the teacher distribution and are intended for correctness tests and short
+sequences; optimized long-context backends should fuse this reduction.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from megatron.core.transformer.experimental_attention_variant import dsa_indexer_loss, dsa_masking
+
+
+def qsa_teacher_token_distribution(
+    attention_probabilities: torch.Tensor,
+    valid_key_mask: torch.Tensor | None = None,
+    *,
+    tensor_parallel_size: int = 1,
+) -> torch.Tensor:
+    """Build the detached token-level QSA teacher distribution.
+
+    Args:
+        attention_probabilities: Per-head attention probabilities
+            ``[B, H, Sq, Skv]``.
+        valid_key_mask: Optional attendable-key mask ``[B, Sq, Skv]``.
+        tensor_parallel_size: Teacher head-sharding factor. This materialized
+            reference supports only one because it has no process group for
+            the required cross-rank head sum.
+
+    Returns:
+        Detached token distribution ``[B, Sq, Skv]`` in FP32, unless the input
+        is FP64.
+
+    Raises:
+        NotImplementedError: If attention heads are tensor-parallel sharded.
+    """
+    if tensor_parallel_size != 1:
+        raise NotImplementedError(
+            "The materialized QSA teacher must sum over every attention head. "
+            "Use tensor_parallel_size=1 for this reference implementation."
+        )
+    if attention_probabilities.ndim != 4:
+        raise ValueError(
+            "attention_probabilities must be [B, H, Sq, Skv], "
+            f"got {tuple(attention_probabilities.shape)}."
+        )
+    probabilities = attention_probabilities.detach()
+    compute_dtype = torch.float64 if probabilities.dtype == torch.float64 else torch.float32
+    summed = probabilities.to(compute_dtype).sum(dim=1)
+    if valid_key_mask is not None:
+        if valid_key_mask.shape != summed.shape:
+            raise ValueError("valid_key_mask must be [B, Sq, Skv].")
+        summed = summed.masked_fill(~valid_key_mask, 0.0)
+    return dsa_indexer_loss.normalize_indexer_target(summed)
+
+
+def qsa_maxpool_teacher_to_blocks(
+    token_distribution: torch.Tensor, *, compress_ratio: int, num_blocks: int
+) -> torch.Tensor:
+    """Max-pool token teacher mass onto complete compressed blocks.
+
+    Args:
+        token_distribution: Teacher token mass ``[B, Sq, Skv]``.
+        compress_ratio: Tokens represented by one block.
+        num_blocks: Complete block count ``P``.
+
+    Returns:
+        Unnormalized block teacher mass ``[B, Sq, P]``. Incomplete tail tokens
+        are excluded.
+    """
+    if compress_ratio <= 0:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}.")
+    if num_blocks < 0:
+        raise ValueError(f"num_blocks must be non-negative, got {num_blocks}.")
+    usable = num_blocks * compress_ratio
+    if token_distribution.size(-1) < usable:
+        raise ValueError(
+            f"token_distribution covers {token_distribution.size(-1)} keys, "
+            f"fewer than the {usable} tokens spanned by {num_blocks} complete blocks."
+        )
+    complete = token_distribution[..., :usable]
+    return complete.unflatten(-1, (num_blocks, compress_ratio)).amax(dim=-1)
+
+
+def qsa_indexer_kl_loss(
+    block_logits: torch.Tensor,
+    teacher_token_distribution: torch.Tensor,
+    support_mask: torch.Tensor,
+    *,
+    compress_ratio: int,
+    loss_coeff: float,
+    query_valid_rows: torch.Tensor | None = None,
+    calculate_per_token_loss: bool = False,
+) -> torch.Tensor:
+    """Compute the scaled QSA indexer KL on a fixed block support.
+
+    Args:
+        block_logits: Differentiable scaled indexer logits ``[B, Sq, P]``.
+        teacher_token_distribution: Detached teacher token mass
+            ``[B, Sq, Skv]``.
+        support_mask: Blocks entering the KL ``[B, Sq, P]``. Use every causal
+            block for dense warmup or the indexer's detached Top-K for sparse
+            training.
+        compress_ratio: Tokens represented by one block.
+        loss_coeff: Objective multiplier.
+        query_valid_rows: Optional valid-query mask ``[B, Sq]``.
+        calculate_per_token_loss: Return the valid-row sum instead of its mean.
+
+    Returns:
+        Scalar loss carrying gradient into ``block_logits`` only.
+    """
+    if block_logits.shape != support_mask.shape:
+        raise ValueError("block_logits and support_mask must have the same shape.")
+    query_valid_rows = dsa_masking.normalize_query_valid_rows(
+        query_valid_rows,
+        b=block_logits.size(0),
+        sq=block_logits.size(1),
+        device=block_logits.device,
+    )
+    pooled = qsa_maxpool_teacher_to_blocks(
+        teacher_token_distribution.detach(),
+        compress_ratio=compress_ratio,
+        num_blocks=block_logits.size(-1),
+    )
+    pooled = pooled.masked_fill(~support_mask, 0.0).to(block_logits.dtype)
+    target = dsa_indexer_loss.normalize_indexer_target(pooled)
+    student_log_probs = dsa_masking.masked_log_softmax(block_logits, support_mask)
+    return dsa_indexer_loss.indexer_loss_from_target(
+        target,
+        student_log_probs,
+        loss_coeff,
+        query_valid_rows=query_valid_rows,
+        calculate_per_token_loss=calculate_per_token_loss,
+        valid_mask=support_mask,
+    )
+
+
+__all__ = ["qsa_indexer_kl_loss", "qsa_maxpool_teacher_to_blocks", "qsa_teacher_token_distribution"]

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_qsa_indexer_loss.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_qsa_indexer_loss.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Correctness tests for the QSA indexer KL objective."""
+
+import pytest
+import torch
+
+from megatron.core.transformer.experimental_attention_variant.qsa import (
+    QSAIndexer,
+    compute_block_scores,
+    qsa_block_causal_mask,
+    qsa_topk_block_support,
+)
+from megatron.core.transformer.experimental_attention_variant.qsa_indexer_loss import (
+    qsa_indexer_kl_loss,
+    qsa_maxpool_teacher_to_blocks,
+    qsa_teacher_token_distribution,
+)
+
+
+def _teacher(batch, heads, queries, keys, dtype=torch.float64, seed=5):
+    torch.manual_seed(seed)
+    return torch.softmax(torch.randn(batch, heads, queries, keys, dtype=dtype), dim=-1)
+
+
+def test_teacher_pipeline_sums_heads_then_max_pools_blocks() -> None:
+    """Eq. (17): head sum, token L1, then block MaxPool -- not sum pooling."""
+    batch, heads, queries, keys, ratio = 2, 3, 6, 8, 4
+    probabilities = _teacher(batch, heads, queries, keys)
+
+    tokens = qsa_teacher_token_distribution(probabilities)
+    expected_tokens = probabilities.sum(dim=1)
+    expected_tokens = expected_tokens / expected_tokens.sum(dim=-1, keepdim=True)
+    torch.testing.assert_close(tokens, expected_tokens)
+    torch.testing.assert_close(tokens.sum(-1), torch.ones(batch, queries, dtype=torch.float64))
+
+    num_blocks = keys // ratio
+    blocks = qsa_maxpool_teacher_to_blocks(tokens, compress_ratio=ratio, num_blocks=num_blocks)
+    expected_blocks = tokens.unflatten(-1, (num_blocks, ratio)).amax(-1)
+    torch.testing.assert_close(blocks, expected_blocks)
+
+    # The whole point of MaxPool: it must not agree with sum pooling.
+    sum_pooled = tokens.unflatten(-1, (num_blocks, ratio)).sum(-1)
+    assert not torch.allclose(blocks, sum_pooled)
+
+
+def test_incomplete_tail_tokens_never_reach_the_kl() -> None:
+    """The tail block joins core attention but is not a scoring candidate."""
+    batch, heads, queries, keys, ratio = 1, 2, 5, 10, 4
+    num_blocks = keys // ratio  # 2 complete blocks; tokens 8 and 9 are the tail
+    probabilities = _teacher(batch, heads, queries, keys)
+    tokens = qsa_teacher_token_distribution(probabilities)
+
+    torch.manual_seed(11)
+    logits = torch.randn(batch, queries, num_blocks, dtype=torch.float64)
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+    baseline = qsa_indexer_kl_loss(logits, tokens, support, compress_ratio=ratio, loss_coeff=1.0)
+
+    perturbed = tokens.clone()
+    perturbed[..., num_blocks * ratio :] += 10.0  # tail mass only
+    shifted = qsa_indexer_kl_loss(logits, perturbed, support, compress_ratio=ratio, loss_coeff=1.0)
+    torch.testing.assert_close(baseline, shifted)
+
+
+def test_kl_vanishes_when_student_matches_the_pooled_teacher() -> None:
+    batch, heads, queries, keys, ratio = 2, 3, 6, 8, 4
+    num_blocks = keys // ratio
+    tokens = qsa_teacher_token_distribution(_teacher(batch, heads, queries, keys))
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+    pooled = qsa_maxpool_teacher_to_blocks(tokens, compress_ratio=ratio, num_blocks=num_blocks)
+    target = pooled / pooled.sum(-1, keepdim=True)
+
+    loss = qsa_indexer_kl_loss(target.log(), tokens, support, compress_ratio=ratio, loss_coeff=1.0)
+    assert abs(float(loss)) < 1e-12
+
+
+def test_stage_two_support_is_the_detached_indexer_topk() -> None:
+    batch, queries, num_blocks, budget, ratio = 2, 12, 6, 2, 4
+    torch.manual_seed(17)
+    logits = torch.randn(batch, queries, num_blocks, dtype=torch.float64, requires_grad=True)
+    lengths = torch.full((batch,), queries, dtype=torch.int64)
+    causal = qsa_block_causal_mask(
+        queries, num_blocks, lengths, compress_ratio=ratio, device=logits.device
+    )
+    support = qsa_topk_block_support(logits, causal, block_budget=budget)
+
+    assert not support.requires_grad
+    assert bool((support & ~causal).sum() == 0), "support must stay inside the causal mask"
+    visible = causal.sum(-1)
+    sparse = visible > budget
+    assert bool(sparse.any()), "configuration must exercise a real top-k"
+    assert torch.equal(support.sum(-1)[sparse], torch.full_like(support.sum(-1)[sparse], budget))
+    # Rows within budget keep every visible block.
+    assert torch.equal(support[~sparse], causal[~sparse])
+
+
+def test_indexer_kl_gradcheck_in_float64() -> None:
+    """Gradcheck the differentiable chain with a frozen, smooth configuration."""
+    batch, queries, heads, num_blocks, ratio, head_dim = 2, 6, 3, 4, 4, 5
+    keys = num_blocks * ratio
+    torch.manual_seed(19)
+
+    # Strictly positive q and k keep every dot product away from the ReLU kink.
+    index_query = (
+        torch.rand(batch, queries, heads, head_dim, dtype=torch.float64) + 1.0
+    ).requires_grad_(True)
+    compressed_key = (
+        torch.rand(batch, num_blocks, 1, head_dim, dtype=torch.float64) + 1.0
+    ).requires_grad_(True)
+
+    # A teacher with a unique arg-max inside every block, so MaxPool is smooth.
+    tokens = torch.zeros(batch, queries, keys, dtype=torch.float64)
+    peaks = torch.arange(1, num_blocks + 1, dtype=torch.float64)
+    for block in range(num_blocks):
+        tokens[..., block * ratio] = peaks[block]
+        for offset in range(1, ratio):
+            tokens[..., block * ratio + offset] = peaks[block] * 0.1 * offset
+    tokens = tokens / tokens.sum(-1, keepdim=True)
+
+    # Freeze the support: gradcheck must never differentiate the discrete top-k.
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+
+    def objective(query: torch.Tensor, key: torch.Tensor) -> torch.Tensor:
+        logits = compute_block_scores(query, key)
+        return qsa_indexer_kl_loss(logits, tokens, support, compress_ratio=ratio, loss_coeff=1.0)
+
+    assert torch.autograd.gradcheck(objective, (index_query, compressed_key), eps=1e-6, atol=1e-8)
+
+
+def test_indexer_only_training_drives_the_kl_down() -> None:
+    """Freeze everything but the indexer and overfit a fixed teacher."""
+    torch.manual_seed(29)
+    sequence_length, batch_size, hidden_size = 32, 2, 16
+    ratio, budget_tokens, heads, head_dim = 4, 8, 4, 8
+    indexer = QSAIndexer(
+        hidden_size=hidden_size,
+        num_query_heads=heads,
+        num_key_heads=1,
+        head_dim=head_dim,
+        compress_ratio=ratio,
+        token_budget=budget_tokens,
+        params_dtype=torch.float32,
+    )
+    indexer.requires_grad_(True)  # the checkpoint contract freezes it by default
+
+    hidden_states = torch.randn(sequence_length, batch_size, hidden_size)
+    rotary_angles = torch.randn(sequence_length, 1, 1, head_dim // 2)
+    lengths = torch.full((batch_size,), sequence_length, dtype=torch.int64)
+    num_blocks = sequence_length // ratio
+    tokens = qsa_teacher_token_distribution(
+        _teacher(batch_size, 3, sequence_length, sequence_length, dtype=torch.float32, seed=41)
+    )
+    causal = qsa_block_causal_mask(
+        sequence_length, num_blocks, lengths, compress_ratio=ratio, device=hidden_states.device
+    )
+
+    optimizer = torch.optim.Adam(indexer.parameters(), lr=1e-2)
+    before = {name: p.detach().clone() for name, p in indexer.named_parameters()}
+    history = []
+    for _ in range(150):
+        optimizer.zero_grad(set_to_none=True)
+        query, pooled_key = indexer.index_states(hidden_states, rotary_angles)
+        logits = compute_block_scores(query, pooled_key)
+        support = qsa_topk_block_support(logits, causal, block_budget=budget_tokens // ratio)
+        loss = qsa_indexer_kl_loss(logits, tokens, support, compress_ratio=ratio, loss_coeff=1.0)
+        loss.backward()
+        grads = [p.grad for p in indexer.parameters() if p.grad is not None]
+        assert grads, "indexer parameters must receive gradients"
+        assert any(bool(g.abs().sum() > 0) for g in grads), "gradients must be nonzero"
+        optimizer.step()
+        history.append(loss.detach().item())
+
+    assert history[-1] < history[0] * 0.7, f"KL did not fall: {history[0]:.4f} -> {history[-1]:.4f}"
+    assert all(
+        not torch.equal(before[name], p.detach()) for name, p in indexer.named_parameters()
+    ), "every indexer parameter must actually move"
+
+
+def test_teacher_promotes_bf16_to_fp32_and_tracks_the_fp32_reference() -> None:
+    """A BF16 teacher must reduce in FP32; BF16 rows have many small terms."""
+    batch, heads, queries, keys = 2, 8, 6, 32
+    torch.manual_seed(61)
+    logits = torch.randn(batch, heads, queries, keys)
+    bf16 = qsa_teacher_token_distribution(torch.softmax(logits.bfloat16(), dim=-1))
+    fp32 = qsa_teacher_token_distribution(torch.softmax(logits, dim=-1))
+
+    assert bf16.dtype == torch.float32, "BF16 input must reduce and return in FP32"
+    assert fp32.dtype == torch.float32
+    torch.testing.assert_close(bf16.sum(-1), torch.ones(batch, queries))
+    torch.testing.assert_close(bf16, fp32, rtol=3e-2, atol=3e-3)
+
+    doubles = qsa_teacher_token_distribution(torch.softmax(logits.double(), dim=-1))
+    assert doubles.dtype == torch.float64, "FP64 must survive for gradcheck"
+
+
+def test_kl_never_propagates_gradient_into_core_attention() -> None:
+    """The teacher is a target, not a gradient path."""
+    batch, heads, queries, keys, ratio = 1, 4, 8, 16, 4
+    num_blocks = keys // ratio
+    torch.manual_seed(67)
+    attention_scores = torch.randn(batch, heads, queries, keys, requires_grad=True)
+    teacher = qsa_teacher_token_distribution(torch.softmax(attention_scores, dim=-1))
+    assert not teacher.requires_grad, "teacher must be detached"
+
+    logits = torch.randn(batch, queries, num_blocks, requires_grad=True)
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+    qsa_indexer_kl_loss(logits, teacher, support, compress_ratio=ratio, loss_coeff=1.0).backward()
+
+    assert attention_scores.grad is None, "no gradient may reach core attention"
+    assert logits.grad is not None and bool(logits.grad.abs().sum() > 0)
+
+
+def test_dense_stage1_teacher_rejects_head_sharded_tensor_parallelism() -> None:
+    """The materialized Stage-1 helper has no process group for its required head sum."""
+    probabilities = torch.softmax(torch.randn(1, 4, 3, 8), dim=-1)
+    with pytest.raises(NotImplementedError, match="tensor_parallel_size=1"):
+        qsa_teacher_token_distribution(probabilities, tensor_parallel_size=2)
+    qsa_teacher_token_distribution(probabilities, tensor_parallel_size=1)
+
+
+def test_fully_masked_rows_contribute_zero_and_stay_finite() -> None:
+    """A query with no scorable block must not produce NaN or a gradient."""
+    batch, heads, queries, keys, ratio = 1, 3, 6, 8, 4
+    num_blocks = keys // ratio
+    teacher = qsa_teacher_token_distribution(_teacher(batch, heads, queries, keys))
+    torch.manual_seed(71)
+    logits = torch.randn(batch, queries, num_blocks, dtype=torch.float64, requires_grad=True)
+
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+    support[:, 0, :] = False  # query 0 sees no complete block
+    loss = qsa_indexer_kl_loss(logits, teacher, support, compress_ratio=ratio, loss_coeff=1.0)
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert torch.isfinite(logits.grad).all()
+    torch.testing.assert_close(logits.grad[:, 0], torch.zeros_like(logits.grad[:, 0]))
+
+
+def test_padded_query_rows_are_excluded_from_loss_and_gradient() -> None:
+    batch, heads, queries, keys, ratio = 2, 3, 6, 8, 4
+    num_blocks = keys // ratio
+    teacher = qsa_teacher_token_distribution(_teacher(batch, heads, queries, keys))
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+    torch.manual_seed(73)
+    base = torch.randn(batch, queries, num_blocks, dtype=torch.float64)
+
+    valid_rows = torch.ones(batch, queries, dtype=torch.bool)
+    valid_rows[:, 4:] = False  # right padding
+
+    logits = base.clone().requires_grad_(True)
+    loss = qsa_indexer_kl_loss(
+        logits, teacher, support, compress_ratio=ratio, loss_coeff=1.0, query_valid_rows=valid_rows
+    )
+    loss.backward()
+    torch.testing.assert_close(logits.grad[:, 4:], torch.zeros_like(logits.grad[:, 4:]))
+
+    # Perturbing only the padded rows must not move the loss.
+    shifted = base.clone()
+    shifted[:, 4:] += 5.0
+    other = qsa_indexer_kl_loss(
+        shifted, teacher, support, compress_ratio=ratio, loss_coeff=1.0, query_valid_rows=valid_rows
+    )
+    torch.testing.assert_close(loss.detach(), other)
+
+
+def test_query_valid_rows_are_normalized_or_rejected() -> None:
+    teacher = qsa_teacher_token_distribution(_teacher(2, 3, 6, 8))
+    support = torch.ones(2, 6, 2, dtype=torch.bool)
+    logits = torch.randn(2, 6, 2, dtype=torch.float64)
+
+    one_dimensional = qsa_indexer_kl_loss(
+        logits,
+        teacher,
+        support,
+        compress_ratio=4,
+        loss_coeff=1.0,
+        query_valid_rows=torch.tensor([True, True, True, False, False, False]),
+    )
+    expanded = qsa_indexer_kl_loss(
+        logits,
+        teacher,
+        support,
+        compress_ratio=4,
+        loss_coeff=1.0,
+        query_valid_rows=torch.tensor([[True, True, True, False, False, False]] * 2),
+    )
+    torch.testing.assert_close(one_dimensional, expanded)
+
+    with pytest.raises(ValueError, match="query_valid_rows shape mismatch"):
+        qsa_indexer_kl_loss(
+            logits,
+            teacher,
+            support,
+            compress_ratio=4,
+            loss_coeff=1.0,
+            query_valid_rows=torch.ones(2, 1),
+        )
+
+
+def test_loss_coefficient_scales_linearly_and_reductions_are_consistent() -> None:
+    batch, heads, queries, keys, ratio = 2, 3, 8, 8, 4
+    num_blocks = keys // ratio
+    teacher = qsa_teacher_token_distribution(_teacher(batch, heads, queries, keys))
+    support = torch.ones(batch, queries, num_blocks, dtype=torch.bool)
+    torch.manual_seed(79)
+    logits = torch.randn(batch, queries, num_blocks, dtype=torch.float64)
+
+    single = qsa_indexer_kl_loss(logits, teacher, support, compress_ratio=ratio, loss_coeff=1.0)
+    doubled = qsa_indexer_kl_loss(logits, teacher, support, compress_ratio=ratio, loss_coeff=2.0)
+    torch.testing.assert_close(doubled, single * 2.0)
+
+    summed = qsa_indexer_kl_loss(
+        logits,
+        teacher,
+        support,
+        compress_ratio=ratio,
+        loss_coeff=1.0,
+        calculate_per_token_loss=True,
+    )
+    torch.testing.assert_close(summed, single * (batch * queries))
+
+    valid_rows = torch.ones(batch, queries, dtype=torch.bool)
+    valid_rows[:, 6:] = False
+    masked_mean = qsa_indexer_kl_loss(
+        logits, teacher, support, compress_ratio=ratio, loss_coeff=1.0, query_valid_rows=valid_rows
+    )
+    masked_sum = qsa_indexer_kl_loss(
+        logits,
+        teacher,
+        support,
+        compress_ratio=ratio,
+        loss_coeff=1.0,
+        query_valid_rows=valid_rows,
+        calculate_per_token_loss=True,
+    )
+    torch.testing.assert_close(masked_mean, masked_sum / float(valid_rows.sum()))

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_qsa_reference.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_qsa_reference.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the PyTorch QSA indexer and sparse-GQA references."""
+
+import math
+
+import pytest
+import torch
+
+from megatron.core.transformer.experimental_attention_variant.ops.qsa_stable_topk import (
+    qsa_stable_topk_indices,
+)
+from megatron.core.transformer.experimental_attention_variant.qsa import (
+    QSAIndexer,
+    compute_block_scores,
+    qsa_block_causal_mask,
+    qsa_raw_block_logits,
+    select_qsa_token_ids,
+    unfused_qsa_gqa_attention,
+)
+from megatron.core.transformer.experimental_attention_variant.qsa_indexer_loss import (
+    qsa_indexer_kl_loss,
+    qsa_teacher_token_distribution,
+)
+
+_INDEXER_SETTINGS = dict(
+    hidden_size=12,
+    num_query_heads=3,
+    num_key_heads=1,
+    head_dim=4,
+    compress_ratio=2,
+    token_budget=4,
+    norm_epsilon=1e-6,
+    attention_scaling=0.75,
+    params_dtype=torch.float32,
+    query_chunk_size=3,
+)
+
+
+def _indexer(**overrides) -> QSAIndexer:
+    settings = dict(_INDEXER_SETTINGS)
+    settings.update(overrides)
+    return QSAIndexer(**settings)
+
+
+def _indexer_inputs(seed: int = 23) -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(seed)
+    hidden_states = torch.randn(14, 2, _INDEXER_SETTINGS["hidden_size"])
+    rotary_angles = torch.randn(14, 1, 1, _INDEXER_SETTINGS["head_dim"])
+    return hidden_states, rotary_angles
+
+
+def test_block_score_equation_and_scale() -> None:
+    torch.manual_seed(31)
+    batch, queries, heads, blocks, head_dim = 2, 5, 3, 4, 8
+    index_query = torch.randn(batch, queries, heads, head_dim, dtype=torch.float64)
+    compressed_key = torch.randn(batch, blocks, 1, head_dim, dtype=torch.float64)
+
+    raw = qsa_raw_block_logits(index_query, compressed_key[:, :, 0])
+    scaled = compute_block_scores(index_query, compressed_key)
+    expected = torch.zeros_like(raw)
+    for batch_idx in range(batch):
+        for query_idx in range(queries):
+            for block_idx in range(blocks):
+                expected[batch_idx, query_idx, block_idx] = sum(
+                    max(
+                        0.0,
+                        float(
+                            index_query[batch_idx, query_idx, head_idx]
+                            @ compressed_key[batch_idx, block_idx, 0]
+                        ),
+                    )
+                    for head_idx in range(heads)
+                )
+
+    torch.testing.assert_close(raw, expected, rtol=1e-12, atol=1e-12)
+    torch.testing.assert_close(scaled, expected / math.sqrt(head_dim), rtol=1e-12, atol=1e-12)
+    assert raw.dtype == scaled.dtype == torch.float64
+    assert not torch.allclose(raw, scaled)
+
+
+def test_stable_topk_breaks_equal_scores_by_ascending_block_id() -> None:
+    scores = torch.tensor([[4.0, 2.0, 2.0, 3.0, 2.0]])
+    expected = torch.tensor([[0, 3, 1, 2]])
+    assert torch.equal(qsa_stable_topk_indices(scores, 4), expected)
+
+
+def test_routes_are_causal_deterministic_and_respect_right_padding() -> None:
+    sequence_length, ratio, token_budget = 20, 2, 4
+    query = torch.zeros(2, sequence_length, 3, 4)
+    key = torch.zeros(2, sequence_length // ratio, 1, 4)
+    lengths = torch.tensor([sequence_length, 13])
+
+    first = select_qsa_token_ids(
+        query, key, lengths, token_budget=token_budget, compress_ratio=ratio, query_chunk_size=5
+    )
+    second = select_qsa_token_ids(
+        query, key, lengths, token_budget=token_budget, compress_ratio=ratio, query_chunk_size=7
+    )
+
+    assert torch.equal(first, second)
+    assert torch.equal(first[0, -1, :token_budget], torch.arange(token_budget, dtype=torch.int32))
+    positions = torch.arange(sequence_length).view(1, -1, 1)
+    assert not bool(((first >= 0) & (first > positions)).any())
+    assert bool((first[1, lengths[1] :] == -1).all())
+
+
+def test_block_causal_mask_excludes_incomplete_and_padded_blocks() -> None:
+    mask = qsa_block_causal_mask(
+        10, 2, torch.tensor([10, 7]), compress_ratio=4, device=torch.device("cpu")
+    )
+    assert not bool(mask[:, :3].any())
+    assert bool(mask[0, 3:, 0].all())
+    assert bool(mask[0, 7:, 1].all())
+    assert not bool(mask[1, :, 1].any())
+    assert not bool(mask[1, 7:].any())
+
+
+def test_partial_rope_passes_suffix_and_rotates_block_at_start() -> None:
+    head_dim, rotary_dim, ratio = 16, 8, 4
+    sequence_length, hidden_size, heads = 8, 12, 3
+    indexer = QSAIndexer(
+        hidden_size=hidden_size,
+        num_query_heads=heads,
+        num_key_heads=1,
+        head_dim=head_dim,
+        compress_ratio=ratio,
+        token_budget=8,
+        params_dtype=torch.float32,
+    )
+    torch.manual_seed(37)
+    hidden_states = torch.randn(sequence_length, 1, hidden_size)
+    rotary_angles = torch.randn(sequence_length, 1, 1, rotary_dim)
+    query, pooled_key = indexer.index_states(hidden_states, rotary_angles)
+
+    projected = indexer.index_qk_proj(hidden_states)
+    raw_query, raw_key = torch.split(projected, [heads * head_dim, head_dim], dim=-1)
+    raw_query = indexer.q_layernorm(
+        raw_query.view(sequence_length, 1, heads, head_dim).permute(1, 0, 2, 3)
+    )
+    raw_key = raw_key.view(sequence_length, 1, 1, head_dim).permute(1, 0, 2, 3)
+    pooled = indexer.k_layernorm(raw_key.reshape(1, 2, ratio, head_dim).mean(dim=2).unsqueeze(2))
+
+    angles = rotary_angles.reshape(sequence_length, rotary_dim)
+    cos = torch.cos(angles) * indexer.attention_scaling
+    sin = torch.sin(angles) * indexer.attention_scaling
+
+    def rotate(states: torch.Tensor, cos_: torch.Tensor, sin_: torch.Tensor) -> torch.Tensor:
+        first, second = states.chunk(2, dim=-1)
+        return states * cos_ + torch.cat((-second, first), dim=-1) * sin_
+
+    torch.testing.assert_close(query[..., rotary_dim:], raw_query[..., rotary_dim:])
+    torch.testing.assert_close(pooled_key[..., rotary_dim:], pooled[..., rotary_dim:])
+    starts = torch.arange(2) * ratio
+    expected = rotate(
+        pooled[..., :rotary_dim], cos[starts][None, :, None, :], sin[starts][None, :, None, :]
+    )
+    torch.testing.assert_close(pooled_key[..., :rotary_dim], expected)
+    ends = starts + ratio - 1
+    wrong = rotate(
+        pooled[..., :rotary_dim], cos[ends][None, :, None, :], sin[ends][None, :, None, :]
+    )
+    assert not torch.allclose(pooled_key[..., :rotary_dim], wrong)
+
+
+def test_unfused_gqa_matches_direct_per_head_reference_and_backpropagates() -> None:
+    torch.manual_seed(41)
+    query = torch.randn(1, 3, 4, 3, dtype=torch.float64, requires_grad=True)
+    key = torch.randn(1, 4, 2, 3, dtype=torch.float64, requires_grad=True)
+    value = torch.randn(1, 4, 2, 3, dtype=torch.float64, requires_grad=True)
+    routes = torch.tensor([[[0, -1, -1], [0, 1, -1], [0, 1, 2]]], dtype=torch.int32)
+
+    output = unfused_qsa_gqa_attention(query, key, value, routes)
+    expected = torch.zeros_like(output)
+    for query_idx in range(query.size(1)):
+        ids = routes[0, query_idx]
+        ids = ids[ids >= 0].long()
+        for head_idx in range(query.size(2)):
+            kv_head = head_idx // 2
+            scores = query[0, query_idx, head_idx] @ key[0, ids, kv_head].T
+            probabilities = torch.softmax(scores / math.sqrt(query.size(-1)), dim=-1)
+            expected[0, query_idx, head_idx] = probabilities @ value[0, ids, kv_head]
+
+    torch.testing.assert_close(output, expected)
+    output.square().sum().backward()
+    for tensor in (query, key, value):
+        assert tensor.grad is not None
+        assert torch.isfinite(tensor.grad).all()
+        assert bool(tensor.grad.abs().sum() > 0)
+
+
+def test_route_and_score_runs_one_projection_and_keeps_topk_detached() -> None:
+    indexer = _indexer(qsa_indexer_loss_coeff=0.05)
+    hidden_states, rotary_angles = _indexer_inputs()
+    calls = 0
+
+    def count_projection(module, args, output) -> None:
+        nonlocal calls
+        calls += 1
+
+    handle = indexer.index_qk_proj.register_forward_hook(count_projection)
+    output = indexer.route_and_score(hidden_states, rotary_angles)
+    handle.remove()
+
+    assert calls == 1
+    assert output.block_logits is not None and output.block_logits.requires_grad
+    assert output.support_mask is not None and not output.support_mask.requires_grad
+    assert not output.routes.requires_grad
+
+    teacher = qsa_teacher_token_distribution(torch.softmax(torch.randn(2, 3, 14, 14), dim=-1))
+    loss = qsa_indexer_kl_loss(
+        output.block_logits,
+        teacher,
+        output.support_mask,
+        compress_ratio=indexer.compress_ratio,
+        loss_coeff=indexer.qsa_indexer_loss_coeff,
+    )
+    loss.backward()
+    assert all(parameter.grad is not None for parameter in indexer.parameters())
+
+
+def test_zero_loss_coefficient_freezes_indexer_and_skips_loss_tensors() -> None:
+    indexer = _indexer()
+    hidden_states, rotary_angles = _indexer_inputs()
+    output = indexer.route_and_score(hidden_states, rotary_angles)
+
+    assert all(not parameter.requires_grad for parameter in indexer.parameters())
+    assert output.block_logits is None
+    assert output.support_mask is None
+    assert not output.routes.requires_grad
+
+
+def test_sparse_loss_flag_changes_only_support() -> None:
+    hidden_states, rotary_angles = _indexer_inputs()
+    sparse = _indexer(qsa_indexer_loss_coeff=0.05, qsa_indexer_use_sparse_loss=True)
+    dense = _indexer(qsa_indexer_loss_coeff=0.05, qsa_indexer_use_sparse_loss=False)
+    dense.load_state_dict(sparse.state_dict(), strict=True)
+
+    sparse_output = sparse.route_and_score(hidden_states, rotary_angles)
+    dense_output = dense.route_and_score(hidden_states, rotary_angles)
+    assert torch.equal(sparse_output.routes, dense_output.routes)
+    assert bool((sparse_output.support_mask & ~dense_output.support_mask).sum() == 0)
+    assert int(sparse_output.support_mask.sum()) < int(dense_output.support_mask.sum())
+
+
+@pytest.mark.parametrize("coefficient", [-1e-9, float("nan"), float("inf")])
+def test_invalid_loss_coefficients_are_rejected(coefficient: float) -> None:
+    with pytest.raises(ValueError, match="qsa_indexer_loss_coeff"):
+        _indexer(qsa_indexer_loss_coeff=coefficient)
+
+
+def test_boolean_loss_coefficient_is_rejected() -> None:
+    with pytest.raises(TypeError, match="qsa_indexer_loss_coeff"):
+        _indexer(qsa_indexer_loss_coeff=True)


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

This PR adds the first independently reviewable part of the QSA training support proposed in #7060:

- a PyTorch BSHD correctness oracle;
- QSA indexer scoring and routing contracts;
- deterministic block TopK semantics;
- a materialized sparse KL reference objective;
- a differentiable Sparse-GQA attention reference.

The reference implementation defines:

- QSA block-score scaling with `1 / sqrt(index_head_dim)`;
- query/key projection, zero-centered RMSNorm, partial RoPE, block-key mean pooling, and block-start RoPE phase;
- causal complete-block routing and deterministic TopK ordering by score descending, then block ID ascending;
- current-block causal tail handling and right-padding behavior;
- detached teacher construction, attention-head aggregation, token normalization, block MaxPool, and block normalization;
- sparse and dense KL support;
- indexer-only gradient flow;
- frozen and trainable indexer modes with a single projection per forward.

This PR intentionally does not include:

- TileLang kernels;
- the bounded-memory streaming indexer;
- fused Sparse-GQA or fused KL kernels;
- MCore attention/module-spec integration;
- THD, TP, or CP integration.

Those components will be submitted as later, independently reviewable PRs in the series.

Where the semantics match, this implementation reuses the existing DSA masking and indexer-loss helpers.

I also reviewed the DSA-over-GQA series (#7152, #7156, #7158, and #7181). Later QSA kernel and integration PRs will evaluate reuse of those production abstractions while keeping QSA-specific multi-head score aggregation and block-routing semantics separate.

## Validation

```text
26 passed
```

The focused tests cover:

- score equations and `1 / sqrt(index_head_dim)` scaling;
- deterministic TopK tie-breaking;
- causal, incomplete-tail, and right-padding routing;
- partial RoPE and block-start positions;
- Sparse-GQA forward and backward;
- teacher distribution construction;
- sparse and dense KL objectives;
- FP64 gradcheck;
- BF16-to-FP32 teacher reduction;
- teacher gradient isolation;
- indexer-only optimization.

The official `tools/autoformat.sh` check passed for all changed files:

- Black: passed
- isort: passed
- pylint: 10.00/10
- ruff: passed
- `compileall`: passed
- `git diff --check`: passed

## Acknowledgements

This work was developed through a collaborative effort by Engine Architecture Group 5, Engine Infrastructure Department, Xiaohongshu (RedNote), with contributions from Fei Ziyu, Luo Zhaokai, Su Zhan, Jin Huayi, and Ma Mingxiao.

## Issue tracking

Part of #7060

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
  - Not applicable to this reference-only PR. Production kernel and integration coverage will be added in later PRs.
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run `tools/autoformat.sh` on my PR
