### PR TITLE
Support multimodal metadata and vision context parallelism

### DIFF
--- a/megatron/core/models/multimodal/context_parallel.py
+++ b/megatron/core/models/multimodal/context_parallel.py
@@ -10,6 +10,7 @@ from megatron.core.parallel_state import (
     get_context_parallel_group,
     get_context_parallel_rank,
     get_context_parallel_world_size,
+    get_tensor_model_parallel_rank,
 )
 
 
@@ -236,52 +237,48 @@ def _compute_tubelet_aware_split_points(num_frames, temporal_patch_size, cp_size
     Returns ``cp_size + 1`` split points in **frame** indices (not tubelet indices),
     since callers slice per-frame ``cu_seqlens`` and ``imgs_sizes`` with these bounds.
     Splits land on either media boundaries or tubelet boundaries inside a media so
-    that no rank receives a partial tubelet.
+    that no rank receives a partial tubelet. The caller must first add enough dummy
+    media to provide at least one indivisible image or tubelet per CP rank.
     """
     T = temporal_patch_size
-    target_per_rank = total_frames / cp_size
-
-    media_boundaries = [0]
+    unit_lengths = []
     for nf in num_frames:
-        media_boundaries.append(media_boundaries[-1] + nf)
-    boundary_set = set(media_boundaries)
+        num_tubelets = math.ceil(nf / T)
+        if num_tubelets <= 1:
+            unit_lengths.append(nf)
+            continue
+        for start in range(0, nf, T):
+            unit_lengths.append(min(T, nf - start))
+
+    derived_total_frames = sum(unit_lengths)
+    if derived_total_frames != total_frames:
+        total_frames = derived_total_frames
+
+    if len(unit_lengths) < cp_size:
+        raise ValueError(
+            f"Expected at least {cp_size} image/tubelet units after padding, got "
+            f"{len(unit_lengths)} for num_frames={num_frames} and "
+            f"temporal_patch_size={temporal_patch_size}."
+        )
+
+    unit_boundaries = [0]
+    for unit_length in unit_lengths:
+        unit_boundaries.append(unit_boundaries[-1] + unit_length)
 
     split_points = [0]
+    previous_unit_index = 0
     for rank in range(1, cp_size):
-        target_split = int(rank * target_per_rank)
+        remaining_ranks = cp_size - rank
+        minimum_unit_index = previous_unit_index + 1
+        maximum_unit_index = len(unit_lengths) - remaining_ranks
+        target_split = rank * total_frames / cp_size
 
-        # If the target lands exactly on a media boundary, split there cleanly
-        # without forcing a cut into the next media.
-        if target_split in boundary_set:
-            split_point = target_split
-        else:
-            media_idx = 0
-            for i, boundary in enumerate(media_boundaries[1:], 1):
-                if boundary > target_split:
-                    media_idx = i - 1
-                    break
-            else:
-                media_idx = len(num_frames) - 1
-
-            media_start = media_boundaries[media_idx]
-            media_end = media_boundaries[media_idx + 1]
-            nf = num_frames[media_idx]
-            num_tubelets = math.ceil(nf / T)
-
-            if num_tubelets <= 1:
-                if target_split - media_start < media_end - target_split:
-                    split_point = media_start
-                else:
-                    split_point = media_end
-            else:
-                offset_in_media = target_split - media_start
-                tubelet_idx = round(offset_in_media / T)
-                tubelet_idx = max(1, min(tubelet_idx, num_tubelets - 1))
-                split_point = media_start + tubelet_idx * T
-                split_point = min(split_point, media_end)
-
-        split_point = max(split_point, split_points[-1])
-        split_points.append(split_point)
+        best_unit_index = min(
+            range(minimum_unit_index, maximum_unit_index + 1),
+            key=lambda unit_index: abs(unit_boundaries[unit_index] - target_split),
+        )
+        split_points.append(unit_boundaries[best_unit_index])
+        previous_unit_index = best_unit_index
 
     split_points.append(total_frames)
     return split_points
@@ -310,16 +307,122 @@ def _split_num_frames(num_frames, lb, ub):
     return new_num_frames
 
 
+def _partition_contiguous_weights(weights, num_parts):
+    """Partition positive weights into non-empty contiguous parts.
+
+    Return boundaries for a partition that minimizes the maximum part sum.
+    """
+    weights = [int(weight) for weight in weights]
+    if num_parts <= 0:
+        raise ValueError(f"num_parts must be positive, got {num_parts}")
+    if len(weights) < num_parts:
+        raise ValueError(f"cannot create {num_parts} non-empty parts from {len(weights)} weights")
+    if any(weight <= 0 for weight in weights):
+        raise ValueError(f"weights must be positive, got {weights}")
+
+    def required_parts(max_part_sum):
+        parts = 1
+        part_sum = 0
+        for weight in weights:
+            if part_sum + weight > max_part_sum:
+                parts += 1
+                part_sum = weight
+            else:
+                part_sum += weight
+        return parts
+
+    lower = max(max(weights), math.ceil(sum(weights) / num_parts))
+    upper = sum(weights)
+    while lower < upper:
+        candidate = (lower + upper) // 2
+        if required_parts(candidate) <= num_parts:
+            upper = candidate
+        else:
+            lower = candidate + 1
+
+    boundaries = [len(weights)]
+    end = len(weights)
+    for part in range(num_parts - 1, 0, -1):
+        start = end - 1
+        part_sum = weights[start]
+        while start > part and part_sum + weights[start - 1] <= lower:
+            start -= 1
+            part_sum += weights[start]
+        boundaries.append(start)
+        end = start
+    boundaries.append(0)
+    boundaries.reverse()
+    return boundaries
+
+
+def _build_vision_partition_units(seqlens, num_frames=None, temporal_patch_size=1):
+    """Build frame boundaries and post-compression token weights for vision units."""
+    frame_weights = seqlens.tolist() if hasattr(seqlens, "tolist") else list(seqlens)
+    frame_weights = [int(weight) for weight in frame_weights]
+    if num_frames is None or temporal_patch_size <= 1:
+        unit_boundaries = list(range(len(frame_weights) + 1))
+    else:
+        num_frames_list = num_frames.tolist() if hasattr(num_frames, "tolist") else list(num_frames)
+        unit_boundaries = [0]
+        frame_offset = 0
+        for media_num_frames in num_frames_list:
+            media_num_frames = int(media_num_frames)
+            step = 1 if media_num_frames == 1 else temporal_patch_size
+            for unit_start in range(0, media_num_frames, step):
+                unit_boundaries.append(frame_offset + min(unit_start + step, media_num_frames))
+            frame_offset += media_num_frames
+        if frame_offset != len(frame_weights):
+            raise ValueError(
+                f"sum(num_frames)={frame_offset} does not match "
+                f"{len(frame_weights)} frame weights"
+            )
+
+    unit_weights = [
+        frame_weights[unit_boundaries[index]] for index in range(len(unit_boundaries) - 1)
+    ]
+    return unit_boundaries, unit_weights
+
+
+def _compute_token_balanced_split_points(seqlens, cp_size, num_frames=None, temporal_patch_size=1):
+    """Compute contiguous frame boundaries balanced by post-compression token count."""
+    unit_boundaries, unit_weights = _build_vision_partition_units(
+        seqlens, num_frames=num_frames, temporal_patch_size=temporal_patch_size
+    )
+    unit_split_points = _partition_contiguous_weights(unit_weights, cp_size)
+    return [unit_boundaries[index] for index in unit_split_points]
+
+
+def _vision_cp_partition_loads(seqlens, split_points, num_frames=None, temporal_patch_size=1):
+    """Return the vision-token load assigned to each CP partition."""
+    unit_boundaries, unit_weights = _build_vision_partition_units(
+        seqlens, num_frames=num_frames, temporal_patch_size=temporal_patch_size
+    )
+    boundary_to_unit = {
+        frame_boundary: unit_index for unit_index, frame_boundary in enumerate(unit_boundaries)
+    }
+    return [
+        sum(
+            unit_weights[
+                boundary_to_unit[split_points[index]] : boundary_to_unit[split_points[index + 1]]
+            ]
+        )
+        for index in range(len(split_points) - 1)
+    ]
+
+
 def split_to_context_parallel_ranks_dynamic_res(
     global_t,
     global_imgs_sizes,
     global_packed_seq_params,
     *,
     patch_dim,
+    dummy_image_size=None,
     fp8_enabled=False,
     fp8_recipe=None,
     num_frames=None,
     temporal_patch_size=1,
+    balance_by_tokens=False,
+    profile_partition=False,
 ):
     """Split patched vision input across CP ranks.
 
@@ -335,12 +438,17 @@ def split_to_context_parallel_ranks_dynamic_res(
         patch_dim: Patch size of the vision backbone (e.g. 14 for SigLIP, 16 for
             many ViTs). Required because dummy padding tensors are sized in patch
             units and the default would silently mismatch some backbones.
+        dummy_image_size: Side length in pixels for context-parallel dummy images.
+            Defaults to one patch. Increase this when downstream compression (for
+            example pixel shuffle) requires a larger spatial grid.
         fp8_enabled: If True, pad each rank's local sequence to the FP8 multiple
             (16 by default; 32 for ``mxfp8``).
         fp8_recipe: Forwarded to :func:`get_padding` so the FP8 padding multiple
             matches the active recipe.
         num_frames: Per-media frame count, required when ``temporal_patch_size > 1``.
         temporal_patch_size: Tubelet size for temporal compression.
+        balance_by_tokens: Balance contiguous shards by post-compression vision tokens.
+        profile_partition: Log the selected per-rank token loads from TP=0/CP=0.
 
     Returns:
         (local_t, local_imgs_sizes, local_packed_seq_params, has_padding,
@@ -377,11 +485,22 @@ def split_to_context_parallel_ranks_dynamic_res(
         f"{int(global_t.shape[2])} (patch_dim={patch_dim})."
     )
 
+    if dummy_image_size is None:
+        dummy_image_size = patch_dim
+    dummy_image_size = int(dummy_image_size)
+    if dummy_image_size <= 0 or dummy_image_size % patch_dim != 0:
+        raise ValueError(
+            f"dummy_image_size must be a positive multiple of patch_dim={patch_dim}, "
+            f"got {dummy_image_size}."
+        )
+    dummy_patches_per_side = dummy_image_size // patch_dim
     dummy_img_size = torch.tensor(
-        [[patch_dim, patch_dim]], device=global_imgs_sizes.device, dtype=global_imgs_sizes.dtype
+        [[dummy_image_size, dummy_image_size]],
+        device=global_imgs_sizes.device,
+        dtype=global_imgs_sizes.dtype,
     )
     hidden_dim = expected_hidden
-    dummy_seqlen = 1
+    dummy_seqlen = dummy_patches_per_side * dummy_patches_per_side
     dummy_img = torch.zeros(
         [1, dummy_seqlen, hidden_dim], device=global_t.device, dtype=global_t.dtype
     )
@@ -418,19 +537,29 @@ def split_to_context_parallel_ranks_dynamic_res(
     num_padded_ranks = num_padded_imgs
 
     if use_tubelet_aware_split:
-        for _retry in range(cp_size):
-            total_frames = len(global_imgs_sizes)
-            split_points = _compute_tubelet_aware_split_points(
-                num_frames_list, temporal_patch_size, cp_size, total_frames
+        if balance_by_tokens:
+            split_points = _compute_token_balanced_split_points(
+                seqlens,
+                cp_size,
+                num_frames=num_frames_list,
+                temporal_patch_size=temporal_patch_size,
             )
-            num_empty = sum(1 for k in range(cp_size) if split_points[k] == split_points[k + 1])
-            if num_empty == 0:
-                break
-            global_t, global_imgs_sizes, cu_seqlens, num_frames_list = _add_dummies(
-                num_empty, global_t, global_imgs_sizes, cu_seqlens, num_frames_list
-            )
-            num_padded_imgs += num_empty
-            seqlens = cu_seqlens[1:] - cu_seqlens[:-1]
+        else:
+            for _retry in range(cp_size):
+                total_frames = len(global_imgs_sizes)
+                split_points = _compute_tubelet_aware_split_points(
+                    num_frames_list, temporal_patch_size, cp_size, total_frames
+                )
+                num_empty = sum(
+                    1 for rank in range(cp_size) if split_points[rank] == split_points[rank + 1]
+                )
+                if num_empty == 0:
+                    break
+                global_t, global_imgs_sizes, cu_seqlens, num_frames_list = _add_dummies(
+                    num_empty, global_t, global_imgs_sizes, cu_seqlens, num_frames_list
+                )
+                num_padded_imgs += num_empty
+                seqlens = cu_seqlens[1:] - cu_seqlens[:-1]
 
         original_total_frames = total_frames - num_padded_imgs
         if num_padded_imgs > 0 and original_total_frames not in split_points:
@@ -451,12 +580,39 @@ def split_to_context_parallel_ranks_dynamic_res(
         ub = split_points[cp_rank + 1]
         local_num_frames = _split_num_frames(num_frames_list, lb, ub)
     else:
-        seq_per_rank = total_frames // cp_size
-        lb = cp_rank * seq_per_rank
-        # The last rank absorbs the remainder so the union of [lb, ub) ranges
-        # exactly covers the [0, total_frames) image set.
-        ub = (cp_rank + 1) * seq_per_rank if cp_rank < cp_size - 1 else total_frames
+        if balance_by_tokens:
+            split_points = _compute_token_balanced_split_points(seqlens, cp_size)
+            lb = split_points[cp_rank]
+            ub = split_points[cp_rank + 1]
+        else:
+            seq_per_rank = total_frames // cp_size
+            lb = cp_rank * seq_per_rank
+            # The last rank absorbs the remainder so the union of [lb, ub) ranges
+            # exactly covers the [0, total_frames) image set.
+            ub = (cp_rank + 1) * seq_per_rank if cp_rank < cp_size - 1 else total_frames
+            split_points = [rank * seq_per_rank for rank in range(cp_size)] + [total_frames]
         local_num_frames = None
+
+    if profile_partition and cp_rank == 0 and get_tensor_model_parallel_rank() == 0:
+        partition_loads = _vision_cp_partition_loads(
+            seqlens,
+            split_points,
+            num_frames=num_frames_list if use_tubelet_aware_split else None,
+            temporal_patch_size=temporal_patch_size,
+        )
+        mean_load = sum(partition_loads) / len(partition_loads)
+        # Keep this opt-in profile output visible independently of logging configuration.
+        print(  # pylint: disable=bad-builtin
+            "VISION_CP_PARTITION_PROFILE "
+            f"mode={'token_balanced' if balance_by_tokens else 'legacy'} "
+            f"global_rank={torch.distributed.get_rank()} "
+            f"min_tokens={min(partition_loads)} "
+            f"max_tokens={max(partition_loads)} "
+            f"mean_tokens={mean_load:.3f} "
+            f"max_over_mean={max(partition_loads) / mean_load:.6f} "
+            f"loads={','.join(str(load) for load in partition_loads)}",
+            flush=True,
+        )
 
     seqlens_local = torch.cat([torch.tensor([0], device=seqlens.device), seqlens[lb:ub]])
     cu_seqlens_local = torch.cumsum(seqlens_local, dim=0).to(torch.int32)
@@ -525,6 +681,13 @@ def split_to_context_parallel_ranks_dynamic_res(
         local_num_frames = torch.tensor(
             local_num_frames, dtype=torch.int32, device=global_imgs_sizes.device
         )
+
+    assert lb < ub and local_imgs_sizes.numel() > 0, (
+        "Context-parallel split produced an empty local shard: "
+        f"cp_rank={cp_rank}, cp_size={cp_size}, lb={lb}, ub={ub}, "
+        f"num_padded_imgs={num_padded_imgs}, split_points={split_points}, "
+        f"temporal_patch_size={temporal_patch_size}"
+    )
 
     return (
         local_t,

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -12,6 +12,13 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt import GPTModel
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.multimodal.context_parallel import (
+    gather_from_context_parallel_ranks,
+    gather_from_context_parallel_ranks_dynamic_res,
+    get_padding,
+    split_to_context_parallel_ranks,
+    split_to_context_parallel_ranks_dynamic_res,
+)
 from megatron.core.models.vision.clip_vit_model import CLIPViTModel, get_num_image_embeddings
 from megatron.core.models.vision.multimodal_projector import MultimodalProjector
 from megatron.core.models.vision.radio import RADIOViTModel
@@ -136,6 +143,7 @@ class LLaVAModel(MegatronModule):
         radio_interpolate_only_cpe: bool = False,
         radio_cpe_aspect_ratio_select: bool = False,
         radio_disable_cpe: bool = False,
+        use_loss_scaling: bool = False,
         # Audio/video configuration.
         sound_model: Optional[torch.nn.Module] = None,
         sound_projection: Optional[torch.nn.Module] = None,
@@ -143,6 +151,8 @@ class LLaVAModel(MegatronModule):
         temporal_patch_dim: int = 1,
         separate_video_embedder: bool = False,
         temporal_ckpt_compat: bool = False,
+        balance_vision_context_parallel_by_tokens: bool = False,
+        profile_vision_context_parallel_partition: bool = False,
     ) -> None:
         super().__init__(config=language_transformer_config)
 
@@ -187,13 +197,21 @@ class LLaVAModel(MegatronModule):
         self.radio_interpolate_only_cpe = radio_interpolate_only_cpe
         self.radio_cpe_aspect_ratio_select = radio_cpe_aspect_ratio_select
         self.radio_disable_cpe = radio_disable_cpe
+        self.use_loss_scaling = use_loss_scaling
         self.temporal_patch_dim = temporal_patch_dim
         self.separate_video_embedder = separate_video_embedder
         self.temporal_ckpt_compat = temporal_ckpt_compat
+        self._vision_fp8 = bool(vision_transformer_config.fp8 or use_vision_backbone_fp8_arch)
+        self._vision_fp8_recipe = vision_transformer_config.fp8_recipe
+        self._vision_projection_fp8 = bool(vision_projection_config.fp8)
+        self._vision_projection_fp8_recipe = vision_projection_config.fp8_recipe
+        self._balance_vision_context_parallel_by_tokens = balance_vision_context_parallel_by_tokens
+        self._profile_vision_context_parallel_partition = profile_vision_context_parallel_partition
         if self.sequence_parallel_lm or self.context_parallel_lm > 1:
             if not (
                 language_model_type.startswith('nemotron5-hybrid')
                 or language_model_type == 'nemotron6-moe'
+                or language_model_type == 'nemotron6-super'
             ):  # pylint: disable=line-too-long
                 assert isinstance(
                     language_transformer_layer_spec.submodules, TransformerLayerSubmodules
@@ -229,7 +247,9 @@ class LLaVAModel(MegatronModule):
                 self.language_model = build_hf_model(
                     language_transformer_config, language_transformer_config.language_model_type
                 )
-            elif language_model_type.startswith(('nemotron5-hybrid', 'nemotron6-moe')):
+            elif language_model_type.startswith(
+                ('nemotron5-hybrid', 'nemotron6-moe', 'nemotron6-super')
+            ):
                 self.language_model = HybridModel(
                     config=language_transformer_config,
                     hybrid_stack_spec=language_transformer_layer_spec,
@@ -559,6 +579,7 @@ class LLaVAModel(MegatronModule):
         freeze_vision_projection: bool,
         freeze_sound_model: bool = False,
         freeze_sound_projection: bool = False,
+        unfreeze_router: bool = False,
     ):
         """Freeze model modules.
 
@@ -570,6 +591,7 @@ class LLaVAModel(MegatronModule):
             freeze_vision_projection (bool): Freeze the vision projection module.
             freeze_sound_model (bool): Freeze the sound model module.
             freeze_sound_projection (bool): Freeze the sound projection module.
+            unfreeze_router (bool): Keep router weights trainable when freezing the language model.
         """
         modules = []
         if freeze_language_model and self.language_model is not None:
@@ -584,7 +606,9 @@ class LLaVAModel(MegatronModule):
             modules.append(self.sound_projection)
 
         for module in modules:
-            for param in module.parameters():
+            for name, param in module.named_parameters():
+                if unfreeze_router and "router" in name:
+                    continue
                 param.requires_grad = False
 
     def _vision_projection_dtype(self) -> torch.dtype:
@@ -686,7 +710,7 @@ class LLaVAModel(MegatronModule):
         if num_image_tiles is None:
             num_image_tiles = torch.empty((0,), dtype=torch.int32, device=input_ids.device)
         if media_token_counts is not None:
-            media_token_counts = media_token_counts.to(device=input_ids.device)
+            media_token_counts = media_token_counts.to(device=input_ids.device, dtype=torch.int32)
         media_counts = media_token_counts if media_token_counts is not None else num_image_tiles
         has_sound_embeddings = sound_embeddings is not None and sound_embeddings.numel() > 0
         if media_counts.numel() == 0 and not has_sound_embeddings:
@@ -1157,6 +1181,7 @@ class LLaVAModel(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         imgs_sizes: Optional[torch.Tensor] = None,
         vision_packed_seq_params: Optional[PackedSeqParams] = None,
+        has_pad_img: Optional[torch.Tensor | bool] = None,
         # Audio and video inputs.
         sound_clips: Optional[torch.Tensor] = None,
         sound_length: Optional[torch.Tensor] = None,
@@ -1188,6 +1213,7 @@ class LLaVAModel(MegatronModule):
             packed_seq_params (PackedSeqParams): 1) If using sequence packing, must contain
                 subsample length information. 2) If using SP/CP with padding mask type,
                 must contain padded token information.
+            has_pad_img: Whether the final dynamic-resolution image is synthetic FP8 padding.
         Returns:
             output (torch.Tensor): Loss of shape [b, s] if labels are provided,
                 otherwise logits of shape [b, s, vocab_size].
@@ -1205,7 +1231,18 @@ class LLaVAModel(MegatronModule):
             )
         )
         has_images = images is not None and images.shape[0] > 0
+        dataset_has_pad_img = bool(
+            has_pad_img.item() if torch.is_tensor(has_pad_img) else has_pad_img
+        )
         media_token_counts = None
+        vision_tokens_retention_mask = None
+        dynamic_vision_cp = False
+        local_vision_has_padding = dataset_has_pad_img
+        num_padded_vision_ranks = 0
+        static_vision_cp_pad = None
+
+        if num_image_tiles is None and has_images:
+            num_image_tiles = torch.ones(images.shape[0], dtype=torch.int, device=input_ids.device)
 
         # If running inference, we can skip image token computation
         # if they were computed already earlier for this sample.
@@ -1217,6 +1254,7 @@ class LLaVAModel(MegatronModule):
             image_device = images.device if images is not None else input_ids.device
             image_embeddings = self._build_zero_projection_anchor(image_device)
         elif self.add_encoder and has_images:
+            vision_images = images
             # Build packed_seq_params for dynamic-resolution vision fprop.
             if (
                 vision_packed_seq_params is None
@@ -1245,7 +1283,7 @@ class LLaVAModel(MegatronModule):
                 )
 
             if self.temporal_patch_dim > 1 and imgs_sizes is not None and num_frames is None:
-                num_frames = [1] * len(imgs_sizes)
+                num_frames = [1] * (len(imgs_sizes) - int(dataset_has_pad_img))
             if num_frames is not None:
                 if imgs_sizes is None:
                     raise ValueError("Video inputs require imgs_sizes.")
@@ -1260,11 +1298,63 @@ class LLaVAModel(MegatronModule):
                     num_frames = [int(value) for value in num_frames]
                 if any(value <= 0 for value in num_frames):
                     raise ValueError("num_frames entries must be positive.")
-                if sum(num_frames) != len(imgs_sizes):
+                expected_frames = (
+                    len(imgs_sizes) - int(dataset_has_pad_img)
+                    if imgs_sizes is not None
+                    else len(num_image_tiles)
+                )
+                if sum(num_frames) != expected_frames:
                     raise ValueError(
                         "num_frames must partition imgs_sizes exactly: "
                         f"sum(num_frames)={sum(num_frames)}, imgs_sizes={len(imgs_sizes)}."
                     )
+
+            real_imgs_sizes = imgs_sizes[:-1] if dataset_has_pad_img else imgs_sizes
+            global_imgs_sizes = (
+                real_imgs_sizes.clone()
+                if torch.is_tensor(real_imgs_sizes)
+                else list(real_imgs_sizes) if real_imgs_sizes is not None else None
+            )
+            global_num_frames = list(num_frames) if num_frames is not None else None
+            dynamic_vision_cp = (
+                self.context_parallel_lm > 1
+                and imgs_sizes is not None
+                and getattr(self.vision_model, 'dynamic_resolution', False)
+            )
+            if dynamic_vision_cp:
+                if dataset_has_pad_img:
+                    raise ValueError(
+                        "Dynamic-resolution CP expects per-rank FP8 padding; the dataloader "
+                        "provided a global padding image."
+                    )
+                dummy_image_size = self.vision_model.patch_dim
+                if self._pixel_shuffle:
+                    dummy_image_size *= 2
+                (
+                    vision_images,
+                    imgs_sizes,
+                    vision_packed_seq_params,
+                    local_vision_has_padding,
+                    num_padded_vision_ranks,
+                    local_num_frames,
+                ) = split_to_context_parallel_ranks_dynamic_res(
+                    vision_images,
+                    imgs_sizes,
+                    vision_packed_seq_params,
+                    patch_dim=self.vision_model.patch_dim,
+                    dummy_image_size=dummy_image_size,
+                    fp8_enabled=self._vision_fp8,
+                    fp8_recipe=self._vision_fp8_recipe,
+                    num_frames=num_frames,
+                    temporal_patch_size=self.temporal_patch_dim,
+                    balance_by_tokens=self._balance_vision_context_parallel_by_tokens,
+                    profile_partition=self._profile_vision_context_parallel_partition,
+                )
+                if local_num_frames is not None:
+                    num_frames = local_num_frames.tolist()
+            elif self.context_parallel_lm > 1 and imgs_sizes is None and images.shape[0] >= 2:
+                vision_images, static_vision_cp_pad = split_to_context_parallel_ranks(images)
+
             use_temporal = self.temporal_patch_dim > 1 and imgs_sizes is not None
             if use_temporal:
                 if not isinstance(self.vision_model, RADIOViTModel):
@@ -1277,22 +1367,20 @@ class LLaVAModel(MegatronModule):
                         if frame_count == 1
                         else (frame_count + self.temporal_patch_dim - 1) // self.temporal_patch_dim
                     )
-                    for frame_count in num_frames
+                    for frame_count in global_num_frames
                 ]
+                vision_num_frames = list(num_frames)
+                if local_vision_has_padding:
+                    vision_num_frames.append(1)
                 if self._tile_tags is not None:
                     raise NotImplementedError(
                         "Tile tagging is not supported with temporal video inputs."
                     )
-                if self.context_parallel_lm > 1:
-                    raise NotImplementedError(
-                        "Temporal video encoding does not support context parallelism."
-                    )
-
                 image_embeddings, post_imgs_sizes, _ = self.vision_model(
-                    images,
+                    vision_images,
                     imgs_sizes=imgs_sizes,
                     packed_seq_params=vision_packed_seq_params,
-                    num_frames=num_frames,
+                    num_frames=vision_num_frames,
                 )
                 sizes = (
                     post_imgs_sizes.tolist()
@@ -1312,6 +1400,10 @@ class LLaVAModel(MegatronModule):
                 chunks = list(torch.split(image_embeddings.squeeze(0), sequence_lengths, dim=0))
                 if self._drop_vision_class_token and class_token_len > 0:
                     chunks = [chunk[class_token_len:] for chunk in chunks]
+                if local_vision_has_padding:
+                    chunks = chunks[:-1]
+                    post_imgs_sizes = post_imgs_sizes[:-1]
+                    sizes = sizes[:-1]
                 if self._pixel_shuffle:
                     if class_token_len > 0 and not self._drop_vision_class_token:
                         raise ValueError(
@@ -1330,9 +1422,13 @@ class LLaVAModel(MegatronModule):
                 image_embeddings = torch.cat(chunks, dim=0)
 
                 image_embeddings = image_embeddings.unsqueeze(0)
-                if tubelet_token_counts is not None:
-                    media_token_counts = _group_temporal_token_counts_tensor(
-                        tubelet_token_counts, media_tubelet_counts
+                imgs_sizes = post_imgs_sizes
+                if tubelet_token_counts is not None and not dynamic_vision_cp:
+                    media_token_counts = _align_temporal_token_counts_to_placeholders(
+                        tubelet_token_counts,
+                        media_tubelet_counts,
+                        input_ids,
+                        self.image_token_index,
                     )
             else:
                 # Stock CLIPViTModel does not accept VLM-specific kwargs.
@@ -1342,7 +1438,7 @@ class LLaVAModel(MegatronModule):
                 if imgs_sizes is not None:
                     vision_kwargs["imgs_sizes"] = imgs_sizes
                 image_embeddings = self.vision_model(
-                    images, **vision_kwargs
+                    vision_images, **vision_kwargs
                 )  # [num_tiles, img_seq_len, h_vision]
 
                 if self._drop_vision_class_token:
@@ -1383,6 +1479,13 @@ class LLaVAModel(MegatronModule):
                             :, self.vision_model.class_token_len :, :
                         ]
 
+                if local_vision_has_padding:
+                    pad_patch_size = imgs_sizes[-1] // self.vision_model.patch_dim
+                    pad_token_count = int(torch.prod(pad_patch_size).item())
+                    if not self._drop_vision_class_token:
+                        pad_token_count += int(self.vision_model.class_token_len)
+                    image_embeddings = image_embeddings[:, :-pad_token_count, :]
+                    imgs_sizes = imgs_sizes[:-1]
                 if self._pixel_shuffle:
                     if imgs_sizes is not None and getattr(
                         self.vision_model, 'dynamic_resolution', False
@@ -1398,8 +1501,10 @@ class LLaVAModel(MegatronModule):
                 # With temporal_patch_dim=1, encode frames independently but
                 # retain num_frames so one video placeholder can consume the
                 # concatenated embeddings from all of its frames.
-                if num_frames is not None and imgs_sizes is not None and self.add_decoder:
-                    if torch.is_tensor(imgs_sizes):
+                if num_frames is not None and self.add_decoder and not dynamic_vision_cp:
+                    if imgs_sizes is None:
+                        frame_token_counts = num_image_tiles.to(torch.int32) * self.img_seq_len
+                    elif torch.is_tensor(imgs_sizes):
                         frame_token_counts = torch.prod(
                             imgs_sizes // self.patch_dim, dim=-1, dtype=torch.int32
                         )
@@ -1417,10 +1522,8 @@ class LLaVAModel(MegatronModule):
                         frame_token_counts = frame_token_counts + class_token_len
                     if self._pixel_shuffle:
                         frame_token_counts = frame_token_counts // 4
-                    if self._conv_merging:
-                        frame_token_counts = frame_token_counts // 4
-                    media_token_counts = _group_temporal_token_counts_tensor(
-                        frame_token_counts, num_frames
+                    media_token_counts = _align_temporal_token_counts_to_placeholders(
+                        frame_token_counts, num_frames, input_ids, self.image_token_index
                     )
 
             # contiguous() required as `permute` can sparsify the tensor and this breaks pipelining
@@ -1428,10 +1531,88 @@ class LLaVAModel(MegatronModule):
                 1, 0, 2
             ).contiguous()  # [img_seq_len, num_tiles, h_vision]
 
+            vision_projection_padding = 0
+            if dynamic_vision_cp and self._vision_projection_fp8:
+                vision_projection_padding = get_padding(
+                    image_embeddings.shape[0],
+                    1,
+                    1,
+                    False,
+                    fp8_enabled=True,
+                    fp8_recipe=self._vision_projection_fp8_recipe,
+                )
+                if vision_projection_padding > 0:
+                    image_embeddings = torch.cat(
+                        [
+                            image_embeddings,
+                            torch.zeros(
+                                vision_projection_padding,
+                                *image_embeddings.shape[1:],
+                                dtype=image_embeddings.dtype,
+                                device=image_embeddings.device,
+                            ),
+                        ],
+                        dim=0,
+                    )
+
             # map vision model output size to language model input size.
             image_embeddings = self.vision_projection(
                 image_embeddings
             )  # [img_seq_len, num_tiles, h_language]
+            if vision_projection_padding > 0:
+                image_embeddings = image_embeddings[:-vision_projection_padding]
+
+            if dynamic_vision_cp:
+                image_embeddings = gather_from_context_parallel_ranks_dynamic_res(
+                    image_embeddings, num_padded_vision_ranks
+                )
+                if use_temporal:
+                    imgs_sizes = gather_from_context_parallel_ranks_dynamic_res(
+                        imgs_sizes, num_padded_vision_ranks
+                    )
+                    if tubelet_token_counts is not None:
+                        tubelet_token_counts = gather_from_context_parallel_ranks_dynamic_res(
+                            tubelet_token_counts.unsqueeze(-1), num_padded_vision_ranks
+                        ).squeeze(-1)
+                        media_token_counts = _align_temporal_token_counts_to_placeholders(
+                            tubelet_token_counts,
+                            media_tubelet_counts,
+                            input_ids,
+                            self.image_token_index,
+                        )
+                else:
+                    imgs_sizes = global_imgs_sizes
+                    if global_num_frames is not None and self.add_decoder:
+                        if torch.is_tensor(imgs_sizes):
+                            frame_token_counts = torch.prod(
+                                imgs_sizes // self.patch_dim, dim=-1, dtype=torch.int32
+                            )
+                        else:
+                            frame_token_counts = torch.tensor(
+                                [
+                                    (int(height) // self.patch_dim) * (int(width) // self.patch_dim)
+                                    for height, width in imgs_sizes
+                                ],
+                                dtype=torch.int32,
+                                device=image_embeddings.device,
+                            )
+                        if not self._drop_vision_class_token:
+                            frame_token_counts = frame_token_counts + int(
+                                getattr(self.vision_model, "class_token_len", 0)
+                            )
+                        if self._pixel_shuffle:
+                            frame_token_counts = frame_token_counts // 4
+                        media_token_counts = _align_temporal_token_counts_to_placeholders(
+                            frame_token_counts, global_num_frames, input_ids, self.image_token_index
+                        )
+                num_frames = global_num_frames
+                num_image_tiles = torch.ones(
+                    len(imgs_sizes), dtype=torch.int32, device=image_embeddings.device
+                )
+            elif static_vision_cp_pad is not None:
+                image_embeddings = gather_from_context_parallel_ranks(
+                    image_embeddings, static_vision_cp_pad
+                )
 
             # Apply tile tagging if enabled and an image token is present.
             if self._tile_tags is not None and torch.any(input_ids == self.image_token_index):
@@ -1563,6 +1744,23 @@ class LLaVAModel(MegatronModule):
                     max_seqlen_kv=max_seqlen,
                 )
 
+        if self.context_parallel_lm > 1 and self.use_loss_scaling and expanded_labels is not None:
+            boundaries = None
+            if packed_seq_params is not None:
+                boundaries = packed_seq_params.cu_seqlens_q_padded
+                if boundaries is None:
+                    boundaries = packed_seq_params.cu_seqlens_q
+            if boundaries is None:
+                boundaries = torch.tensor(
+                    [0, expanded_labels.shape[1]], dtype=torch.int32, device=expanded_labels.device
+                )
+            assert (
+                expanded_labels.shape[0] == 1
+            ), "Context-parallel loss scaling currently requires micro-batch-size 1"
+            expanded_loss_mask = _precalculate_loss_weights(
+                boundaries, expanded_labels[0]
+            ).unsqueeze(0)
+
         if self.context_parallel_lm > 1 or self.sequence_parallel_lm:
             combined_embeddings, expanded_labels, expanded_loss_mask, packed_seq_params = (
                 self._process_embedding_token_parallel(
@@ -1663,6 +1861,27 @@ class LLaVAModel(MegatronModule):
         return output
 
 
+def _precalculate_loss_weights(boundaries, labels):
+    """Precompute packed-sample loss weights before context-parallel sharding."""
+    weights = torch.zeros(labels.shape[0], dtype=torch.float32, device=labels.device)
+    valid_counts = []
+
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        start = int(start.item())
+        end = min(int(end.item()), labels.shape[0])
+        valid = labels[start:end] != IGNORE_INDEX
+        count = valid.sum()
+        if count > 0:
+            weights[start:end][valid] = count.float().rsqrt()
+            valid_counts.append(count)
+
+    if not valid_counts:
+        raise RuntimeError("Cannot scale a packed batch with no loss-bearing tokens")
+
+    normalization = torch.stack(valid_counts).sqrt().sum()
+    return weights / normalization
+
+
 def _load_state_dict_hook_ignore_param_names(
     param_names: List[str], module: torch.nn.Module, incompatible_keys: namedtuple
 ):
@@ -1747,6 +1966,30 @@ def _group_temporal_token_counts_tensor(
         )
         tubelet_offset += tubelet_count
     return torch.stack(media_token_counts)
+
+
+def _align_temporal_token_counts_to_placeholders(
+    tubelet_token_counts: torch.Tensor,
+    media_tubelet_counts: list[int],
+    input_ids: torch.Tensor,
+    image_token_index: int,
+) -> torch.Tensor:
+    """Match temporal token counts to compact inference or expanded training placeholders."""
+    num_placeholders = int((input_ids == image_token_index).sum().item())
+    if num_placeholders == tubelet_token_counts.numel():
+        return tubelet_token_counts
+
+    media_token_counts = _group_temporal_token_counts_tensor(
+        tubelet_token_counts, media_tubelet_counts
+    )
+    if num_placeholders == media_token_counts.numel():
+        return media_token_counts
+
+    raise ValueError(
+        "Temporal media placeholders must align with either tubelets or media items: "
+        f"placeholders={num_placeholders}, tubelets={tubelet_token_counts.numel()}, "
+        f"media={media_token_counts.numel()}."
+    )
 
 
 def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):

--- a/megatron/core/tensor_parallel/data.py
+++ b/megatron/core/tensor_parallel/data.py
@@ -72,10 +72,13 @@ def broadcast_data(keys, data, datatype, tp_group=None):
                   with keys.
         tp_group: the tensor model parallel group to broadcast to.
     """
-    # Build (key, size) and (key, number of elements) dictionaries along
-    # with the total number of elements on all ranks.
-    key_size, key_numel, total_numel = _build_key_size_numel_dictionaries(keys, data)
     tp_group = get_tensor_model_parallel_group_if_none(tp_group)
+    # Build (key, size) and (key, number of elements) dictionaries along
+    # with the total number of elements on all ranks. The metadata and payload
+    # broadcasts must use the same group and source rank.
+    key_size, key_numel, total_numel = _build_key_size_numel_dictionaries(
+        keys, data, tp_group=tp_group
+    )
     # Pack on rank zero.
     if tp_group.rank() == 0:
         # Check that all keys have the same data type.

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1524,7 +1524,7 @@ def maybe_save_dataloader_state(
         get_pg_rank(tp_group) == 0
         if tp_group is not None
         else mpu.get_tensor_model_parallel_rank() == 0
-    )
+    ) and mpu.get_context_parallel_rank() == 0
     if not first_rank:
         return
 

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -286,7 +286,8 @@ class TestLLaVAModel:
         assert torch.allclose(loss_mask[4], expected_loss_mask)
 
     @pytest.mark.internal
-    def test_preprocess_data_with_media_token_counts(self):
+    @pytest.mark.parametrize("media_token_counts_dtype", [torch.int32, torch.int64])
+    def test_preprocess_data_with_media_token_counts(self, media_token_counts_dtype):
         self.model.cuda()
 
         hidden_size = 8
@@ -301,7 +302,7 @@ class TestLLaVAModel:
             [[image_token_index, 1, 2], [3, image_token_index, 4]], dtype=torch.long, device="cuda"
         )
         num_image_tiles = torch.ones(2, dtype=torch.int, device="cuda")
-        media_token_counts = torch.tensor([2, 3], dtype=torch.int, device="cuda")
+        media_token_counts = torch.tensor([2, 3], dtype=media_token_counts_dtype, device="cuda")
 
         embeddings, _, _, _, _ = self.model._preprocess_data(
             image_embeddings,

--- a/tests/unit_tests/models/test_llava_vision.py
+++ b/tests/unit_tests/models/test_llava_vision.py
@@ -14,7 +14,7 @@ def _minimal_llava_forward(model, **kwargs):
     return LLaVAModel.forward(
         model,
         images=kwargs.pop("images", torch.ones(2, 3, 2, 2)),
-        input_ids=torch.tensor([[1, 2]], dtype=torch.long),
+        input_ids=kwargs.pop("input_ids", torch.tensor([[1, 2]], dtype=torch.long)),
         position_ids=torch.tensor([[0, 1]], dtype=torch.long),
         attention_mask=None,
         **kwargs,
@@ -90,6 +90,7 @@ def test_forward_temporal_video_groups_tubelet_counts_per_placeholder():
 
     output, loss_mask = _minimal_llava_forward(
         model,
+        input_ids=torch.tensor([[1, model.image_token_index]], dtype=torch.long),
         images=torch.ones(4, 3, 4, 4),
         imgs_sizes=torch.tensor([[4, 4]] * 4, dtype=torch.int32),
         num_frames=[4],

--- a/tests/unit_tests/models/test_multimodal_context_parallel.py
+++ b/tests/unit_tests/models/test_multimodal_context_parallel.py
@@ -8,7 +8,9 @@ import torch
 
 from megatron.core.models.multimodal.context_parallel import (
     GatherFromContextParallelRanks,
+    _compute_token_balanced_split_points,
     _compute_tubelet_aware_split_points,
+    _partition_contiguous_weights,
     _split_num_frames,
     gather_from_context_parallel_ranks,
     gather_from_context_parallel_ranks_dynamic_res,
@@ -64,9 +66,6 @@ class TestComputeTubeletAwareSplitPoints:
             ([8, 8], 8, 2),
             # Mixed-length videos across many cp ranks.
             ([8, 4, 12], 4, 4),
-            # Single short video (1 tubelet) with cp_size=2 (triggers the
-            # num_tubelets<=1 branch that snaps to media_start or media_end).
-            ([4], 4, 2),
             # Temporal patch size 1 degenerates to frame-granular splits.
             ([10], 1, 5),
         ],
@@ -101,15 +100,14 @@ class TestComputeTubeletAwareSplitPoints:
         assert split_points == [0, 4, 6]
 
     @pytest.mark.internal
-    def test_monotonicity_is_enforced(self):
-        # A pathological case where the raw target-based split would go
-        # backwards; the implementation must clamp to the previous split.
-        # 3 frames total, T=2, cp=3, num_tubelets=2 on the only media.
-        # Every interior rank must still produce a monotone sequence.
-        split_points = _compute_tubelet_aware_split_points([3], 2, 3, 3)
-        assert split_points[0] == 0
-        assert split_points[-1] == 3
-        assert all(split_points[i] <= split_points[i + 1] for i in range(3))
+    def test_every_rank_receives_at_least_one_tubelet(self):
+        split_points = _compute_tubelet_aware_split_points([9, 1], 4, 4, 10)
+        assert split_points == [0, 4, 8, 9, 10]
+
+    @pytest.mark.internal
+    def test_requires_padding_when_there_are_too_few_tubelets(self):
+        with pytest.raises(ValueError, match="after padding"):
+            _compute_tubelet_aware_split_points([3], 2, 3, 3)
 
 
 class TestSplitNumFrames:
@@ -146,6 +144,42 @@ class TestSplitNumFrames:
     @pytest.mark.internal
     def test_empty_num_frames(self):
         assert _split_num_frames([], 0, 10) == []
+
+
+class TestTokenBalancedSplitPoints:
+    """Tests for token-balanced contiguous CP partitioning."""
+
+    @pytest.mark.internal
+    def test_minimizes_maximum_contiguous_load(self):
+        weights = [16, 16, 8, 8, 4, 4, 2, 2]
+
+        boundaries = _partition_contiguous_weights(weights, num_parts=4)
+        loads = [sum(weights[boundaries[i] : boundaries[i + 1]]) for i in range(4)]
+
+        assert boundaries == [0, 1, 2, 4, 8]
+        assert loads == [16, 16, 16, 12]
+
+    @pytest.mark.internal
+    def test_non_temporal_split_uses_image_token_weights(self):
+        seqlens = torch.tensor([8, 7, 6, 5, 4, 3, 2, 1], dtype=torch.int32)
+
+        split_points = _compute_token_balanced_split_points(seqlens, cp_size=2)
+
+        assert split_points == [0, 2, 8]
+        loads = [int(seqlens[split_points[i] : split_points[i + 1]].sum()) for i in range(2)]
+        assert loads == [15, 21]
+
+    @pytest.mark.internal
+    def test_temporal_split_preserves_tubelet_boundaries(self):
+        seqlens = torch.tensor([8, 8, 8, 8, 3, 5, 5, 5], dtype=torch.int32)
+        num_frames = [4, 1, 3]
+
+        split_points = _compute_token_balanced_split_points(
+            seqlens, cp_size=3, num_frames=num_frames, temporal_patch_size=2
+        )
+
+        _assert_split_point_invariants(split_points, num_frames, 2, 3)
+        assert all(split_points[i] < split_points[i + 1] for i in range(3))
 
 
 class TestSplitToContextParallelRanks:
@@ -310,6 +344,59 @@ class TestDynamicResCPDistributed:
         assert torch.all(local_t == float(cp_rank))
 
     @pytest.mark.internal
+    def test_token_balanced_split_preserves_global_order(self):
+        """Uneven image sizes are balanced and split/gather remains an exact roundtrip."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+
+        from megatron.core.parallel_state import get_context_parallel_rank
+
+        cp_rank = get_context_parallel_rank()
+        patch_dim = 16
+        hidden = 3 * patch_dim * patch_dim
+        image_seqlens = [8, 7, 6, 5, 4, 3, 2, 1]
+        chunks = [
+            torch.full((seqlen, hidden), float(image_index), device="cuda")
+            for image_index, seqlen in enumerate(image_seqlens)
+        ]
+        global_t = torch.cat(chunks, dim=0).unsqueeze(0)
+        global_imgs_sizes = torch.tensor(
+            [[patch_dim, patch_dim * seqlen] for seqlen in image_seqlens],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(image_seqlens).cumsum(0).tolist()], dtype=torch.int32, device="cuda"
+        )
+        global_packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=max(image_seqlens),
+            max_seqlen_kv=max(image_seqlens),
+        )
+
+        local_t, local_sizes, _packed, _has_pad, _num_padded, _local_frames = (
+            split_to_context_parallel_ranks_dynamic_res(
+                global_t,
+                global_imgs_sizes,
+                global_packed_seq_params,
+                patch_dim=patch_dim,
+                balance_by_tokens=True,
+                profile_partition=True,
+            )
+        )
+
+        expected_num_images = 2 if cp_rank == 0 else 6
+        expected_num_tokens = 15 if cp_rank == 0 else 21
+        assert local_sizes.shape[0] == expected_num_images
+        assert local_t.shape[1] == expected_num_tokens
+
+        gathered = gather_from_context_parallel_ranks_dynamic_res(
+            local_t.permute(1, 0, 2).contiguous()
+        )
+        torch.testing.assert_close(gathered, global_t.permute(1, 0, 2).contiguous(), rtol=0, atol=0)
+
+    @pytest.mark.internal
     def test_split_dynamic_res_temporal_aware_tubelets(self):
         """``temporal_patch_size > 1`` triggers the tubelet-aware split.
 
@@ -355,7 +442,7 @@ class TestDynamicResCPDistributed:
         )
         num_frames = torch.tensor([frames_per_video] * num_videos, dtype=torch.int32, device="cuda")
 
-        (local_t, local_imgs_sizes, _packed, has_padding, num_padded_ranks, local_num_frames) = (
+        local_t, local_imgs_sizes, _packed, has_padding, num_padded_ranks, local_num_frames = (
             split_to_context_parallel_ranks_dynamic_res(
                 global_t,
                 global_imgs_sizes,
@@ -407,6 +494,76 @@ class TestDynamicResCPDistributed:
             )
         )
         # cp_size=2, num_imgs=1 ⇒ one dummy added ⇒ one rank is padded.
+        assert num_padded_ranks == 1
+
+    @pytest.mark.internal
+    def test_token_balanced_split_preserves_dummy_rank_padding(self):
+        """Token balancing keeps trailing CP dummy ranks removable by the gather."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+
+        patch_dim = 16
+        per_img_seq = patch_dim * patch_dim
+        hidden = 3 * patch_dim * patch_dim
+        global_t = torch.zeros((1, per_img_seq, hidden), device="cuda")
+        global_imgs_sizes = torch.tensor([[patch_dim, patch_dim]], dtype=torch.int32, device="cuda")
+        cu_seqlens = torch.tensor([0, per_img_seq], dtype=torch.int32, device="cuda")
+        global_packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=per_img_seq,
+            max_seqlen_kv=per_img_seq,
+        )
+
+        local_t, local_sizes, _packed, _has_pad, num_padded_ranks, _ = (
+            split_to_context_parallel_ranks_dynamic_res(
+                global_t,
+                global_imgs_sizes,
+                global_packed_seq_params,
+                patch_dim=patch_dim,
+                balance_by_tokens=True,
+            )
+        )
+
+        assert local_t.numel() > 0
+        assert local_sizes.shape == (1, 2)
+        assert num_padded_ranks == 1
+
+    @pytest.mark.internal
+    def test_split_dynamic_res_sizes_dummy_for_pixel_shuffle(self):
+        """CP dummy images can provide the 2x2 patch grid required by pixel shuffle."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+
+        from megatron.core.parallel_state import get_context_parallel_rank
+
+        cp_rank = get_context_parallel_rank()
+        patch_dim = 16
+        hidden = 3 * patch_dim * patch_dim
+        global_t = torch.zeros((1, 1, hidden), dtype=torch.float32, device="cuda")
+        global_imgs_sizes = torch.tensor([[patch_dim, patch_dim]], dtype=torch.int32, device="cuda")
+        cu_seqlens = torch.tensor([0, 1], dtype=torch.int32, device="cuda")
+        global_packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=1,
+            max_seqlen_kv=1,
+        )
+
+        local_t, local_sizes, _packed, _has_pad, num_padded_ranks, _ = (
+            split_to_context_parallel_ranks_dynamic_res(
+                global_t,
+                global_imgs_sizes,
+                global_packed_seq_params,
+                patch_dim=patch_dim,
+                dummy_image_size=2 * patch_dim,
+            )
+        )
+
+        expected_size = patch_dim if cp_rank == 0 else 2 * patch_dim
+        expected_seqlen = 1 if cp_rank == 0 else 4
+        assert local_sizes.tolist() == [[expected_size, expected_size]]
+        assert local_t.shape == (1, expected_seqlen, hidden)
         assert num_padded_ranks == 1
 
     @pytest.mark.internal

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -373,7 +373,10 @@ class TestPixelShuffleNonSquare:
 
     @pytest.mark.internal
     def test_temporal_token_counts_group_one_placeholder_per_media(self):
-        from megatron.core.models.multimodal.llava_model import _group_temporal_token_counts_tensor
+        from megatron.core.models.multimodal.llava_model import (
+            _align_temporal_token_counts_to_placeholders,
+            _group_temporal_token_counts_tensor,
+        )
 
         tubelet_counts = torch.tensor([252, 252, 128], dtype=torch.int32, device="cuda")
         media_tubelet_counts = [2, 1]
@@ -381,6 +384,24 @@ class TestPixelShuffleNonSquare:
         assert torch.equal(
             grouped_counts, torch.tensor([504, 128], dtype=torch.int32, device="cuda")
         )
+
+        compact_input_ids = torch.tensor([[-200, 1, -200]], device="cuda")
+        aligned_counts = _align_temporal_token_counts_to_placeholders(
+            tubelet_counts, media_tubelet_counts, compact_input_ids, -200
+        )
+        assert torch.equal(aligned_counts, grouped_counts)
+
+        expanded_input_ids = torch.tensor([[-200, -200, 1, -200]], device="cuda")
+        aligned_counts = _align_temporal_token_counts_to_placeholders(
+            tubelet_counts, media_tubelet_counts, expanded_input_ids, -200
+        )
+        assert torch.equal(aligned_counts, tubelet_counts)
+
+        invalid_input_ids = torch.tensor([[-200]], device="cuda")
+        with pytest.raises(ValueError, match="must align"):
+            _align_temporal_token_counts_to_placeholders(
+                tubelet_counts, media_tubelet_counts, invalid_input_ids, -200
+            )
 
         # temporal_patch_dim=1 makes every frame one tubelet. A per-video
         # placeholder therefore receives the sum of all frame embeddings.

--- a/tests/unit_tests/tensor_parallel/test_data.py
+++ b/tests/unit_tests/tensor_parallel/test_data.py
@@ -20,4 +20,16 @@ def test_broadcast_data():
     actual_output = broadcast_data([0, 1], input_data, dtype)
     assert torch.equal(actual_output[0], input_data[0])
     assert torch.equal(actual_output[1], input_data[1])
+
+    # A custom process group must be used for both shape metadata and payload.
+    world_input = (
+        {"value": torch.arange(12, dtype=dtype, device="cuda").reshape(3, 4)}
+        if torch.distributed.get_rank() == 0
+        else None
+    )
+    world_output = broadcast_data(
+        ["value"], world_input, dtype, tp_group=torch.distributed.group.WORLD
+    )
+    expected = torch.arange(12, dtype=dtype, device="cuda").reshape(3, 4)
+    assert torch.equal(world_output["value"], expected)
     Utils.destroy_model_parallel()

--- a/tests/unit_tests/tensor_parallel/test_data.py
+++ b/tests/unit_tests/tensor_parallel/test_data.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import torch
 
 from megatron.core.tensor_parallel.data import broadcast_data

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -150,6 +150,29 @@ def test_maybe_save_dataloader_state_skips_empty_state_after_barriers(tmp_path):
     save.assert_not_called()
 
 
+def test_maybe_save_dataloader_state_skips_duplicate_context_parallel_rank(tmp_path):
+    """Only CP rank zero writes each data-parallel dataloader shard."""
+    group = SimpleNamespace(rank=0, size=1)
+    iterator = SimpleNamespace(iterable=SimpleNamespace(save_state=mock.Mock()))
+
+    with (
+        mock.patch(
+            "megatron.training.checkpointing.get_pg_rank",
+            side_effect=lambda process_group: process_group.rank,
+        ),
+        mock.patch("megatron.training.checkpointing.mpu.get_context_parallel_rank", return_value=1),
+        mock.patch("megatron.training.checkpointing.torch.distributed.barrier") as barrier,
+        mock.patch("megatron.training.checkpointing.torch.save") as save,
+    ):
+        maybe_save_dataloader_state(
+            iterator, 2, tmp_path, tp_group=group, pp_group=group, dp_group=group
+        )
+
+    iterator.iterable.save_state.assert_not_called()
+    barrier.assert_not_called()
+    save.assert_not_called()
+
+
 class MockOptParamScheduler(MockState):
     def __init__(self, state_dict):
         super().__init__(state_dict)


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

## What does this PR do?

Carry packed multimodal metadata through LLaVA, split/gather vision tokens for context parallelism, and handle padding and loss weighting consistently. Include model tests and single-writer dataloader checkpoint-state handling.

This is part of a review-split multimodal SFT series. Production run scripts, data YAMLs, checkpoint conversion tooling, and separate CI compatibility fixes are outside this series.

## Dependencies and review scope

Stacked on #7249. Review the vision context-parallelism/metadata commits above that parent. The review base uses its bot-created mirror; retarget to `main` before merging.

## Validation

- Replayed onto public `main` at `46fb90ca942a2950c58c5654b3e56877e88a3e35`, preserving atomic signed and signed-off commits.
- The original combined feature stack had multi-node Super SFT validation before this migration; that is not an isolated-PR or rebased-head test result.
- GitHub CI is pending. No GPU tests have been rerun locally for these rebased heads.
- Local Black, isort, pylint, and Ruff checks passed for paths covered by the repository autoformat script (`megatron/core` and `tests`). Mypy is unavailable locally. Changed Python files pass syntax parsing; no CI configuration changes are included.

Kept as a draft pending CI and dependency integration.
