### PR TITLE
Initialize multimodal models from language checkpoints

### DIFF
--- a/megatron/core/enums.py
+++ b/megatron/core/enums.py
@@ -7,6 +7,12 @@ class ModelType(enum.Enum):
     """Model type."""
 
     encoder_or_decoder = 1
+    # Retained so checkpoints written before the encoder/decoder model-type
+    # cleanup can still be deserialized. New models should use
+    # ``encoder_or_decoder``.
+    encoder_and_decoder = 2
+    retro_encoder = 3
+    retro_decoder = 4
 
 
 class Fp8Recipe(str, enum.Enum):

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -2,12 +2,14 @@
 import logging
 from collections import namedtuple
 from functools import partial
+from itertools import chain
 from typing import List, Optional
 
 import torch
 
 from megatron.core import tensor_parallel
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
+from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
 from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt import GPTModel
@@ -73,6 +75,8 @@ class LLaVAModel(MegatronModule):
         vision_projection_type (str): Type of the vision projection. Default: 2-layer MLP.
         allow_missing_vision_projection_checkpoint (bool): Allow vision projection weights to be
             missing when loading a checkpoint. Default False.
+        allow_llm_only_checkpoint (bool): Load language weights from an LLM-only distributed
+            checkpoint and leave multimodal modules initialized locally. Default False.
         parallel_output (bool): Keep outputs split across tensor parallel ranks.
             This is typically True for training and False for inference.
         share_embeddings_and_output_weights (bool): Input embedding and output layer share weights.
@@ -111,6 +115,7 @@ class LLaVAModel(MegatronModule):
         vision_projection_layer_spec: ModuleSpec,
         vision_projection_type: str = "mlp",
         allow_missing_vision_projection_checkpoint: bool = False,
+        allow_llm_only_checkpoint: bool = False,
         parallel_output: bool = True,
         share_embeddings_and_output_weights: bool = False,
         language_position_embedding_type: str = 'learned_absolute',
@@ -182,6 +187,7 @@ class LLaVAModel(MegatronModule):
         self.tensor_model_parallel_size_lm = language_transformer_config.tensor_model_parallel_size
         # Used by finalize_model_grads._allreduce_word_embedding_grads.
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
+        self._allow_llm_only_checkpoint = allow_llm_only_checkpoint
 
         # Audio/video/image attributes.
         self.image_token_index = image_token_index
@@ -493,6 +499,16 @@ class LLaVAModel(MegatronModule):
             self.vision_model.register_load_state_dict_post_hook(
                 _load_state_dict_hook_ignore_extra_state
             )
+            if allow_llm_only_checkpoint:
+                vision_model_param_names = [
+                    f"vision_model.{name}"
+                    for name, _ in chain(
+                        self.vision_model.named_parameters(), self.vision_model.named_buffers()
+                    )
+                ]
+                self.vision_model.register_load_state_dict_post_hook(
+                    partial(_load_state_dict_hook_ignore_param_names, vision_model_param_names)
+                )
 
             vision_encoder_output_size = getattr(
                 self.vision_model, 'out_hidden_size', vision_transformer_config.hidden_size
@@ -513,7 +529,7 @@ class LLaVAModel(MegatronModule):
             # This should be disabled by default but can be enabled if your checkpoint contains
             # pretrained vision and language models but not the projection from vision model
             # outputs to language model inputs.
-            if allow_missing_vision_projection_checkpoint:
+            if allow_missing_vision_projection_checkpoint or allow_llm_only_checkpoint:
                 vision_projection_param_names = [
                     f"vision_projection.{name}"
                     for name in self.vision_projection.state_dict().keys()
@@ -554,6 +570,23 @@ class LLaVAModel(MegatronModule):
         if self.add_decoder:
             return self.language_model.shared_embedding_or_output_weight()
         return None
+
+    def sharded_state_dict(self, prefix: str = '', sharded_offsets: tuple = (), metadata=None):
+        """Build a sharded state dict, optionally targeting an LLM-only checkpoint."""
+        sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+
+        if self._allow_llm_only_checkpoint and (metadata or {}).get(
+            'load_from_llm_only_checkpoint', False
+        ):
+            multimodal_prefixes = tuple(
+                f'{prefix}{module_name}.' for module_name in ('vision_model', 'vision_projection')
+            )
+            for key in list(sharded_state_dict):
+                if key.startswith(multimodal_prefixes):
+                    del sharded_state_dict[key]
+            apply_prefix_mapping(sharded_state_dict, {f'{prefix}language_model.': prefix})
+
+        return sharded_state_dict
 
     def set_input_tensor(self, input_tensor) -> None:
         """Set model chunk input tensor."""

--- a/megatron/core/safe_globals.py
+++ b/megatron/core/safe_globals.py
@@ -44,6 +44,7 @@ SAFE_GLOBALS = [
     RerunMode,
     RerunState,
     BytesIO,
+    frozenset,
     Signals,
     torch._C.Generator,  # Needed for torch ckpt format loading after weights_only default change
 ]

--- a/megatron/core/transformer/enums.py
+++ b/megatron/core/transformer/enums.py
@@ -9,9 +9,11 @@ class ModelType(enum.Enum):
     """Model Type
 
     encoder_or_decoder for bert, gpt etc
+    encoder_and_decoder is retained for checkpoint backward compatibility
     """
 
     encoder_or_decoder = 1
+    encoder_and_decoder = 2
 
 
 class LayerType(enum.Enum):

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2494,6 +2494,7 @@ def load_checkpoint(
     """
     args = get_args()
     load_dir = getattr(args, load_arg)
+    loading_pretrained_checkpoint = False
 
     # --freeze-all-layers: nothing trains, so load the model in --load weights-only (finetune-style)
     # and auto-resume the data position by feeding this run's own progress tracker -- written to
@@ -2521,6 +2522,7 @@ def load_checkpoint(
         if not checkpoint_exists(load_dir):
             raise FileNotFoundError('No checkpoint found in load directory or pretrained directory')
         args.finetune = True
+        loading_pretrained_checkpoint = True
 
     model = unwrap_model(ddp_model)
 
@@ -2701,6 +2703,8 @@ def load_checkpoint(
         if sharded_sd_metadata is None:
             sharded_sd_metadata = {}
         sharded_sd_metadata['dp_cp_group'] = dp_cp_group
+        if loading_pretrained_checkpoint and getattr(args, 'allow_llm_only_checkpoint', False):
+            sharded_sd_metadata['load_from_llm_only_checkpoint'] = True
 
         optim_sd_kwargs = dict(metadata=sharded_sd_metadata, is_loading=True)
         model_sd_kwargs = dict(metadata=sharded_sd_metadata)

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -34,6 +34,9 @@ class TestLLaVAModel:
         self.language_hidden_size = 64
         self.language_num_attention_heads = 4
 
+        self.model = self._build_model()
+
+    def _build_model(self, allow_llm_only_checkpoint=False):
         language_config = TransformerConfig(
             num_layers=3,
             hidden_size=self.language_hidden_size,
@@ -60,7 +63,7 @@ class TestLLaVAModel:
 
         language_config.language_model_type = "dummy"
         vision_config.vision_model_type = "clip"
-        self.model = LLaVAModel(
+        model = LLaVAModel(
             language_transformer_config=language_config,
             language_transformer_layer_spec=ModuleSpec(
                 module=TransformerLayer, submodules=language_layer_submodules
@@ -72,10 +75,12 @@ class TestLLaVAModel:
             drop_vision_class_token=False,
             vision_projection_config=vision_projection_config,
             vision_projection_layer_spec=vision_projection_spec,
+            allow_llm_only_checkpoint=allow_llm_only_checkpoint,
             img_h=336,
             img_w=336,
             patch_dim=14,
         )
+        return model
 
     @pytest.mark.internal
     def teardown_method(self, method):
@@ -606,6 +611,33 @@ class TestLLaVAModel:
         torch.save(self.model.state_dict(), path)
 
         self.model.load_state_dict(torch.load(path))
+
+    @pytest.mark.internal
+    def test_llm_only_checkpoint_sharded_key_mapping_is_load_only(self):
+        model = self._build_model(allow_llm_only_checkpoint=True)
+
+        save_state_dict = model.sharded_state_dict()
+        assert (
+            save_state_dict['language_model.embedding.word_embeddings.weight'].key
+            == 'language_model.embedding.word_embeddings.weight'
+        )
+
+        load_state_dict = model.sharded_state_dict(metadata={'load_from_llm_only_checkpoint': True})
+        assert (
+            load_state_dict['language_model.embedding.word_embeddings.weight'].key
+            == 'embedding.word_embeddings.weight'
+        )
+        assert 'vision_model.class_token' not in load_state_dict
+
+    @pytest.mark.internal
+    def test_llm_only_checkpoint_allows_missing_vision_modules(self):
+        model = self._build_model(allow_llm_only_checkpoint=True)
+        language_state_dict = {
+            f'language_model.{name}': tensor
+            for name, tensor in model.language_model.state_dict().items()
+        }
+
+        model.load_state_dict(language_state_dict, strict=True)
 
     @pytest.mark.internal
     def test_freeze(self):

--- a/tests/unit_tests/tensor_parallel/test_data.py
+++ b/tests/unit_tests/tensor_parallel/test_data.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import torch
 
 from megatron.core.tensor_parallel.data import broadcast_data

--- a/tests/unit_tests/test_model_type_backward_compatibility.py
+++ b/tests/unit_tests/test_model_type_backward_compatibility.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pickle
+
+import pytest
+
+from megatron.core.enums import ModelType as CoreModelType
+from megatron.core.transformer.enums import ModelType as TransformerModelType
+
+
+@pytest.mark.parametrize(
+    ("model_type", "legacy_members"),
+    [
+        (CoreModelType, {2: "encoder_and_decoder", 3: "retro_encoder", 4: "retro_decoder"}),
+        (TransformerModelType, {2: "encoder_and_decoder"}),
+    ],
+)
+def test_legacy_model_type_members_can_be_unpickled(model_type, legacy_members):
+    """Legacy enum values stored in checkpoint arguments must remain loadable."""
+    for value, name in legacy_members.items():
+        member = model_type(value)
+        assert member.name == name
+        assert pickle.loads(pickle.dumps(member)) is member


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

## What does this PR do?

Support initializing the language component of a multimodal model from a language-only checkpoint while leaving vision parameters locally initialized. Preserve legacy checkpoint enum deserialization compatibility and add regression tests.

This is part of a review-split multimodal SFT series. Production run scripts, data YAMLs, checkpoint conversion tooling, and separate CI compatibility fixes are outside this series.

## Dependencies and review scope

Stacked on #7250 (which builds on #7249). Review only the checkpoint-initialization and legacy-deserialization commits above that parent. The review base uses its bot-created mirror; retarget to `main` before merging.

## Validation

- Replayed onto public `main` at `46fb90ca942a2950c58c5654b3e56877e88a3e35`, preserving atomic signed and signed-off commits.
- The original combined feature stack had multi-node Super SFT validation before this migration; that is not an isolated-PR or rebased-head test result.
- GitHub CI is pending. No GPU tests have been rerun locally for these rebased heads.
- Local Black, isort, pylint, and Ruff checks passed for paths covered by the repository autoformat script (`megatron/core` and `tests`). Mypy is unavailable locally. Changed Python files pass syntax parsing; no CI configuration changes are included.

Kept as a draft pending CI and dependency integration.
