### PR TITLE
Support packed multimodal inputs in Super hybrid models

### DIFF
--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -482,6 +482,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         if in_inference_mode:
             assert runtime_gather_output, "Inference must always gather TP logits"
 
+        use_precomputed_mtp_embeddings = decoder_input is not None
+
         # Decoder embedding.
         if decoder_input is not None:
             pass
@@ -596,6 +598,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,
+                decoder_input=decoder_input if use_precomputed_mtp_embeddings else None,
                 mhc_multistream=mhc_multistream,
                 labels=labels,
                 loss_mask=loss_mask,
@@ -603,7 +606,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 packed_seq_params=packed_seq_params,
                 cp_batch=cp_batch,
             )
-            assert mtp_inputs.input_ids is not None and mtp_inputs.position_ids is not None
+            if mtp_inputs.decoder_input is None:
+                assert mtp_inputs.input_ids is not None and mtp_inputs.position_ids is not None
             mtp_hidden_states = self.mtp(
                 input_ids=mtp_inputs.input_ids,
                 position_ids=mtp_inputs.position_ids,
@@ -614,6 +618,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 rotary_pos_emb=rotary_pos_emb,
                 packed_seq_params=mtp_inputs.packed_seq_params,
                 embedding=self.embedding,
+                decoder_input=mtp_inputs.decoder_input,
                 mtp_input_mask=mtp_inputs.mtp_input_mask,
                 packed_seq_params_by_layout=packed_seq_params_by_layout,
                 cp_layout_plan=cp_layout_plan,

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -32,6 +32,7 @@ from megatron.core.ssm.ops.common.intermediate_extraction import (
 )
 from megatron.core.ssm.ops.mamba2.batch_invariant_decode import MambaBatchInvariantDecode
 from megatron.core.ssm.ops.mamba2.mamba_ssm import selective_state_update
+from megatron.core.ssm.packed_seq_helpers import build_packed_seq_idx
 from megatron.core.ssm.ssm_inference import SSMDynamicInferenceMixin
 from megatron.core.ssm.utils import _split_tensor_factory
 from megatron.core.tensor_parallel import get_cuda_rng_tracker
@@ -705,6 +706,8 @@ class MambaMixer(SSMDynamicInferenceMixin, MegatronModule):
             )
             assert sequence_packing_available, reason_for_no_sequence_packing
             seq_idx = packed_seq_params.seq_idx
+            if seq_idx is None:
+                seq_idx = build_packed_seq_idx(packed_seq_params, zxBCdt.shape[1])
 
         state_dtype_kwarg = (
             {"state_dtype": self.mamba_training_ssm_states_dtype} if MAMBA_HAS_STATE_DTYPE else {}

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import warnings
 from contextlib import AbstractContextManager, nullcontext
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
@@ -324,9 +325,12 @@ def _roll_tensor_packed_seq(
 
     # Notice: This is a naive implementation to test the correctness,
     # a better solution will only sync the boundary tokens once.
-    assert (
-        dims == -1 or dims == tensor.dim() - 1
-    ), "Packed sequence roll only supports the last dimension."
+    ndim = tensor.dim()
+    sequence_dim = dims if dims >= 0 else ndim + dims
+    assert sequence_dim in (
+        0,
+        ndim - 1,
+    ), f"Packed sequence roll only supports the first or last dimension, got dims={dims}."
     assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
     cu_seqlens = packed_seq_params.cu_seqlens_q
     assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
@@ -336,6 +340,16 @@ def _roll_tensor_packed_seq(
 
     rolled_tensor = tensor.clone()
 
+    def slice_sequence(tensor, start, end):
+        index = [slice(None)] * tensor.dim()
+        index[sequence_dim] = slice(start, end)
+        return tensor[tuple(index)]
+
+    def assign_sequence(tensor, start, end, value):
+        index = [slice(None)] * tensor.dim()
+        index[sequence_dim] = slice(start, end)
+        tensor[tuple(index)] = value
+
     cp_size = cp_group.size() if cp_group is not None else 1
     if cp_size == 1:
         # CP disabled: roll each packed sequence independently within its boundaries
@@ -344,12 +358,12 @@ def _roll_tensor_packed_seq(
             valid_length = cu_seqlens[i + 1] - cu_seqlens[i]
             end_idx = start_idx + valid_length
             physical_end_idx = physical_cu_seqlens[i + 1]
-            seq_slice = tensor[..., start_idx:end_idx]
-            rolled_seq = torch.roll(seq_slice, shifts=shifts, dims=dims)
+            seq_slice = slice_sequence(tensor, start_idx, end_idx)
+            rolled_seq = torch.roll(seq_slice, shifts=shifts, dims=sequence_dim)
             # Zero out the last position(s) that would cross sequence boundaries
-            rolled_seq[..., shifts:] = 0
-            rolled_tensor[..., start_idx:end_idx] = rolled_seq
-            rolled_tensor[..., end_idx:physical_end_idx] = 0
+            rolled_seq.select(sequence_dim, shifts).zero_()
+            assign_sequence(rolled_tensor, start_idx, end_idx, rolled_seq)
+            assign_sequence(rolled_tensor, end_idx, physical_end_idx, 0)
         rolled_sum = rolled_tensor.sum() if return_sum else None
         return rolled_tensor, rolled_sum
 
@@ -374,25 +388,29 @@ def _roll_tensor_packed_seq(
         if local_seq_len == 0:
             continue
 
-        tensor_slice = rolled_tensor[..., local_start_idx:local_end_idx].clone()
+        tensor_slice = slice_sequence(rolled_tensor, local_start_idx, local_end_idx).clone()
 
         # The following code is very similar as the code in roll_tensor function
-        local_chunks = tensor_slice.chunk(2, dim=dims)
-        rolled_chunks = [torch.roll(chunk, shifts=shifts, dims=dims) for chunk in local_chunks]
+        local_chunks = tensor_slice.chunk(2, dim=sequence_dim)
+        rolled_chunks = [
+            torch.roll(chunk, shifts=shifts, dims=sequence_dim) for chunk in local_chunks
+        ]
 
         tensor_send_list = []
         tensor_recv_list = []
         for chunk in rolled_chunks:
             # Skip empty chunks that can occur when the sequence slice is very small
-            if chunk.size(dims) == 0:
+            if chunk.size(sequence_dim) == 0:
+                boundary_shape = list(chunk.shape)
+                del boundary_shape[sequence_dim]
                 tensor_send_list.append(
-                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
+                    torch.empty(boundary_shape, dtype=chunk.dtype, device=chunk.device)
                 )
                 tensor_recv_list.append(
-                    torch.empty(chunk.shape[:-1], dtype=chunk.dtype, device=chunk.device)
+                    torch.empty(boundary_shape, dtype=chunk.dtype, device=chunk.device)
                 )
                 continue
-            boundary = chunk.select(dims, shifts).contiguous().clone()
+            boundary = chunk.select(sequence_dim, shifts).contiguous().clone()
             tensor_send_list.append(boundary)
             tensor_recv_list.append(torch.empty_like(boundary))
 
@@ -413,20 +431,53 @@ def _roll_tensor_packed_seq(
             op.wait()
 
         index = [slice(None)] * rolled_chunks[0].dim()
-        index[dims] = shifts
+        index[sequence_dim] = shifts
         for chunk, recv in zip(rolled_chunks, tensor_recv_list):
             # Skip empty chunks
-            if chunk.size(dims) == 0:
+            if chunk.size(sequence_dim) == 0:
                 continue
             chunk[tuple(index)] = recv
 
-        seq_result = torch.cat(rolled_chunks, dim=dims)
+        seq_result = torch.cat(rolled_chunks, dim=sequence_dim)
 
         # update the rolled tensor
-        rolled_tensor[..., local_start_idx:local_end_idx] = seq_result
+        assign_sequence(rolled_tensor, local_start_idx, local_end_idx, seq_result)
 
     rolled_sum = rolled_tensor.sum() if return_sum else None
     return rolled_tensor, rolled_sum
+
+
+def roll_tensor_precomputed_embeddings(
+    tensor, shifts=-1, dims=0, sp_group=None, cp_group=None, packed_seq_params=None, return_sum=True
+):
+    """Roll precomputed embeddings while preserving SP and packed-sequence boundaries."""
+    sp_size = get_pg_size(sp_group)
+    if sp_size == 1:
+        return roll_tensor(
+            tensor,
+            shifts=shifts,
+            dims=dims,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=return_sum,
+        )
+
+    sp_rank = get_pg_rank(sp_group)
+    gathered_shape = list(tensor.shape)
+    gathered_shape[dims] *= sp_size
+    full_tensor = torch.empty(gathered_shape, dtype=tensor.dtype, device=tensor.device)
+    dist_all_gather_func(full_tensor, tensor.contiguous(), group=sp_group)
+
+    rolled_full, rolled_sum = roll_tensor(
+        full_tensor,
+        shifts=shifts,
+        dims=dims,
+        cp_group=cp_group,
+        packed_seq_params=packed_seq_params,
+        return_sum=return_sum,
+    )
+    local_tensor = rolled_full.chunk(sp_size, dim=dims)[sp_rank].contiguous()
+    return local_tensor, rolled_sum
 
 
 def _packed_seq_params_for_local_hsm_roll(
@@ -1232,6 +1283,10 @@ class MultiTokenPredictionLayer(MegatronModule):
         Args:
             name (str | None): module instance name passed top-down from its paranet module
         """
+        if config.keep_mtp_spec_in_bf16:
+            config = deepcopy(config)
+            config.fp4 = None
+            config.fp8 = None
         super().__init__(config=config)
         if mamba_submodules is not None:
             if hybrid_submodules is not None:
@@ -1540,6 +1595,26 @@ class MultiTokenPredictionLayer(MegatronModule):
             hidden_states.requires_grad_(True)
 
         return (input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states)
+
+    def _get_precomputed_embeddings(self, decoder_input: torch.Tensor, hidden_states: torch.Tensor):
+        """Prepare externally composed embeddings for an MTP depth."""
+        row_norms = decoder_input.norm(dim=-1)
+        zero_norm_mask = row_norms < 1e-6
+        if zero_norm_mask.any():
+            non_zero_mask = ~zero_norm_mask
+            if non_zero_mask.any():
+                fill_embedding = decoder_input[non_zero_mask].mean(dim=0)
+                decoder_input = decoder_input.clone()
+                decoder_input[zero_norm_mask] = fill_embedding
+
+        if self.config.mtp_detach_heads:
+            decoder_input = decoder_input.detach()
+
+        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
+        if not hidden_states.requires_grad:
+            hidden_states.requires_grad_(True)
+
+        return decoder_input, hidden_states
 
     def _concat_embeddings(self, hidden_states: torch.Tensor, decoder_input: torch.Tensor):
         """
@@ -1902,8 +1977,8 @@ class MultiTokenPredictionLayer(MegatronModule):
 
     def forward(
         self,
-        input_ids: Tensor,
-        position_ids: Tensor,
+        input_ids: Optional[Tensor],
+        position_ids: Optional[Tensor],
         hidden_states: Tensor,
         attention_mask: Tensor,
         padding_mask: Optional[Tensor] = None,
@@ -1917,6 +1992,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         packed_seq_params: Optional[PackedSeqParams] = None,
         sequence_len_offset: Optional[Tensor] = None,
         embedding=None,
+        decoder_input: Optional[Tensor] = None,
         mtp_input_mask: Optional[Tensor] = None,
         packed_seq_params_by_layout: Optional[dict[CPLayout, PackedSeqParams | None]] = None,
         cp_layout_plan: Optional[THDCPLayoutPlan] = None,
@@ -1945,8 +2021,16 @@ class MultiTokenPredictionLayer(MegatronModule):
             [s, b, h], and optionally the updated context tensor if cross-attention is used.
         """
         assert context is None, "multi token prediction + cross attention is not yet supported."
-        input_ids, position_ids, padding_mask, mtp_input_mask, decoder_input, hidden_states = (
-            self._get_embeddings(
+        if decoder_input is None:
+            assert input_ids is not None and position_ids is not None
+            (
+                input_ids,
+                position_ids,
+                padding_mask,
+                mtp_input_mask,
+                decoder_input,
+                hidden_states,
+            ) = self._get_embeddings(
                 input_ids=input_ids,
                 position_ids=position_ids,
                 padding_mask=padding_mask,
@@ -1955,7 +2039,10 @@ class MultiTokenPredictionLayer(MegatronModule):
                 packed_seq_params=packed_seq_params,
                 mtp_input_mask=mtp_input_mask,
             )
-        )
+        else:
+            decoder_input, hidden_states = self._get_precomputed_embeddings(
+                decoder_input=decoder_input, hidden_states=hidden_states
+            )
 
         # Legacy GPT MTP owns one outer checkpoint around its projection and Transformer
         # layer. Hybrid MTP instead delegates full recompute to the nested HybridStack so
@@ -2055,9 +2142,10 @@ class MultiTokenPredictionBlockSubmodules:
 class MultiTokenPredictionInputs:
     """Inputs prepared in the CP layout consumed by an MTP block."""
 
-    input_ids: Tensor
-    position_ids: Tensor
+    input_ids: Optional[Tensor]
+    position_ids: Optional[Tensor]
     hidden_states: Tensor
+    decoder_input: Optional[Tensor]
     mhc_multistream: Optional[Tensor]
     labels: Optional[Tensor]
     loss_mask: Optional[Tensor]
@@ -2211,6 +2299,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         input_ids: Tensor,
         position_ids: Tensor,
         hidden_states: Tensor,
+        decoder_input: Optional[Tensor],
         mhc_multistream: Optional[Tensor],
         labels: Optional[Tensor],
         loss_mask: Optional[Tensor],
@@ -2240,6 +2329,17 @@ class MultiTokenPredictionBlock(MegatronModule):
                 self.tp_cp_group,
                 cp_batch.thd_plan,
             )
+            if decoder_input is not None:
+                decoder_input = convert_cp_layout(
+                    decoder_input,
+                    source_layout,
+                    target_layout,
+                    self.cp_group,
+                    self.sequence_parallel,
+                    self.tp_group,
+                    self.tp_cp_group,
+                    cp_batch.thd_plan,
+                )
             if mhc_multistream is not None:
                 mhc_multistream = convert_cp_layout(
                     mhc_multistream,
@@ -2262,6 +2362,7 @@ class MultiTokenPredictionBlock(MegatronModule):
             input_ids=input_ids,
             position_ids=position_ids,
             hidden_states=hidden_states,
+            decoder_input=decoder_input,
             mhc_multistream=mhc_multistream,
             labels=labels,
             loss_mask=loss_mask,
@@ -2358,8 +2459,8 @@ class MultiTokenPredictionBlock(MegatronModule):
 
     def forward(
         self,
-        input_ids: Tensor,
-        position_ids: Tensor,
+        input_ids: Optional[Tensor],
+        position_ids: Optional[Tensor],
         hidden_states: Tensor,
         attention_mask: Tensor,
         padding_mask: Optional[Tensor] = None,
@@ -2374,6 +2475,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         extra_block_kwargs: Optional[dict] = None,
         embedding=None,
+        decoder_input: Optional[Tensor] = None,
         mtp_input_mask: Optional[Tensor] = None,
         mhc_multistream: Optional[Tensor] = None,
         packed_seq_params_by_layout: Optional[dict[CPLayout, PackedSeqParams | None]] = None,
@@ -2412,6 +2514,17 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
+
+            if decoder_input is not None:
+                decoder_input, _ = roll_tensor_precomputed_embeddings(
+                    decoder_input,
+                    shifts=-1,
+                    dims=0,
+                    sp_group=self.tp_group if self.sequence_parallel else None,
+                    cp_group=self.cp_group,
+                    packed_seq_params=packed_seq_params,
+                    return_sum=False,
+                )
 
             # Older HSM entries predict earlier targets than the newest entry. Roll
             # them once per depth so all candidates correspond to the same target.
@@ -2494,6 +2607,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                 cp_layout_plan=cp_layout_plan,
                 sequence_len_offset=sequence_len_offset,
                 embedding=embedding,
+                decoder_input=decoder_input,
                 mtp_input_mask=mtp_input_mask,
                 **(extra_block_kwargs or {}),
             )

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -358,11 +358,14 @@ def _roll_tensor_packed_seq(
             valid_length = cu_seqlens[i + 1] - cu_seqlens[i]
             end_idx = start_idx + valid_length
             physical_end_idx = physical_cu_seqlens[i + 1]
-            seq_slice = slice_sequence(tensor, start_idx, end_idx)
-            rolled_seq = torch.roll(seq_slice, shifts=shifts, dims=sequence_dim)
-            # Zero out the last position(s) that would cross sequence boundaries
-            rolled_seq.select(sequence_dim, shifts).zero_()
-            assign_sequence(rolled_tensor, start_idx, end_idx, rolled_seq)
+            # Shard-local packed boundaries can collapse documents outside this
+            # SP rank to empty slices. They have no boundary token to clear.
+            if end_idx > start_idx:
+                seq_slice = slice_sequence(tensor, start_idx, end_idx)
+                rolled_seq = torch.roll(seq_slice, shifts=shifts, dims=sequence_dim)
+                # Zero out the last position that would cross a document boundary.
+                rolled_seq.select(sequence_dim, shifts).zero_()
+                assign_sequence(rolled_tensor, start_idx, end_idx, rolled_seq)
             assign_sequence(rolled_tensor, end_idx, physical_end_idx, 0)
         rolled_sum = rolled_tensor.sum() if return_sum else None
         return rolled_tensor, rolled_sum

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -88,6 +88,9 @@ class TransformerConfig(ModelParallelConfig):
     freeze_base_model_for_mtp: bool = False
     """Freeze every non-MTP parameter and avoid recording backbone activations."""
 
+    keep_mtp_spec_in_bf16: bool = False
+    """Keep MTP layers out of FP8 and FP4 quantization contexts."""
+
     mtp_detach_heads: bool = False
     """If True, detach MTP head inputs from the main model graph.
     This prevents MTP loss gradients from flowing back to the main model,

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -27,6 +27,7 @@ from megatron.training.global_vars import (
 from tests.unit_tests.test_utilities import Utils
 
 GOLDEN_CONFIG: Dict[str, Any] = {
+    "keep_mtp_spec_in_bf16": False,
     "_cpu_offloading_context": None,
     "account_for_embedding_in_pipeline_split": False,
     "account_for_loss_in_pipeline_split": False,

--- a/tests/unit_tests/ssm/test_packed_seq_helpers.py
+++ b/tests/unit_tests/ssm/test_packed_seq_helpers.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import torch
+
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.ssm.packed_seq_helpers import build_packed_seq_idx
+
+
+def test_build_packed_seq_idx_covers_sequences_and_trailing_padding():
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd", cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32)
+    )
+
+    seq_idx = build_packed_seq_idx(packed_seq_params, total_tokens=8)
+
+    assert torch.equal(seq_idx, torch.tensor([[0, 0, 1, 1, 1, 2, 2, 2]], dtype=torch.int32))
+
+
+def test_build_packed_seq_idx_prefers_padded_boundaries():
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=torch.tensor([0, 2, 5], dtype=torch.int32),
+        cu_seqlens_q_padded=torch.tensor([0, 4, 8], dtype=torch.int32),
+    )
+
+    seq_idx = build_packed_seq_idx(packed_seq_params, total_tokens=8)
+
+    assert torch.equal(seq_idx, torch.tensor([[0, 0, 0, 0, 1, 1, 1, 1]], dtype=torch.int32))

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -784,6 +784,10 @@ class TestMegatronNetworkArgumentGeneration:
         with pytest.raises(ArgumentError, match="invalid choice"):
             self._parser().parse_args(["--mhc-fused-backend", "cuda"])
 
+    def test_keep_mtp_spec_in_bf16_flag(self):
+        assert self._parser().parse_args([]).keep_mtp_spec_in_bf16 is False
+        assert self._parser().parse_args(["--keep-mtp-spec-in-bf16"]).keep_mtp_spec_in_bf16
+
 
 class TestMegatronMLAArgumentGeneration:
     """Test Megatron's manually registered MLA arguments."""

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -47,6 +47,7 @@ from megatron.core.transformer.multi_token_prediction import (
     mtp_on_this_rank,
     process_mtp_loss,
     roll_tensor,
+    roll_tensor_precomputed_embeddings,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import (
@@ -470,6 +471,49 @@ class TestMultiTokenPredictionLayer:
         )
         assert len(seen_masks) == 2
         assert all(mask is mtp_input_mask for mask in seen_masks)
+
+    def test_block_rolls_precomputed_embeddings_for_each_depth(self):
+        config = TransformerConfig(
+            num_layers=2, hidden_size=1, num_attention_heads=1, mtp_num_layers=2
+        )
+        seen_embeddings = []
+
+        class _CaptureLayer:
+            def __call__(
+                self, hidden_states, input_ids, position_ids, padding_mask, decoder_input, **kwargs
+            ):
+                seen_embeddings.append(decoder_input.clone())
+                return hidden_states, input_ids, position_ids, padding_mask, None
+
+        block = types.SimpleNamespace(
+            config=config,
+            training=True,
+            vp_stage=None,
+            pp_rank=0,
+            mtp_use_repeated_layer=False,
+            cp_group=None,
+            tp_group=None,
+            hidden_state_mixing_rng_tracker_name=None,
+            sequence_parallel=False,
+            layers=[_CaptureLayer(), _CaptureLayer()],
+        )
+        decoder_input = torch.arange(4, dtype=torch.float32).view(4, 1, 1)
+
+        MultiTokenPredictionBlock.forward(
+            block,
+            input_ids=None,
+            position_ids=None,
+            hidden_states=torch.ones_like(decoder_input),
+            decoder_input=decoder_input,
+            attention_mask=None,
+        )
+
+        torch.testing.assert_close(
+            seen_embeddings[0], torch.tensor([1.0, 2.0, 3.0, 0.0]).view(4, 1, 1)
+        )
+        torch.testing.assert_close(
+            seen_embeddings[1], torch.tensor([2.0, 3.0, 0.0, 0.0]).view(4, 1, 1)
+        )
 
     @pytest.mark.parametrize("packed", [False, True])
     def test_hsm_aligns_history_with_target_tokens(self, monkeypatch, packed):
@@ -2819,6 +2863,32 @@ class TestMultiTokenPrediction:
         assert torch.equal(rolled, expected)
         Utils.destroy_model_parallel()
 
+    def test_roll_precomputed_embeddings_respects_packed_boundaries(self):
+        embeddings = torch.arange(10, dtype=torch.float32).view(5, 1, 2)
+        cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32)
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            max_seqlen_q=3,
+            max_seqlen_kv=3,
+            qkv_format='thd',
+        )
+
+        rolled, rolled_sum = roll_tensor_precomputed_embeddings(
+            embeddings, packed_seq_params=packed_seq_params
+        )
+
+        expected = torch.cat(
+            (
+                embeddings[1:3],
+                torch.zeros_like(embeddings[:1]),
+                embeddings[4:5],
+                torch.zeros_like(embeddings[:1]),
+            )
+        )
+        torch.testing.assert_close(rolled, expected)
+        torch.testing.assert_close(rolled_sum, expected.sum())
+
     def test_process_mtp_loss_skips_when_no_labels_and_no_input_ids(self):
         """When labels and input_ids are both None, MTP loss is skipped (early return)."""
         config = TransformerConfig(
@@ -3470,7 +3540,13 @@ class TestMultiTokenPredictionHybrid:
     @staticmethod
     def _make_forward_stub():
         hidden_states = torch.arange(4, dtype=torch.float32).reshape(2, 1, 2)
-        call_counts = {"mtp": 0, "mtp_loss": 0, "main_loss": 0, "mtp_input_mask": None}
+        call_counts = {
+            "mtp": 0,
+            "mtp_loss": 0,
+            "main_loss": 0,
+            "decoder_input": None,
+            "mtp_input_mask": None,
+        }
         metric_avg_group = object()
 
         def decoder(**kwargs):
@@ -3483,6 +3559,7 @@ class TestMultiTokenPredictionHybrid:
 
         def mtp(**kwargs):
             call_counts["mtp"] += 1
+            call_counts["decoder_input"] = kwargs.get("decoder_input")
             call_counts["mtp_input_mask"] = kwargs.get("mtp_input_mask")
             decoder_hidden_states = kwargs["hidden_states"]
             return torch.cat((decoder_hidden_states, decoder_hidden_states + 100.0), dim=0)
@@ -3496,6 +3573,7 @@ class TestMultiTokenPredictionHybrid:
                     input_ids=kwargs["input_ids"],
                     position_ids=kwargs["position_ids"],
                     hidden_states=kwargs["hidden_states"],
+                    decoder_input=kwargs["decoder_input"],
                     mhc_multistream=kwargs["mhc_multistream"],
                     labels=kwargs["labels"],
                     loss_mask=kwargs["loss_mask"],
@@ -3600,6 +3678,8 @@ class TestMultiTokenPredictionHybrid:
         )
 
         expected_block_mask = mtp_input_mask if expected_mtp_calls else None
+        expected_decoder_input = hidden_states if expected_mtp_calls else None
+        assert call_counts.pop("decoder_input") is expected_decoder_input
         assert call_counts.pop("mtp_input_mask") is expected_block_mask
         assert call_counts == {
             "mtp": expected_mtp_calls,
@@ -3720,6 +3800,7 @@ class TestMultiTokenPredictionHybrid:
         )
 
         assert captured["mtp"]["hidden_states"] is zigzag_hidden_states
+        assert captured["mtp"]["decoder_input"] is zigzag_hidden_states
         assert captured["mtp"]["input_ids"] is zigzag_input_ids
         assert captured["mtp"]["position_ids"] is zigzag_position_ids
         assert captured["mtp"]["packed_seq_params"] is zigzag_packed_seq_params

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -3849,6 +3849,7 @@ class TestMultiTokenPredictionHybrid:
 
         torch.testing.assert_close(output, hidden_states.transpose(0, 1).contiguous())
         torch.testing.assert_close(inference_context.mtp_decoder_hidden_states, hidden_states)
+        assert call_counts.pop("decoder_input") is None
         assert call_counts.pop("mtp_input_mask") is None
         assert call_counts == {"mtp": 0, "mtp_loss": 0, "main_loss": 0}
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

## What does this PR do?

Derive Mamba sequence identifiers from packed boundaries, accept precomputed embeddings in hybrid MTP, and make packed MTP rolling handle empty shard-local documents. Include Mamba/MTP tests.

This is part of a review-split multimodal SFT series. Production run scripts, data YAMLs, checkpoint conversion tooling, and separate CI compatibility fixes are outside this series.

## Dependencies and review scope

Targets `main`.

## Validation

- Replayed onto public `main` at `46fb90ca942a2950c58c5654b3e56877e88a3e35`, preserving atomic signed and signed-off commits.
- The original combined feature stack had multi-node Super SFT validation before this migration; that is not an isolated-PR or rebased-head test result.
- GitHub CI is pending. No GPU tests have been rerun locally for these rebased heads.
- Local Black, isort, pylint, and Ruff checks passed for paths covered by the repository autoformat script (`megatron/core` and `tests`). Mypy is unavailable locally. Changed Python files pass syntax parsing; no CI configuration changes are included.

Kept as a draft pending CI and dependency integration.
