### PR TITLE
Add the Energon multimodal SFT data pipeline

### DIFF
--- a/examples/multimodal/data_loading/conversation_base.py
+++ b/examples/multimodal/data_loading/conversation_base.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import copy
+import dataclasses
+import io
+import os
+import re
+from collections import defaultdict
+from pathlib import Path
+
+from PIL import Image
+
+from megatron.energon import CachePool, FileStore, SourceInfo, basic_sample_keys, cooker, stateless
+from megatron.energon.av import AVDecoder
+
+from .conversation_sample import (
+    ConversationSample,
+    ImageMedia,
+    Media,
+    Message,
+    VideoFrameMedia,
+    VideoMedia,
+)
+from .misc import retrieve_media_source
+
+# List of allowed tags
+conversation_allowed_tags = {
+    'image': '<image>',
+    'video': '<video>',
+}
+
+conversation_default_media_extensions = {
+    'image': ['png', 'jpeg', 'jpg', 'img'],
+    'video': ['mp4'],
+}
+
+# WARNING: values cannot be used as the keys in the same dict to avoid cyclic graph
+conversation_tags_mapping_sample_to_allowed = {
+    'images': 'image',
+    'videos': 'video',
+}
+
+
+# map the senders from the sample to the allowed ones
+# allowed senders can be found in conversation_sample.py
+conversation_sender_mapping_sample_to_allowed = {
+    'human': 'user',
+    'gpt': 'assistant',
+    'agent': 'assistant',
+}
+
+
+# Build a pattern like: <image>|<video>
+conversation_tag_pattern = re.compile(
+    r"(" + "|".join(re.escape(tag) for tag in conversation_allowed_tags.values()) + ")"
+)
+
+
+def conversation_open_medias(media_tag: str, media):
+    if media_tag == "image":
+        if isinstance(media, bytes):
+            media = Image.open(io.BytesIO(media))
+        elif not isinstance(media, Image.Image):
+            media = Image.open(media)
+    elif media_tag == "video" or media_tag == "vis_video":
+        if not isinstance(media, AVDecoder):
+            if isinstance(media, str):
+                media = Path(media).read_bytes()
+            if isinstance(media, bytes):
+                media = io.BytesIO(media)
+            media = AVDecoder(media)
+    else:
+        raise ValueError(f"Unknown tag: {tag}")
+
+    return media
+
+
+def conversation_convert_tag_to_objects(tag: str, value) -> list[Media]:
+    result = []
+    if tag == "image":
+        result.append(ImageMedia(value=value))
+    elif tag == "video":
+        result.append(VideoMedia(value=value))
+    else:
+        raise ValueError(f"Unknown tag: {tag}")
+
+    if len(result) == 0:
+        raise ValueError(f"Tag {tag} not found in sample: {raw}")
+
+    return result
+
+
+def conversation_convert_message(
+    meta: dict,
+    msg: dict,
+    media_index: dict,
+    raw: dict = {},
+    check_if_media_file_exist=True,
+    tried_default_extensions: set = None,
+    tags_mapping_sample_to_allowed: dict = conversation_tags_mapping_sample_to_allowed,
+    loss: bool | None = None,
+) -> Message:
+    """Convert one conversation message from a string to a list of dictionaries representing media or text.
+
+    Args:
+        meta: dictionary with at least two keys: "conversations" and the media tag.
+        msg: it is the conversation message to be converted.
+            meta["conversations"][...]["value"]
+        media_index: it keeps the latest index of media tags over "conversations".
+        raw: dictionary with all webdataset compliant keys of a sample.
+            Emtpy for jsonl dataset, non-empty otherwise
+        check_if_media_file_exist: if true, it will throw an error if the media file is not found.
+        tags_mapping_sample_to_allowed:
+            different media namings maybe used in the raw dataset,
+            in which case, they need to be mapped to the allowed ones
+    """
+    if tried_default_extensions is None:
+        tried_default_extensions = set()
+
+    fragments = []
+    for tag in tags_mapping_sample_to_allowed:
+        tag_str = '<' + tag + '>'
+        if tag_str in msg["value"]:
+            tag_str_mapped = '<' + tags_mapping_sample_to_allowed[tag] + '>'
+            msg["value"] = msg["value"].replace(tag_str, tag_str_mapped)
+    parts = re.split(conversation_tag_pattern, msg["value"])
+
+    # Convert the parts to message fragments
+    empty_text = True
+    for i, part in enumerate(parts):
+        if part in conversation_allowed_tags.values():
+            tag = part.strip('<>')
+            if not isinstance(meta[tag], list):
+                meta[tag] = [meta[tag]]
+            # try to extract the media object from the shard
+            ext = os.path.basename(meta[tag][media_index[tag]]).split('.', 1)[1]
+            if (
+                raw
+                and ext not in raw
+                and ext not in tried_default_extensions
+                and tag in conversation_default_media_extensions
+            ):
+                # try the default extension
+                for ext in conversation_default_media_extensions[tag]:
+                    if ext in raw:
+                        tried_default_extensions.add(ext)
+                        break
+            media_file = None
+            if ext in raw:
+                media_file = ext
+            elif isinstance(meta[tag][media_index[tag]], str) and os.path.isfile(
+                meta[tag][media_index[tag]]
+            ):
+                # if cannot get it from the shard files, try to find the local file
+                media_file = meta[tag][media_index[tag]]
+            elif check_if_media_file_exist:
+                sample_to_print = raw if raw else meta
+                raise ValueError(
+                    f"Cannot find the media file {meta[tag][media_index[tag]]} from {sample_to_print} or locally."
+                )
+            else:
+                media_file = meta[tag][media_index[tag]]
+            media_index[tag] += 1
+            fragments += conversation_convert_tag_to_objects(tag, media_file)
+        else:
+            # Even indices are plain text, but skip empty strings
+            if part.strip():
+                fragments.append(part)
+                empty_text = False
+
+    if empty_text:
+        fragments.append(' ')
+
+    sender = msg["from"]
+    if sender in conversation_sender_mapping_sample_to_allowed:
+        sender = conversation_sender_mapping_sample_to_allowed[sender]
+    return Message(sender=sender, fragments=fragments, loss=loss)
+
+
+warn_about_slow_media_loading = defaultdict(lambda: True)
+
+
+def conversation_post_processing(
+    conversation: list,
+    sample: dict,
+    cache: CachePool,
+    primary: FileStore,
+    media_source: FileStore | None = None,
+    process_conversation_in_place: bool = True,
+    **media_sources: FileStore,
+) -> ConversationSample:
+    global warn_about_slow_media_loading
+
+    messages = conversation
+    if not process_conversation_in_place:
+        messages = copy.deepcopy(messages)
+
+    for msg in messages:
+        for frag in msg.fragments:
+            if isinstance(frag, (ImageMedia, VideoMedia, VideoFrameMedia)):
+                if isinstance(frag.value, str):
+                    if frag.value in sample:
+                        val = conversation_open_medias(
+                            ConversationSample.__MEDIA_TYPES_REVERSE__[type(frag)],
+                            sample[frag.value],
+                        )
+                        if frag.metadata is None:
+                            # Try to fetch the metadata directly from the primary dataset
+                            try:
+                                frag.metadata = dataclasses.asdict(
+                                    primary.get_media_metadata(f".{frag.value}")
+                                )
+                            except Exception as e:
+                                if warn_about_slow_media_loading[primary.get_path()]:
+                                    print(
+                                        f"WARNING: Dataset {primary.get_path()} not prepared with media metadata, slow metadata for .{frag.value}: {e!r}"
+                                    )
+                                    warn_about_slow_media_loading[primary.get_path()] = False
+                        try:
+                            frag.value = cache.to_cache(val, sample['__key__'] + f".{frag.value}")
+                        except:
+                            raise ValueError(f"fragment's value: {val} cannot be cached.")
+                    else:
+                        # it is a media file outside the primary dataset
+                        media_path = frag.value
+                        media_dirname = os.path.dirname(media_path)
+                        media_basename = os.path.basename(media_path)
+                        media_extension = media_basename.rsplit(".", 1)[-1]
+
+                        # get the local or remote media source
+                        current_media_source = media_source
+                        if (
+                            current_media_source is None
+                            and media_sources
+                            and "aux_data_prefixes" in sample["__subflavors__"]
+                        ):
+                            current_media_source = retrieve_media_source(
+                                media_path,
+                                media_sources,
+                                sample["__subflavors__"]["aux_data_prefixes"],
+                            )
+
+                        # check if the auxiliary media dataset is energon prepared
+                        media_path_properly_defined_in_metadataset = (
+                            current_media_source is not None
+                        )
+
+                        if not media_path_properly_defined_in_metadataset:
+                            if os.path.isfile(media_path):
+                                print(
+                                    f"Warning: Media file {media_path} of {primary.get_path()} is an absolute path, loading is slow."
+                                )
+                                val = media_path
+                            else:
+                                raise ValueError(f"Cannot find media file {media_path} in {sample}")
+
+                        # process the media file
+                        if media_path_properly_defined_in_metadataset:
+                            m_path = media_path
+                            if os.path.isabs(m_path) and not os.path.isfile(m_path):
+                                # if the media path is absolute path and cannot be found locally,
+                                # then use the basename and rely on the aux path in the metadataset
+                                m_path = media_basename
+                            if frag.metadata is None:
+                                try:
+                                    frag.metadata = dataclasses.asdict(
+                                        current_media_source.get_media_metadata(m_path)
+                                    )
+                                except Exception as e:
+                                    if warn_about_slow_media_loading[
+                                        current_media_source.get_path()
+                                    ]:
+                                        print(
+                                            f"WARNING: Dataset {current_media_source.get_path()} not prepared with media metadata, slow metadata for {m_path}: {e!r}"
+                                        )
+                                        warn_about_slow_media_loading[
+                                            current_media_source.get_path()
+                                        ] = False
+                            if frag.metadata is None:
+                                val = cache.get(current_media_source, m_path)
+                            sample['__sources__'] = (
+                                *sample['__sources__'],
+                                SourceInfo(
+                                    dataset_path=current_media_source.get_path(),
+                                    index=m_path,
+                                    shard_name=None,
+                                    file_names=(m_path,),
+                                ),
+                            )
+                            frag.value = cache.get_lazy(current_media_source, m_path)
+                        else:
+                            # load and cache the media file on the fly
+                            # warning: slow
+                            if isinstance(val, str):
+                                sample['__sources__'] = (
+                                    *sample['__sources__'],
+                                    SourceInfo(
+                                        dataset_path=Path(val).parent,
+                                        index=Path(val).name,
+                                        shard_name=None,
+                                        file_names=(Path(val).name,),
+                                    ),
+                                )
+                            val_opened = conversation_open_medias(
+                                ConversationSample.__MEDIA_TYPES_REVERSE__[type(frag)], val
+                            )
+                            try:
+                                frag.value = cache.to_cache(
+                                    val_opened, sample['__key__'] + f".{media_extension}"
+                                )
+                                val = val_opened
+                            except:
+                                # let's try again on the raw bytes
+                                raise ValueError(
+                                    f"fragment's value: {val_opened} cannot be cached."
+                                )
+                else:
+                    raise NotImplementedError(
+                        f"Postprocessing on media type {type(frag.value)} hasn't been implemented yet."
+                    )
+
+                if frag.metadata is None:
+                    if isinstance(frag, ImageMedia):
+                        frag.metadata = dict(
+                            width=val.width, height=val.height, format=val.format, mode=val.mode
+                        )
+                    elif isinstance(frag, (VideoMedia, VideoFrameMedia)):
+                        frag.metadata = dataclasses.asdict(val.get_metadata())
+
+            elif isinstance(frag, str):
+                # No source
+                pass
+            else:
+                raise ValueError(f"Unknown fragment type: {type(frag)}")
+
+    return ConversationSample(conversation=messages, **basic_sample_keys(sample))

--- a/examples/multimodal/data_loading/conversation_sample.py
+++ b/examples/multimodal/data_loading/conversation_sample.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import dataclasses
+from typing import Literal, Optional, Union
+
+import torch
+from PIL import Image
+
+from megatron.energon import Lazy, Sample
+from megatron.energon.av import AVDecoder
+from megatron.energon.edataclass import edataclass
+
+
+@edataclass
+class Media:
+    """A media object in a conversation."""
+
+    pass
+
+
+@edataclass
+class ImageMedia(Media):
+    """An image media object in a conversation."""
+
+    value: Union[torch.Tensor, Image.Image, Lazy[Image.Image], str]
+
+    metadata: dict[str, Union[str, int, float, bool]] | None = None
+
+    @property
+    def width(self) -> int:
+        return self.metadata["width"]
+
+    @property
+    def height(self) -> int:
+        return self.metadata["height"]
+
+    @width.setter
+    def width(self, value):
+        self.metadata["width"] = value
+
+    @height.setter
+    def height(self, value):
+        self.metadata["height"] = value
+
+
+@edataclass
+class VideoMedia(Media):
+    """A video media object in a conversation."""
+
+    value: Union[AVDecoder, torch.Tensor, Lazy[AVDecoder], str]
+
+    #: If set, the video needs to be trimmed to the given range in seconds.
+    start_time: Optional[float] = None
+    end_time: Optional[float] = None
+
+    metadata: dict[str, Union[str, int, float, bool]] | None = None
+
+    @property
+    def clip_duration(self) -> float:
+        start_time = self.start_time
+        end_time = self.end_time
+        if start_time is None:
+            start_time = 0
+        if end_time is None:
+            end_time = self.metadata["video_duration"]
+        return end_time - start_time
+
+    @property
+    def video_width(self) -> int:
+        return self.metadata["video_width"]
+
+    @property
+    def video_height(self) -> int:
+        return self.metadata["video_height"]
+
+    @property
+    def video_duration(self) -> float:
+        return self.metadata["video_duration"]
+
+    @property
+    def video_num_frames(self) -> int:
+        return self.metadata["video_num_frames"]
+
+    @property
+    def video_fps(self) -> float:
+        return self.metadata["video_fps"]
+
+
+@edataclass
+class VideoFrameMedia(Media):
+    """A video frame media object in a conversation."""
+
+    value: Union[AVDecoder, torch.Tensor, Lazy[AVDecoder], str]
+
+    timestamp: Optional[float] = None
+
+    # Frame index: original frame index in source video; non-integer means we're interpolating
+    # Sample index: consecutive index (0, 1, 2, ...) within the sampled frames for the video media
+    frame_index: Optional[Union[int, float]] = None
+    sample_index: Optional[int] = None
+
+    metadata: dict[str, Union[str, int, float, bool]] | None = None
+
+    @property
+    def video_width(self) -> int:
+        return self.metadata["video_width"]
+
+    @property
+    def video_height(self) -> int:
+        return self.metadata["video_height"]
+
+
+@edataclass
+class Message:
+    """A message in a conversation between a user and an assistant."""
+
+    #: The sender of the message
+    sender: Literal["user", "assistant", "system", "tool"]
+
+    #: The message content
+    fragments: list[Media | str]
+
+    #: Whether this assistant turn contributes to the training loss.
+    #: ``None`` preserves the legacy implicit-loss behavior.
+    loss: bool | None = None
+
+
+@edataclass
+class ConversationSample(Sample):
+    """Sample type for a conversation between a user and an assistant.
+
+    Can include media of various types.
+    """
+
+    __MEDIA_TYPES__ = {
+        "image": ImageMedia,
+        "video": VideoMedia,
+        "video_frame": VideoFrameMedia,
+    }
+    __MEDIA_TYPES_REVERSE__ = {v: k for k, v in __MEDIA_TYPES__.items()}
+
+    #: The messages in the conversation
+    conversation: list[Message]
+
+    @staticmethod
+    def from_json(json_data: dict, **kwargs) -> "ConversationSample":
+        return ConversationSample(
+            conversation=[
+                Message(
+                    sender=msg["sender"],
+                    fragments=[
+                        (
+                            frag
+                            if isinstance(frag, str)
+                            # TODO: This is a hack to support legacy formatted text media in the conversation
+                            else (
+                                frag["value"]
+                                if frag["t"] == "text"
+                                else ConversationSample.__MEDIA_TYPES__[frag.pop("t")](**frag)
+                            )
+                        )
+                        for frag in msg["fragments"]
+                    ],
+                    loss=msg.get("loss"),
+                )
+                for msg in json_data["conversation"]
+            ],
+            **kwargs,
+        )
+
+    def to_json(self) -> dict:
+        return dict(
+            conversation=[
+                dict(
+                    sender=msg.sender,
+                    fragments=[
+                        (
+                            frag
+                            if isinstance(frag, str)
+                            else dict(
+                                t=ConversationSample.__MEDIA_TYPES_REVERSE__[type(frag)],
+                                **dataclasses.asdict(frag),
+                            )
+                        )
+                        for frag in msg.fragments
+                    ],
+                    **({"loss": msg.loss} if msg.loss is not None else {}),
+                )
+                for msg in self.conversation
+            ]
+        )

--- a/examples/multimodal/data_loading/cookers/conversation.py
+++ b/examples/multimodal/data_loading/cookers/conversation.py
@@ -1,0 +1,548 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import dataclasses
+import re
+from collections import defaultdict
+
+from megatron.energon import CachePool, FileStore, SourceInfo, basic_sample_keys, cooker, stateless
+
+from ..conversation_base import (
+    conversation_convert_message,
+    conversation_post_processing,
+    conversation_tags_mapping_sample_to_allowed,
+)
+from ..conversation_sample import (
+    ConversationSample,
+    ImageMedia,
+    Message,
+    VideoFrameMedia,
+    VideoMedia,
+)
+
+warn_about_slow_media_loading = defaultdict(lambda: True)
+_re_clean_path = re.compile(r"(?:^\./|/\.(?=/))")
+
+NO_TOOL_SYSTEM_CONTENT = (
+    "<|im_start|>system\n"
+    "You are a helpful and harmless assistant.\n\n"
+    "You are not allowed to use any tools.<|im_end|>\n"
+)
+LEGACY_SYSTEM_CONTENT = "<|im_start|>system\nYou are a helpful and harmless assistant.<|im_end|>\n"
+EMPTY_SYSTEM_CONTENT = "<|im_start|>system\n<|im_end|>\n"
+
+EXPLICIT_ASSISTANT_LOSS_COOK = "general_conversations_jsonl_explicit_loss_v1"
+EXPLICIT_ASSISTANT_LOSS_MODE = "explicit_assistant_turns"
+EXPLICIT_ASSISTANT_LOSS_FIELD = "conversations[*].loss"
+_ASSISTANT_SENDERS = {"assistant", "gpt", "agent"}
+_KNOWN_SENDERS = _ASSISTANT_SENDERS | {"system", "human", "user", "tool"}
+_EXPLICIT_ASSISTANT_LOSS_INCOMPATIBLE_OPTIONS = (
+    "train_only_on_last_assistant_turn",
+    "skip_chat_template",
+    "tool_response_as_turn_boundary",
+    "offline_packed_messages",
+)
+
+
+def _validate_loss_mask_subflavors(subflavors: dict) -> bool:
+    """Validate loss-mask configuration before selecting its masking path."""
+    cook = subflavors.get("cook")
+    loss_mask_mode = subflavors.get("loss_mask_mode")
+    assistant_loss_mask_field = subflavors.get("assistant_loss_mask_field")
+
+    if loss_mask_mode not in (None, "", EXPLICIT_ASSISTANT_LOSS_MODE):
+        raise ValueError(f"unsupported loss_mask_mode={loss_mask_mode!r}")
+    if "assistant_loss_mask_field" in subflavors and loss_mask_mode != EXPLICIT_ASSISTANT_LOSS_MODE:
+        raise ValueError(
+            "assistant_loss_mask_field requires " f"loss_mask_mode={EXPLICIT_ASSISTANT_LOSS_MODE}"
+        )
+    if loss_mask_mode == EXPLICIT_ASSISTANT_LOSS_MODE:
+        if cook != EXPLICIT_ASSISTANT_LOSS_COOK:
+            raise ValueError(
+                f"loss_mask_mode={EXPLICIT_ASSISTANT_LOSS_MODE} requires "
+                f"cook={EXPLICIT_ASSISTANT_LOSS_COOK}"
+            )
+        if assistant_loss_mask_field != EXPLICIT_ASSISTANT_LOSS_FIELD:
+            raise ValueError(
+                f"loss_mask_mode={EXPLICIT_ASSISTANT_LOSS_MODE} requires "
+                f"assistant_loss_mask_field={EXPLICIT_ASSISTANT_LOSS_FIELD}"
+            )
+        for incompatible_option in _EXPLICIT_ASSISTANT_LOSS_INCOMPATIBLE_OPTIONS:
+            if subflavors.get(incompatible_option, False):
+                raise ValueError(
+                    "explicit assistant loss is incompatible with " f"{incompatible_option}"
+                )
+        return True
+    if cook == EXPLICIT_ASSISTANT_LOSS_COOK:
+        raise ValueError(
+            f"cook={EXPLICIT_ASSISTANT_LOSS_COOK} requires "
+            f"loss_mask_mode={EXPLICIT_ASSISTANT_LOSS_MODE}"
+        )
+    return False
+
+
+def _validate_standard_jsonl_has_no_explicit_loss(data: dict) -> None:
+    """Reject explicit loss metadata on the legacy JSONL cooker."""
+    for turn_index, message in enumerate(data.get("conversations", [])):
+        if isinstance(message, dict) and "loss" in message:
+            raise ValueError(
+                "conversations[%d].loss requires cook=%s"
+                % (turn_index, EXPLICIT_ASSISTANT_LOSS_COOK)
+            )
+
+
+def _validate_openai_messages_have_no_explicit_loss(messages: list) -> None:
+    """Reject loss metadata on OpenAI schemas, where it is unsupported."""
+    for turn_index, message in enumerate(messages):
+        if isinstance(message, dict) and "loss" in message:
+            raise ValueError(
+                "messages[%d].loss is unsupported; use cook=%s with the "
+                "conversations schema" % (turn_index, EXPLICIT_ASSISTANT_LOSS_COOK)
+            )
+
+
+def _validate_explicit_assistant_loss_contract(data: dict, subflavors: dict) -> None:
+    """Validate the versioned explicit per-assistant-turn loss contract."""
+    if subflavors.get("loss_mask_mode") != EXPLICIT_ASSISTANT_LOSS_MODE:
+        raise ValueError(
+            f"{EXPLICIT_ASSISTANT_LOSS_COOK} requires "
+            f"loss_mask_mode={EXPLICIT_ASSISTANT_LOSS_MODE}"
+        )
+    if subflavors.get("assistant_loss_mask_field") != EXPLICIT_ASSISTANT_LOSS_FIELD:
+        raise ValueError(
+            f"{EXPLICIT_ASSISTANT_LOSS_COOK} requires "
+            f"assistant_loss_mask_field={EXPLICIT_ASSISTANT_LOSS_FIELD}"
+        )
+    for incompatible_option in _EXPLICIT_ASSISTANT_LOSS_INCOMPATIBLE_OPTIONS:
+        if subflavors.get(incompatible_option, False):
+            raise ValueError(f"explicit assistant loss is incompatible with {incompatible_option}")
+
+    conversations = data.get("conversations")
+    if not isinstance(conversations, list) or not conversations:
+        raise ValueError("conversations must be a non-empty list")
+
+    has_trainable_assistant = False
+    for turn_index, message in enumerate(conversations):
+        if not isinstance(message, dict):
+            raise ValueError(f"conversations[{turn_index}] must be an object")
+        sender = message.get("from")
+        if sender not in _KNOWN_SENDERS:
+            raise ValueError(f"conversations[{turn_index}].from has unsupported sender {sender!r}")
+        if sender in _ASSISTANT_SENDERS:
+            if "loss" not in message or type(message["loss"]) is not bool:
+                raise ValueError(
+                    f"conversations[{turn_index}].loss must be a boolean for "
+                    f"assistant sender {sender!r}"
+                )
+            has_trainable_assistant = has_trainable_assistant or message["loss"]
+        elif "loss" in message:
+            raise ValueError(f"conversations[{turn_index}].loss is only valid on assistant turns")
+
+    if not has_trainable_assistant:
+        raise ValueError("explicit assistant loss requires at least one loss=true turn")
+
+
+def _openai_message_content_to_fragments(content) -> list[str]:
+    """Convert OpenAI-style message content into text fragments."""
+    if content is None:
+        return [""]
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, list):
+        fragments: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                fragments.append(part)
+            elif isinstance(part, dict):
+                part_type = part.get("type") or part.get("t")
+                if part_type in (None, "text"):
+                    fragments.append(
+                        part.get("text") or part.get("content") or part.get("value") or ""
+                    )
+                else:
+                    raise ValueError(
+                        "openai_messages_jsonl only supports text content parts, "
+                        f"got type={part_type!r}"
+                    )
+            else:
+                raise ValueError(f"Unsupported OpenAI message content part: {type(part)}")
+        return fragments
+    raise ValueError(f"Unsupported OpenAI message content: {type(content)}")
+
+
+def _openai_role_to_sender(role: str) -> str:
+    if role in ("system", "user", "assistant", "tool"):
+        return role
+    if role == "function":
+        return "tool"
+    if role == "human":
+        return "user"
+    if role == "gpt":
+        return "assistant"
+    raise ValueError(f"Unsupported OpenAI message role: {role!r}")
+
+
+def _normalize_nano_sft_text_messages(messages: list[dict]) -> list[Message]:
+    """Match the text cleanup used by the Nano 3.5 offline SFT packer."""
+    conversation = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            raise ValueError(f"OpenAI messages entries must be objects, got {type(msg)}")
+        sender = _openai_role_to_sender(msg["role"])
+        content = "".join(_openai_message_content_to_fragments(msg.get("content")))
+        conversation.append(Message(sender=sender, fragments=[content]))
+
+    if conversation[0].sender != "system":
+        first_content = conversation[0].fragments[0]
+        if first_content.startswith(EMPTY_SYSTEM_CONTENT):
+            conversation[0].fragments[0] = first_content.replace(EMPTY_SYSTEM_CONTENT, "")
+        conversation = [Message(sender="system", fragments=[EMPTY_SYSTEM_CONTENT])] + conversation
+    elif conversation[0].fragments[0] in (NO_TOOL_SYSTEM_CONTENT, LEGACY_SYSTEM_CONTENT):
+        conversation[0].fragments[0] = EMPTY_SYSTEM_CONTENT
+
+    for message in conversation:
+        if message.sender == "tool":
+            message.sender = "user"
+
+        content = message.fragments[0]
+        if (
+            message.sender == "user"
+            and "<|im_end|>\n<|im_start|>assistant\n<think></think>\n" in content
+        ):
+            message.fragments[0] = content.replace(
+                "<|im_end|>\n<|im_start|>assistant\n<think></think>\n",
+                "<|im_end|>\n<|im_start|>assistant\n<think></think>",
+            )
+        elif message.sender == "assistant":
+            message.fragments[0] = content.rstrip() + "\n"
+
+    for idx, message in enumerate(conversation):
+        content = message.fragments[0]
+        if message.sender == "user" and idx < len(conversation) - 1:
+            next_message = conversation[idx + 1]
+            if content.endswith(
+                "<|im_end|>\n<|im_start|>assistant\n<think>\n"
+            ) and next_message.fragments[0].startswith("\n</think>"):
+                message.fragments[0] = content.replace(
+                    "<|im_end|>\n<|im_start|>assistant\n<think>\n",
+                    "<|im_end|>\n<|im_start|>assistant\n<think></think>",
+                )
+                next_message.fragments[0] = next_message.fragments[0][len("\n</think>") :].lstrip()
+        elif (
+            message.sender == "assistant"
+            and idx > 0
+            and content.startswith("\n")
+            and conversation[idx - 1].fragments[0].endswith("\n")
+        ):
+            message.fragments[0] = content.lstrip()
+
+    return conversation
+
+
+def _split_openai_messages_at_system(messages: list[dict]) -> list[list[dict]]:
+    """Split an offline-packed Nano SFT row into original conversations."""
+    conversations: list[list[dict]] = []
+    current: list[dict] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise ValueError(f"OpenAI messages entries must be objects, got {type(message)}")
+        if message.get("role") == "system" and current:
+            conversations.append(current)
+            current = []
+        current.append(message)
+    if current:
+        conversations.append(current)
+    return conversations
+
+
+@stateless
+@cooker(need_cache=True)
+def cook_openai_messages_jsonl(
+    sample: dict, cache: CachePool, media_source: FileStore | None = None
+) -> ConversationSample:
+    """Load OpenAI-style JSONL rows with messages[*].role/content."""
+    data = sample["json"]
+    messages = data.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("openai_messages_jsonl requires a non-empty messages list")
+    _validate_openai_messages_have_no_explicit_loss(messages)
+
+    conversation = _normalize_nano_sft_text_messages(messages)
+    for idx, msg in enumerate(conversation):
+        sender = msg.sender
+        if sender == "system" and idx > 0:
+            raise ValueError(
+                "openai_messages_jsonl only supports a leading system message. "
+                "Split rows with repeated system prompts before using this cooker."
+            )
+
+    return ConversationSample(conversation=conversation, **basic_sample_keys(sample))
+
+
+@stateless
+@cooker(need_cache=True)
+def cook_openai_messages_offline_packed_jsonl(
+    sample: dict, cache: CachePool, media_source: FileStore | None = None
+) -> ConversationSample:
+    """Load Nano-style offline-packed JSONL rows with merged ``messages``.
+
+    Each row is one already-packed training item. The row may contain multiple
+    conversations concatenated together, separated by repeated ``system`` turns.
+    Unlike ``openai_messages_jsonl``, this cooker preserves those repeated
+    systems so the task encoder can tokenize each original conversation
+    separately and emit packed ``cu_lengths`` without running online packing.
+    """
+    data = sample["json"]
+    messages = data.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("openai_messages_offline_packed_jsonl requires a non-empty messages list")
+    _validate_openai_messages_have_no_explicit_loss(messages)
+
+    conversation: list[Message] = []
+    for split_messages in _split_openai_messages_at_system(messages):
+        conversation.extend(_normalize_nano_sft_text_messages(split_messages))
+
+    if not conversation:
+        raise ValueError("openai_messages_offline_packed_jsonl produced an empty conversation")
+
+    sample_keys = basic_sample_keys(sample)
+    subflavors = dict(sample_keys.get("__subflavors__", {}) or {})
+    subflavors["offline_packed_messages"] = True
+    sample_keys["__subflavors__"] = subflavors
+    return ConversationSample(conversation=conversation, **sample_keys)
+
+
+def _basic_sample_keys_with_json_dataset(sample: dict, data: dict) -> dict:
+    """Preserve optional raw JSONL dataset metadata for task-encoder filters."""
+    sample_keys = basic_sample_keys(sample)
+    dataset_name = data.get("dataset")
+    if dataset_name is not None:
+        subflavors = dict(sample_keys.get("__subflavors__", {}) or {})
+        subflavors["dataset"] = dataset_name
+        sample_keys["__subflavors__"] = subflavors
+    return sample_keys
+
+
+@stateless
+@cooker(need_cache=True)
+def cook_conversation(
+    sample: dict,
+    cache: CachePool,
+    media_source: FileStore | None = None,
+    **media_sources: FileStore,
+) -> ConversationSample:
+    global warn_about_slow_media_loading
+
+    data = sample["json"]
+    cs = ConversationSample.from_json(data, **_basic_sample_keys_with_json_dataset(sample, data))
+
+    for msg in cs.conversation:
+        for frag in msg.fragments:
+            if isinstance(frag, (ImageMedia, VideoMedia, VideoFrameMedia)):
+                current_media_source = media_source
+                media_path = frag.value
+                if (
+                    current_media_source is None
+                    and media_sources
+                    and "aux_data_prefixes" in cs.__subflavors__
+                ):
+                    path = _re_clean_path.sub("", media_path)
+                    for prefix, aux_key in cs.__subflavors__["aux_data_prefixes"].items():
+                        if path.startswith(prefix):
+                            if aux_key not in media_sources:
+                                raise ValueError(f"Unknown auxiliary media source {aux_key!r}")
+                            current_media_source = media_sources[aux_key]
+                            media_path = path[len(prefix) :]
+                            break
+                    else:
+                        raise ValueError(
+                            f"No prefix for {path!r} in {cs.__subflavors__['aux_data_prefixes']} "
+                            f"for {cs.__sources__}"
+                        )
+                if current_media_source is None:
+                    raise ValueError(
+                        "cook_conversation requires media_source for samples with media fragments"
+                    )
+                if frag.metadata is None:
+                    try:
+                        frag.metadata = dataclasses.asdict(
+                            current_media_source.get_media_metadata(media_path)
+                        )
+                    except Exception as e:
+                        if warn_about_slow_media_loading[current_media_source.get_path()]:
+                            print(
+                                f"WARNING: Dataset {current_media_source.get_path()} not prepared with media "
+                                f"metadata, slow metadata for {media_path}: {e!r}"
+                            )
+                            warn_about_slow_media_loading[current_media_source.get_path()] = False
+                cs.__sources__ = (
+                    *cs.__sources__,
+                    SourceInfo(
+                        dataset_path=current_media_source.get_path(),
+                        index=media_path,
+                        shard_name=None,
+                        file_names=(media_path,),
+                    ),
+                )
+                frag.value = cache.get_lazy(current_media_source, media_path)
+            elif isinstance(frag, str):
+                # No source
+                pass
+            else:
+                raise ValueError(f"Unknown fragment type: {type(frag)}")
+
+    return cs
+
+
+@stateless
+@cooker(need_cache=True, need_primary=True)
+def cook_general_conversations_webdataset(
+    sample: dict,
+    cache: CachePool,
+    primary: FileStore,
+    media_source: FileStore | None = None,
+    **media_sources: FileStore,
+) -> ConversationSample:
+    """Loads general conversation-based datasets of webdataset format (monolithic or polylithic).
+    Each sample can be single/multi-turn converstaions with multiple modalities.
+    Each modality can have one or more number of media objects.
+    Media tags such as ``<image>`` and ``<video>`` may appear in any conversation turn.
+    """
+
+    data = sample["json"].copy()
+    _validate_standard_jsonl_has_no_explicit_loss(data)
+    for tag in conversation_tags_mapping_sample_to_allowed:
+        if tag in data and tag != conversation_tags_mapping_sample_to_allowed[tag]:
+            sample['json'][conversation_tags_mapping_sample_to_allowed[tag]] = data[tag]
+            del sample['json'][tag]
+    # update the data
+    data = sample["json"].copy()
+
+    media_index = defaultdict(int)
+    tried_default_extensions = set()
+
+    # Build the conversation
+    conversation = []
+    for msg in data["conversations"]:
+        conversation.append(
+            conversation_convert_message(
+                data,
+                msg,
+                media_index,
+                raw=sample,
+                check_if_media_file_exist=False,
+                tried_default_extensions=tried_default_extensions,
+                tags_mapping_sample_to_allowed=conversation_tags_mapping_sample_to_allowed,
+            )
+        )
+
+    # Check if all media files are retrieved
+    for media in media_index:
+        medias = data[media]
+        if not isinstance(medias, list):
+            medias = [medias]
+        if media_index[media] != len(medias):
+            raise ValueError(
+                f"Retrieved {media_index[media]}/{len(medias)} {media} files from {sample}"
+            )
+
+    return conversation_post_processing(
+        conversation,
+        sample,
+        cache,
+        primary=primary,
+        media_source=media_source,
+        **media_sources,
+    )
+
+
+def _cook_general_conversations_jsonl(
+    sample: dict,
+    cache: CachePool,
+    primary: FileStore,
+    media_source: FileStore | None = None,
+    *,
+    explicit_assistant_loss: bool,
+    **media_sources: FileStore,
+) -> ConversationSample:
+    """Loads general conversation datasets that have the json (manifest) files and media files in separate files (jsonl datasets).
+    The json(l) file structure is the same as the cook_general_conversations_webdataset
+    """
+    data = sample["json"].copy()
+
+    if explicit_assistant_loss:
+        _validate_explicit_assistant_loss_contract(data, sample.get("__subflavors__", {}))
+    else:
+        _validate_standard_jsonl_has_no_explicit_loss(data)
+
+    for tag in conversation_tags_mapping_sample_to_allowed:
+        if tag in data and tag != conversation_tags_mapping_sample_to_allowed[tag]:
+            sample["json"][conversation_tags_mapping_sample_to_allowed[tag]] = data[tag]
+            del sample["json"][tag]
+
+    data = sample["json"].copy()
+
+    media_index = defaultdict(int)
+    tried_default_extensions = set()
+
+    # Build the conversation
+    conversation = []
+    for msg in data["conversations"]:
+        conversation.append(
+            conversation_convert_message(
+                data,
+                msg,
+                media_index,
+                check_if_media_file_exist=False,
+                tried_default_extensions=tried_default_extensions,
+                tags_mapping_sample_to_allowed=conversation_tags_mapping_sample_to_allowed,
+                loss=msg.get("loss") if explicit_assistant_loss else None,
+            )
+        )
+
+    # Check if all media files are retrieved
+    for media in media_index:
+        medias = data[media]
+        if not isinstance(medias, list):
+            medias = [medias]
+        if media_index[media] != len(medias):
+            raise ValueError(
+                f"Retrieved {media_index[media]}/{len(medias)} {media} files from {sample}"
+            )
+
+    return conversation_post_processing(
+        conversation,
+        sample,
+        cache,
+        primary=primary,
+        media_source=media_source,
+        **media_sources,
+    )
+
+
+@stateless
+@cooker(need_primary=True, need_cache=True)
+def cook_general_conversations_jsonl(
+    sample: dict,
+    cache: CachePool,
+    primary: FileStore,
+    media_source: FileStore | None = None,
+    **media_sources: FileStore,
+) -> ConversationSample:
+    """Load legacy general-conversation JSONL without explicit loss metadata."""
+    return _cook_general_conversations_jsonl(
+        sample, cache, primary, media_source, explicit_assistant_loss=False, **media_sources
+    )
+
+
+@stateless
+@cooker(need_primary=True, need_cache=True)
+def cook_general_conversations_jsonl_explicit_loss_v1(
+    sample: dict,
+    cache: CachePool,
+    primary: FileStore,
+    media_source: FileStore | None = None,
+    **media_sources: FileStore,
+) -> ConversationSample:
+    """Load versioned JSONL with explicit per-assistant-turn loss flags."""
+    return _cook_general_conversations_jsonl(
+        sample, cache, primary, media_source, explicit_assistant_loss=True, **media_sources
+    )

--- a/examples/multimodal/data_loading/cookers/eagle.py
+++ b/examples/multimodal/data_loading/cookers/eagle.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import re
+
+from data_loading.conversation_sample import ConversationSample, Message
+from PIL import Image
+
+from megatron.core.models.multimodal.llava_model import IMAGE_TOKEN
+from megatron.energon import CachePool, FileStore, MockLazy, basic_sample_keys, cooker, stateless
+from megatron.training import get_args
+
+
+@stateless
+@cooker(need_cache=True)
+def cook_eagle(sample: dict, cache: CachePool, media_source: FileStore) -> ConversationSample:
+    args = get_args()
+    data = sample["json"]
+    raw_imgs = data.get("images", [])
+    image_sizes = data.get("image_sizes", [])
+    assert all(isinstance(img, str) for img in raw_imgs) or (
+        all(
+            not isinstance(img, str) and isinstance(img, (tuple, list)) and len(img) == 2
+            for img in raw_imgs
+        )
+    ), f"Expected all images to be either paths or tuples of (path, int): {raw_imgs}"
+    images = []
+    for img in raw_imgs:
+        if isinstance(img, str):
+            images.append(cache.get_lazy(media_source, img))
+        else:
+            images.append((cache.get_lazy(media_source, img[0]), img[1]))
+
+    # If this is a text-only sample and we are freezing the LM,
+    # then use a dummy input image.
+    if len(images) == 0 and args.freeze_LM:
+        image_sizes.append((args.img_w, args.img_h))
+        images.append(
+            MockLazy(
+                "empty_img", lambda x: Image.new("RGB", (args.img_w, args.img_h), (255, 255, 255))
+            )
+        )
+
+    # Note: Some tokenizers may ignore the system prompt.
+    conversation = [Message(sender="system", fragments=["Answer the questions."])]
+
+    # Format the conversation as a list of "user" / "assistant" turns.
+    for turn in data["conversations"]:
+        assert turn["from"] in [
+            "human",
+            "gpt",
+        ], f"Unexpected role {turn['from']} in {data['conversations']}"
+        # TODO: Split the text into fragments.
+        conversation.append(
+            Message(
+                sender="user" if turn["from"] == "human" else "assistant", fragments=[turn["value"]]
+            )
+        )
+
+    # Replace the image tags <image-idx> with IMAGE_TOKEN and count the number of image tags
+    number_image_tags = 0
+    image_tag_ids_list = []
+    for turn in conversation:
+        if turn["role"] == "user":
+            image_tag_ids = [int(x) - 1 for x in re.findall(r"<image-(\d+)>", turn["content"])]
+            image_tag_ids_list.extend(image_tag_ids)
+            turn["content"] = re.sub(r"<image-\d+>", IMAGE_TOKEN, turn["content"])
+            number_image_tags += turn["content"].count(IMAGE_TOKEN)
+
+    # We re-order the images in sample.images according to how they appear in the conversation.
+    if len(image_tag_ids_list) > 0:
+        try:
+            sample.images = [sample.images[idx] for idx in image_tag_ids_list]
+        except Exception as e:
+            print(
+                f"failed to find image tag in images. images {sample.images} and image_tag_ids_list {image_tag_ids_list}"
+            )
+            raise e
+    # If there is only one image, but several image tags, we assume all the tags refer to the
+    # same image and duplicate the image:
+    if len(sample.images) == 1 and number_image_tags > 1:
+        sample.images = sample.images * number_image_tags
+
+    # We currently only support one video per sample.
+    number_of_images = len(sample.images)
+    # Fail if there are more image or video tags than image or videos:
+    assert (
+        number_image_tags <= number_of_images
+    ), f"Found {number_image_tags} image tags for {number_of_images} images. {sample.texts}"
+
+    # If there are less image of video tags than image or videos, prepend the tags to the first
+    # user message:
+    if number_image_tags < number_of_images:
+        for turn in conversation:
+            if turn["role"] == "user":
+                turn["content"] = (
+                    IMAGE_TOKEN * (number_of_images - number_image_tags) + "\n" + turn["content"]
+                )
+                break
+
+    conversation = []
+    for conv in data["conversations"]:
+        fragments = []
+        for fragment in conv:
+            if fragment["from"] == "human":
+                fragments.append(fragment["value"])
+            else:
+                fragments.append(fragment["value"])
+
+    return ConversationSample(**basic_sample_keys(sample), conversation=conversation)

--- a/examples/multimodal/data_loading/image_processing.py
+++ b/examples/multimodal/data_loading/image_processing.py
@@ -1,0 +1,1991 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved. Except portions as noted which are Copyright (c) 2023 OpenGVLab and licensed under the MIT license found in LICENSE.
+import math
+import random
+import warnings
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import albumentations as A
+import einops
+import numpy as np
+import torch
+from data_loading.conversation_sample import ImageMedia, VideoFrameMedia
+from PIL import Image
+from torchvision import transforms as T
+from torchvision.transforms import Compose
+from torchvision.transforms.functional import InterpolationMode
+
+from megatron.core.models.multimodal.utils import patchify_image
+
+IMAGENET_PIXEL_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_PIXEL_STD = [0.229, 0.224, 0.225]
+SIGLIP_PIXEL_MEAN = [0.5, 0.5, 0.5]
+SIGLIP_PIXEL_STD = [0.5, 0.5, 0.5]
+CLIP_PIXEL_MEAN = [0.48145466, 0.4578275, 0.40821073]
+CLIP_PIXEL_STD = [0.26862954, 0.26130258, 0.27577711]
+RADIO_G_PIXEL_MEAN = [0.4850, 0.4560, 0.4060]
+RADIO_G_PIXEL_STD = [0.2230, 0.2240, 0.2250]
+
+
+pixel_statistics = {
+    "clip": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+    "siglip": (SIGLIP_PIXEL_MEAN, SIGLIP_PIXEL_STD),
+    "internvit": (IMAGENET_PIXEL_MEAN, IMAGENET_PIXEL_STD),
+    "radio": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+    "radio-so400m": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+    "radio-g": (RADIO_G_PIXEL_MEAN, RADIO_G_PIXEL_STD),
+    "huggingface": (SIGLIP_PIXEL_MEAN, SIGLIP_PIXEL_STD),
+    "radio_siglip_move": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+    "cradio-v1": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+    "cradio-g": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+}
+
+
+# From https://github.com/OpenGVLab/InternVL/blob/c62fa4f7c850165d7386bdc48ac6bc5a6fab0864/internvl_chat/internvl/train/dataset.py#L685
+# Copyright (c) 2023 OpenGVLab.
+def find_closest_aspect_ratio(
+    aspect_ratio: float,
+    target_ratios: list[tuple[int, int]],
+    width: int,
+    height: int,
+    image_size: int,
+) -> tuple[int, int]:
+    best_ratio_diff = float("inf")
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        elif ratio_diff == best_ratio_diff:
+            if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                best_ratio = ratio
+    return best_ratio
+
+
+def find_closest_area_weighted_aspect_ratio(
+    aspect_ratio: float,
+    target_ratios: list[tuple[int, int]],
+    width: int,
+    height: int,
+    image_size: int,
+):
+    """
+    Find the best number of tiles based on the aspect ratio and the area covered by the tiles.
+    """
+    best_factor = float("-inf")
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        factor_based_on_area_n_ratio = min(
+            (ratio[0] * ratio[1] * image_size * image_size) / area, 0.6
+        ) * min(target_aspect_ratio / aspect_ratio, aspect_ratio / target_aspect_ratio)
+        if factor_based_on_area_n_ratio > best_factor:
+            best_factor = factor_based_on_area_n_ratio
+            best_ratio = ratio
+    return best_ratio
+
+
+# Mike's optimized ToTensor.
+def _fast_to_tensor(pic) -> torch.Tensor:
+    np_img = np.array(pic, copy=False)
+    img = torch.from_numpy(np_img)
+    img = img.permute(2, 0, 1)  # HWC to CHW
+    fp_img = img.to(dtype=torch.float32, memory_format=torch.contiguous_format)
+    fp_img.div_(255)
+    return fp_img
+
+
+@dataclass
+class ImageTilingParams:
+    media: ImageMedia | VideoFrameMedia
+    num_tiles: int
+    num_embeddings: int
+
+
+class ImageTilingStrategy(ABC):
+    """
+    Base class for image tiling strategies.
+    A tiling strategy is a function that takes a list of media and returns a list of image tiling parameters.
+    These can then be used to apply the tiling to the media.
+
+    Subclasses must implement the `compute_params` and `apply_params` methods.
+
+    The `transform` method is a convenience method that computes the transformation parameters and applies the transformation to the media.
+
+    """
+
+    def transform(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: int | None = None,
+    ) -> list[torch.Tensor]:
+        """
+        Transform the media and compute the transformation parameters.
+        """
+        transform_media_list = self.compute_params(media_list, num_tokens_available)
+        return [
+            self.apply_params(transform_media, **kwargs) for transform_media in transform_media_list
+        ]
+
+    @abstractmethod
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: int,
+        max_num_tiles: int | None = None,
+        **kwargs,
+    ) -> list[ImageTilingParams]:
+        """
+        Compute the transformation parameters and the number of tokens to use for the media.
+
+        Args:
+            media_list: List of media to transform
+            num_tokens_available: Number of tokens available for all media
+            max_num_tiles: Maximum number of tiles allowed (optional, defaults to instance's max_num_tiles if not provided)
+
+        Returns:
+            list of transformation parameters with the media
+        """
+        ...
+
+    @abstractmethod
+    def apply_params(self, transform_media: ImageTilingParams, **kwargs) -> list[torch.Tensor]:
+        """
+        Apply the transformation parameters to the media.
+
+        Args:
+            transform_media: The media to apply the transformation to
+
+        Returns:
+            list of transformed media tensors
+        """
+        ...
+
+    @abstractmethod
+    def stack(
+        self, images: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, list[tuple[int, int]], list[int], list[int]]:
+        """
+        Stack the images into a single tensor.
+
+        Args:
+            media_list: List of images to stack
+
+        Returns:
+            tuple of (stacked media, image sizes, vision cu lengths, vision max lengths)
+        """
+        ...
+
+
+class _FixedSizeStrategy(ImageTilingStrategy):
+    """
+    Base class for fixed size image tiling strategies.
+    """
+
+    def __init__(
+        self,
+        vision_model_type: str,
+        target_width: int,
+        target_height: int,
+        embeddings_per_image: int,
+    ):
+        self._vision_model_type = vision_model_type
+        self._target_width = target_width
+        self._target_height = target_height
+        self._embeddings_per_image = embeddings_per_image
+        self._transform = self._build_transform((target_width, target_height), vision_model_type)
+
+    # Based on https://github.com/openai/CLIP/blob/dcba3cb2e2827b402d2701e7e1c7d9fed8a20ef1/clip/clip.py#L79
+    # and https://github.com/OpenGVLab/InternVL/blob/aa521e6eb1df4cf153aa4118fcf13e673c055d46/internvl_chat/internvl/train/dataset.py#L276
+    @staticmethod
+    def _build_transform(target_size: tuple[int, int], vision_model_type: str):
+        """
+        Build a transform for a given vision model type and target size.
+        """
+        if vision_model_type in ("siglip", "internvit") or "radio" in vision_model_type:
+            pixel_mean, pixel_std = pixel_statistics[vision_model_type]
+
+            transform = T.Compose(
+                [
+                    T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+                    T.Resize(
+                        (target_size[1], target_size[0]), interpolation=InterpolationMode.BICUBIC
+                    ),
+                    T.ToTensor(),  # T.Lambda(lambda img: _fast_to_tensor(img)),
+                    T.Normalize(mean=pixel_mean, std=pixel_std),
+                ]
+            )
+        # From the official CLIP repo.
+        elif vision_model_type == "clip":
+            pixel_mean, pixel_std = pixel_statistics[vision_model_type]
+
+            transform = Compose(
+                [
+                    T.Resize(
+                        (target_size[1], target_size[0]), interpolation=InterpolationMode.BICUBIC
+                    ),
+                    T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+                    T.ToTensor(),  # T.Lambda(lambda img: _fast_to_tensor(img)),
+                    T.Normalize(mean=pixel_mean, std=pixel_std),
+                ]
+            )
+        elif vision_model_type.startswith("hf://"):
+            from megatron.core.models.huggingface.module import get_hf_model_type
+
+            model_type = get_hf_model_type(vision_model_type)
+            if "siglip" in model_type:
+                from transformers.models.siglip.image_processing_siglip import SiglipImageProcessor
+
+                processor = SiglipImageProcessor(
+                    size={"height": target_size[1], "width": target_size[0]}
+                )
+
+                def transform(x):
+                    x = x.convert("RGB") if x.mode != "RGB" else x
+                    x = processor(x, return_tensors="pt")
+                    return x["pixel_values"][0]
+
+            else:
+                raise NotImplementedError(
+                    f"image processing not defined for huggingface model {vision_model_type}"
+                )
+        else:
+            raise NotImplementedError(
+                f"image processing not defined for vision model {vision_model_type}"
+            )
+
+        return transform
+
+    def stack(
+        self, images: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, list[tuple[int, int]], list[int] | None, list[int] | None]:
+        return (
+            torch.stack(images) if len(images) > 0 else None,
+            (
+                torch.tensor([(img.shape[1], img.shape[2]) for img in images], dtype=torch.int32)
+                if len(images) > 0
+                else None
+            ),
+            None,
+            None,
+        )
+
+
+class NoTilingStrategy(_FixedSizeStrategy):
+    """
+    A simple image transformation that resizes the image to the target width and height.
+    """
+
+    def __init__(
+        self,
+        vision_model_type: str,
+        target_width: int,
+        target_height: int,
+        embeddings_per_image: int,
+    ):
+        super().__init__(
+            vision_model_type=vision_model_type,
+            target_width=target_width,
+            target_height=target_height,
+            embeddings_per_image=embeddings_per_image,
+        )
+
+    def apply_params(self, transform_media: ImageTilingParams, **kwargs) -> list[torch.Tensor]:
+        return [self._transform(transform_media.media.value)]
+
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: Optional[int] = None,
+        max_num_tiles: int | None = None,
+        **kwargs,
+    ) -> list[ImageTilingParams]:
+        return [
+            ImageTilingParams(media=media, num_tiles=1, num_embeddings=self._embeddings_per_image)
+            for media in media_list
+        ]
+
+    def __str__(self):
+        return f"SimpleImageTransform(vision_model_type={self._vision_model_type}, num_tokens_per_image={self._embeddings_per_image})"
+
+
+@dataclass
+class ImageTilingParamsV1(ImageTilingParams):
+    tiling: tuple[int, int]
+
+
+class ImageTilingStrategyV1(_FixedSizeStrategy):
+    """Tiling image transformation.
+
+    This transformation splits the image into a grid of tiles and applies the transformation to each tile.
+    """
+
+    # Based on https://github.com/openai/CLIP/blob/dcba3cb2e2827b402d2701e7e1c7d9fed8a20ef1/clip/clip.py#L79
+    # and https://github.com/OpenGVLab/InternVL/blob/aa521e6eb1df4cf153aa4118fcf13e673c055d46/internvl_chat/internvl/train/dataset.py#L276
+
+    def __init__(
+        self,
+        vision_model_type: str,
+        tile_size: int,
+        use_thumbnail: bool,
+        min_num_tiles: int,
+        max_num_tiles: int,
+        embeddings_per_tile: int,
+        find_closest_aspect_ratio_fn=find_closest_aspect_ratio,
+    ):
+        super().__init__(
+            vision_model_type=vision_model_type,
+            target_width=tile_size,
+            target_height=tile_size,
+            embeddings_per_image=embeddings_per_tile,
+        )
+
+        # print(f"Transformation params: {vision_model_type=}, {use_tiling=}, {tile_size=}, {use_thumbnail=}, {augment=}, {min_num_tiles=}, {max_num_tiles=}, {find_closest_aspect_ratio_fn=}")
+        self._tile_size = tile_size
+        self._use_thumbnail = use_thumbnail
+        self._min_num_tiles = min_num_tiles
+        self._max_num_tiles = max_num_tiles
+        self._find_closest_aspect_ratio_fn = find_closest_aspect_ratio_fn
+
+        # Calculate all possible aspect ratios for each max_num_tiles.
+        self.target_ratios = {
+            max_num_tiles: sorted(
+                set(
+                    (x, y)
+                    for n in range(self._min_num_tiles, max_num_tiles + 1)
+                    for x in range(1, n + 1)
+                    for y in range(1, n + 1)
+                    if x * y <= max_num_tiles and x * y >= self._min_num_tiles
+                ),
+                key=lambda x: x[0] * x[1],
+            )
+            for max_num_tiles in range(self._min_num_tiles, self._max_num_tiles + 1)
+        }
+
+        self.transform = A.Compose(
+            [
+                A.OneOf(
+                    [
+                        A.GaussNoise(var_limit=(5.0, 30.0)),
+                        A.ISONoise(color_shift=(0.01, 0.05), intensity=(0.1, 0.5)),
+                    ],
+                    p=0.3,
+                ),
+                A.OneOf([A.MedianBlur(blur_limit=5), A.GaussianBlur(blur_limit=5)], p=0.2),
+                A.ColorJitter(brightness=0.2, contrast=0.2, saturation=0.2, hue=0.05, p=0.5),
+                A.HueSaturationValue(
+                    hue_shift_limit=5, sat_shift_limit=15, val_shift_limit=15, p=0.3
+                ),
+                A.ImageCompression(quality_lower=70, quality_upper=100, p=0.3),
+            ]
+        )
+
+    def apply_params(
+        self, transform_media: ImageTilingParams, data_augment: bool = False, **kwargs
+    ) -> list[torch.Tensor]:
+        assert isinstance(transform_media, ImageTilingParamsV1)
+        image = transform_media.media.value
+
+        if data_augment:
+            image = self.transform(image=np.asarray(image))["image"]
+            image = Image.fromarray(image)
+
+        # calculate the target width and height
+        target_width = self._tile_size * transform_media.tiling[0]
+        target_height = self._tile_size * transform_media.tiling[1]
+        blocks = transform_media.tiling[0] * transform_media.tiling[1]
+
+        # resize the image
+        resized_img = image.resize((target_width, target_height))
+        processed_images = []
+        for i in range(blocks):
+            box = (
+                (i % (target_width // self._tile_size)) * self._tile_size,
+                (i // (target_width // self._tile_size)) * self._tile_size,
+                ((i % (target_width // self._tile_size)) + 1) * self._tile_size,
+                ((i // (target_width // self._tile_size)) + 1) * self._tile_size,
+            )
+            # split the image
+            split_img = resized_img.crop(box)
+            processed_images.append(split_img)
+        assert len(processed_images) == blocks
+        if self._use_thumbnail and len(processed_images) != 1:
+            thumbnail_img = image.resize((self._tile_size, self._tile_size))
+            processed_images.append(thumbnail_img)
+
+        return [self._transform(img) for img in processed_images]
+
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: Optional[int] = None,
+        max_num_tiles: int | None = None,
+        data_augment: bool = False,
+        tiling_augment_prob: float = 0.4,
+        **kwargs,
+    ) -> list[ImageTilingParamsV1]:
+        # Use provided max_num_tiles or fall back to instance's max_num_tiles
+        # Clamp to self._max_num_tiles since target_ratios are only pre-computed up to that value
+        effective_max_num_tiles = (
+            max_num_tiles if max_num_tiles is not None else self._max_num_tiles
+        )
+        effective_max_num_tiles = min(effective_max_num_tiles, self._max_num_tiles)
+
+        max_num_tiles_to_use = min(
+            num_tokens_available // self._embeddings_per_image, effective_max_num_tiles
+        )
+
+        # calculate the existing image aspect ratio
+        target_ratios = self.target_ratios[max_num_tiles_to_use]
+
+        params = []
+        for media in media_list:
+            if isinstance(media, ImageMedia):
+                img_size = (media.width, media.height)
+            elif isinstance(media, VideoFrameMedia):
+                img_size = (media.video_width, media.video_height)
+            else:
+                raise ValueError(f"Unsupported media type: {type(media)}")
+
+            aspect_ratio = img_size[0] / img_size[1]
+
+            # find the closest aspect ratio to the target
+            tiling = self._find_closest_aspect_ratio_fn(
+                aspect_ratio, target_ratios, img_size[0], img_size[1], self._tile_size
+            )
+            if (
+                data_augment
+                and isinstance(media, ImageMedia)
+                and random.random() < tiling_augment_prob
+            ):
+                tiling = self.augment_tiling(tiling)
+            num_tiles = tiling[0] * tiling[1]
+            if self._use_thumbnail and num_tiles != 1:
+                num_tiles += 1
+
+            params.append(
+                ImageTilingParamsV1(
+                    media=media,
+                    num_tiles=num_tiles,
+                    num_embeddings=num_tiles * self._embeddings_per_image,
+                    tiling=tiling,
+                )
+            )
+
+        return params
+
+    def augment_tiling(self, tiling: tuple[int, int]) -> tuple[int, int]:
+        def num_tiles(tiling: tuple[int, int]) -> int:
+            return tiling[0] * tiling[1]
+
+        def plus_minus_one(tiling: tuple[int, int], minus_prob: float = 0.65) -> tuple[int, int]:
+            if random.random() < minus_prob:
+                # Minus one
+                if tiling[0] == 1 and tiling[1] == 1:
+                    return tiling
+                elif tiling[0] == 1:
+                    return (tiling[0], tiling[1] - 1)
+                elif tiling[1] == 1:
+                    return (tiling[0] - 1, tiling[1])
+                else:
+                    if random.random() < 0.5:
+                        return (tiling[0] - 1, tiling[1])
+                    else:
+                        return (tiling[0], tiling[1] - 1)
+            else:
+                # Plus one
+                if num_tiles(tiling) < self._max_num_tiles:
+                    tiling0 = (tiling[0] + 1, tiling[1])
+                    tiling1 = (tiling[0], tiling[1] + 1)
+                    if (
+                        num_tiles(tiling0) > self._max_num_tiles
+                        and num_tiles(tiling1) > self._max_num_tiles
+                    ):
+                        return tiling
+                    elif num_tiles(tiling0) > self._max_num_tiles:
+                        return tiling1
+                    elif num_tiles(tiling1) > self._max_num_tiles:
+                        return tiling0
+                    else:
+                        if random.random() < 0.5:
+                            return tiling0
+                        else:
+                            return tiling1
+                return tiling
+
+        new_tiling = plus_minus_one(tiling)
+        return new_tiling
+
+    def __str__(self):
+        return f"TilingImageTransform(vision_model_type={self._vision_model_type}, tile_size={self._tile_size}, use_thumbnail={self._use_thumbnail}, min_num_tiles={self._min_num_tiles}, max_num_tiles={self._max_num_tiles}, embeddings_per_tile={self._embeddings_per_image}, find_closest_aspect_ratio_fn={self._find_closest_aspect_ratio_fn})"
+
+
+class TileDegradationStrategy(ImageTilingStrategy):
+    """Strategy for tiling images and video frames, each with their own tiling strategy, while trying to match the
+    number of tokens left in the sample by reducing the number of tiles if needed.
+    """
+
+    # Based on https://github.com/openai/CLIP/blob/dcba3cb2e2827b402d2701e7e1c7d9fed8a20ef1/clip/clip.py#L79
+    # and https://github.com/OpenGVLab/InternVL/blob/aa521e6eb1df4cf153aa4118fcf13e673c055d46/internvl_chat/internvl/train/dataset.py#L276
+
+    def __init__(
+        self,
+        image_strategy: ImageTilingStrategy,
+        video_frame_strategy: ImageTilingStrategy,
+        embeddings_per_tile: int,
+        max_num_tiles: int,
+        tile_degradation_map: dict[int, int] = {12: 8, 8: 6, 6: 4, 4: 2, 2: 1},
+    ):
+        self._image_strategy = image_strategy
+        self._video_frame_strategy = video_frame_strategy
+        self._embeddings_per_tile = embeddings_per_tile
+        self._max_num_tiles = max_num_tiles
+        self._tile_degradation_map = tile_degradation_map
+
+    def apply_params(self, transform_media: ImageTilingParams, **kwargs) -> list[torch.Tensor]:
+        if isinstance(transform_media.media, ImageMedia):
+            return self._image_strategy.apply_params(transform_media, **kwargs)
+        elif isinstance(transform_media.media, VideoFrameMedia):
+            return self._video_frame_strategy.apply_params(transform_media, **kwargs)
+        else:
+            raise ValueError(f"Unsupported media type: {type(transform_media.media)}")
+
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: int | None = None,
+        max_num_tiles: int | None = None,
+        **kwargs,
+    ) -> list[ImageTilingParams]:
+        # Use provided max_num_tiles or fall back to instance's max_num_tiles
+        effective_max_num_tiles = (
+            max_num_tiles if max_num_tiles is not None else self._max_num_tiles
+        )
+        max_num_tiles_to_use = effective_max_num_tiles
+        degradation_map = self._tile_degradation_map
+
+        while True:
+            params = []
+            img_num_tiles = []
+            for media in media_list:
+                if isinstance(media, ImageMedia):
+                    media_params = self._image_strategy.compute_params(
+                        [media],
+                        max_num_tiles_to_use * self._embeddings_per_tile,
+                        max_num_tiles_to_use,
+                        **kwargs,
+                    )[0]
+                elif isinstance(media, VideoFrameMedia):
+                    max_num_tiles_to_use = 1
+                    media_params = self._video_frame_strategy.compute_params(
+                        [media],
+                        max_num_tiles_to_use * self._embeddings_per_tile,
+                        max_num_tiles_to_use,
+                        **kwargs,
+                    )[0]
+                else:
+                    raise ValueError(f"Unsupported media type: {type(media)}")
+                img_num_tiles.append(media_params.num_tiles)
+                params.append(media_params)
+            if max_num_tiles_to_use == 1 or num_tokens_available is None:
+                break
+            if sum(img_num_tiles) * self._embeddings_per_tile > num_tokens_available:
+                if max_num_tiles_to_use in degradation_map:
+                    max_num_tiles_to_use = degradation_map[max_num_tiles_to_use]
+                else:
+                    # End of degradation
+                    break
+            else:
+                break
+        return params
+
+    def stack(
+        self, images: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, list[tuple[int, int]], list[int] | None, list[int] | None]:
+        return self._image_strategy.stack(images)
+
+    def __str__(self):
+        return f"TileDegradationImageTransform(max_num_tiles={self._max_num_tiles}, image_transform={self._image_strategy}, video_frame_transform={self._video_frame_strategy})"
+
+
+@dataclass
+class DynamicResolutionParams(ImageTilingParams):
+    patch_size: tuple[int, int]
+
+
+class DynamicResolutionImageTilingStrategy(ImageTilingStrategy):
+    """Preprocess an image with dynamic resolution for vision transformers.
+
+    This function resizes an image to optimize the number of patches while respecting
+    constraints on minimum/maximum patches, minimum side length, and compatibility
+    with pixel shuffle operations.
+
+    The algorithm works by:
+    1. Computing the initial patch grid size based on the image dimensions and res_step
+    2. Scaling the patch grid to fit within the max_patches constraint
+    3. Ensuring the result has at least min_patches
+    4. Optionally enforcing a minimum side length constraint
+    5. Rounding patch dimensions to even numbers for pixel-shuffle compatibility
+    6. Resizing the image to the computed target dimensions
+
+    Note:
+        The function preserves aspect ratio as much as possible while satisfying all constraints.
+        When constraints conflict (e.g., min_side vs max_patches), the function prioritizes
+        staying within max_patches while maximizing the image size.
+
+    Example:
+        >>> from PIL import Image
+        >>> img = Image.open("example.jpg")  # 800x600 image
+        >>> strategy = DynamicResolutionImageTilingStrategy(vision_model_type="radio", min_patches=4, max_patches=64, res_step=14, get_num_embeddings=lambda x, y: x * y * 2)
+        >>> params = strategy.compute_params([img])
+        >>> img_tensor = strategy.apply_params(params[0])
+        >>> # Returns image resized to maintain aspect ratio with 4-64 patches of size 14x14
+    """
+
+    def __init__(
+        self,
+        vision_model_type: str,
+        min_num_patches: int,
+        patch_size: int,
+        get_num_embeddings: Callable[[int, int], int],
+        factor_max: float = 1.0,
+        pixel_shuffle: bool = False,
+        min_side: int | None = None,
+        use_thumbnail: bool = False,
+        thumbnail_size: int = 448,
+        thumbnail_area_threshold: float = 0.8,
+        max_num_patches: int = 0,
+        apply_data_augment: bool = False,
+        video_target_img_size: int | None = None,
+        video_target_num_patches: int | None = None,
+        video_maintain_aspect_ratio: bool = False,
+        video_temporal_patch_size: int = 1,
+    ):
+        """
+        Args:
+            vision_model_type: Vision model type.
+            min_num_patches: Minimum number of patches required. Defaults to 1.
+            max_num_patches: Maximum number of patches allowed. Defaults to 0 (no maximum).
+            patch_size: Resolution step size (patch dimension). Defaults to 16.
+            get_num_embeddings: Function to get the number of embeddings from the patch size (width, height).
+            factor_max: Maximum scaling factor to apply. Defaults to 1.0.
+            pixel_shuffle: Whether to ensure compatibility with pixel shuffle operations by rounding to even patch
+                dimensions. Defaults to False.
+            min_side: Minimum side length in pixels. If specified, ensures at least one side meets this constraint.
+                Defaults to None.
+            use_thumbnail: Whether to add a thumbnail image when processing. Defaults to False.
+            thumbnail_size: Size of the thumbnail image (width and height). Defaults to 448.
+            thumbnail_area_threshold: Maximum area percentage (0.0-1.0) of the resized image relative to thumbnail area
+                for which to add a thumbnail. If the resized image area is larger than this threshold of the thumbnail
+                area, no thumbnail will be added. Defaults to 0.8 (80%).
+
+            video_target_img_size: Target image size (pixels) for video frames. Default None, must specify this or video_target_num_patches.
+            video_target_num_patches: Target number of patches for video frames. Default None, must specify this or video_target_img_size.
+            video_maintain_aspect_ratio: If True, match video native aspect ratio while respecting target
+                patch budget. Default False.
+            video_temporal_patch_size: Temporal patch size for video frame compression. Default 1, no temporal compression.
+        """
+        assert "radio" in vision_model_type, "Dynamic resolution is only supported for radio models"
+
+        if apply_data_augment:
+            warnings.warn(
+                "Found apply_data_augment=True. This has no effect and has been deprecated. To toggle"
+                " data augmentation on/off, directly modify the dataset yaml file."
+            )
+
+        # Validate exactly one of video_target_img_size or video_target_num_patches is provided
+        if video_target_img_size is None and video_target_num_patches is None:
+            video_target_img_size = 512  # For backward compatibility
+        elif video_target_img_size is not None and video_target_num_patches is not None:
+            raise ValueError(
+                "Exactly one of video_target_img_size or video_target_num_patches must be provided"
+            )
+
+        self._vision_model_type = vision_model_type
+        self._min_num_patches = min_num_patches
+        self._max_num_patches = max_num_patches if max_num_patches > 0 else float("inf")
+        self._patch_size = patch_size
+        self._get_num_embeddings = get_num_embeddings
+        self._factor_max = factor_max
+        self._pixel_shuffle = pixel_shuffle
+        self._min_side = min_side
+        self._use_thumbnail = use_thumbnail
+        self._thumbnail_size = thumbnail_size
+        self._thumbnail_area_threshold = thumbnail_area_threshold
+
+        # Video frame resolution control
+        self._video_target_img_size = video_target_img_size
+        self._video_target_patches = video_target_num_patches
+        self._video_maintain_aspect_ratio = video_maintain_aspect_ratio
+        self._video_temporal_patch_size = video_temporal_patch_size
+
+        pixel_mean, pixel_std = pixel_statistics[self._vision_model_type]
+        self._transform = T.Compose(
+            [
+                T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+                T.ToTensor(),  # T.Lambda(lambda img: _fast_to_tensor(img)),
+                T.Normalize(mean=pixel_mean, std=pixel_std),
+            ]
+        )
+
+    def apply_params(self, params: DynamicResolutionParams, **kwargs) -> list[torch.Tensor]:
+        # resize the image
+        resized_img = params.media.value.resize(
+            (params.patch_size[0] * self._patch_size, params.patch_size[1] * self._patch_size)
+        )
+        processed_images = [resized_img]
+
+        # Add thumbnail if enabled and image area is below threshold
+        if self._use_thumbnail:
+            # Calculate areas
+            resized_area = resized_img.size[0] * resized_img.size[1]
+            thumbnail_area = self._thumbnail_size * self._thumbnail_size
+            area_ratio = resized_area / thumbnail_area
+
+            # Only add thumbnail if resized image area is less than threshold % of thumbnail area
+            if area_ratio < self._thumbnail_area_threshold:
+                thumbnail_img = params.media.value.resize(
+                    (self._thumbnail_size, self._thumbnail_size)
+                )
+                processed_images.append(thumbnail_img)
+
+        return [self._transform(img) for img in processed_images]
+
+    def process_media(
+        self,
+        media: ImageMedia | VideoFrameMedia,
+        num_tokens_available: int,
+        data_augment: bool = False,
+        tiling_augment_prob: float = 0.4,
+    ) -> DynamicResolutionParams:
+        """Process a single media item and return its parameters.
+
+        Args:
+            media: The media item to process
+            num_tokens_available: Number of tokens available for this media
+            data_augment: Whether to apply data augmentation to the image. Defaults to False.
+        Returns:
+            DynamicResolutionParams for the media
+        """
+        current_num_tokens_available = num_tokens_available
+        if isinstance(media, ImageMedia):
+            orig_width, orig_height = media.width, media.height
+            is_video = False
+        elif isinstance(media, VideoFrameMedia):
+            orig_width, orig_height = media.video_width, media.video_height
+            is_video = True
+        else:
+            raise ValueError(f"Unsupported media type: {type(media)}")
+
+        # NOTE: With python this rounds down if even, e.g. 512/16 = 32 + 0.5 = 32.5 -> 32
+        closest_patch_height = round(orig_height / self._patch_size + 0.5)
+        closest_patch_width = round(orig_width / self._patch_size + 0.5)
+        patches = closest_patch_height * closest_patch_width
+
+        # Calculate the max scaling factor that we could apply to stay within budget
+        # e.g. solve for factor: (patch_height * factor) * (patch_width * factor) == num_tokens_avail
+        #      gives: factor = sqrt((num_tokens_avail / (patch_height * patch_width))
+        #      then take the min of this and factor_max to never scale too high (default: factor_max = 1)
+        # If factor_max == 1, we can only reduce the H/W to stay within budget, never increase it
+        factor = min(math.sqrt(current_num_tokens_available / patches), self._factor_max)
+        target_patch_height = math.floor(factor * closest_patch_height)
+        target_patch_width = math.floor(factor * closest_patch_width)
+
+        # Scale up (possibly > factor_max) if we're less than min_num_patches and this is > num tokens avail
+        if (
+            current_num_tokens_available > self._min_num_patches
+            and target_patch_height * target_patch_width < self._min_num_patches
+        ):
+            up_factor = math.sqrt(
+                self._min_num_patches / (target_patch_height * target_patch_width)
+            )
+            up_target_patch_height = math.ceil(up_factor * target_patch_height)
+            up_target_patch_width = math.ceil(up_factor * target_patch_width)
+
+            # Only apply this if within budget (need to re-check due to rounding)
+            if current_num_tokens_available > up_target_patch_height * up_target_patch_width:
+                target_patch_height = up_target_patch_height
+                target_patch_width = up_target_patch_width
+
+        if (
+            self._min_side is not None
+            and min(target_patch_width, target_patch_height) * self._patch_size < self._min_side
+        ):
+            # Identify short and long sides
+            if target_patch_width <= target_patch_height:
+                short, long = target_patch_width, target_patch_height
+                width_is_short = True
+            else:
+                short, long = target_patch_height, target_patch_width
+                width_is_short = False
+
+            # Scale to make short side meet min_side
+            up_factor = self._min_side / (short * self._patch_size)
+            new_short = math.ceil(up_factor * short)
+            new_long = math.ceil(up_factor * long)
+
+            if new_short * new_long <= current_num_tokens_available:
+                # Scaled size fits in budget
+                short, long = new_short, new_long
+            else:
+                # Check what the long side would have to be to stay within budget w/ this scaled up short side
+                constrained_long = max(current_num_tokens_available // new_short, 1)
+                if constrained_long * self._patch_size < self._min_side:
+                    # Long side would be less than min side w/ increased short side
+                    # So instead, just rescale both to be as large as possible (will be <= min_side)
+                    up_factor = math.sqrt(current_num_tokens_available / (short * long))
+                    short = math.floor(up_factor * short)
+                    long = math.floor(up_factor * long)
+                else:
+                    # Long side can still be >= min_side w/ increased short side
+                    # Use this reduced long side that doesn't maintain aspect ratio, to meet min side req.
+                    short, long = new_short, constrained_long
+
+            # Map back to width/height
+            if width_is_short:
+                target_patch_width, target_patch_height = short, long
+            else:
+                target_patch_width, target_patch_height = long, short
+
+        # Pixel shuffle groups 2x2 patches, so both grid dimensions must be even.
+        required_divisor = 2 if self._pixel_shuffle else 1
+
+        # Augment before handling required divisors
+        if data_augment and random.random() < tiling_augment_prob:
+            target_patch_width, target_patch_height = self.augment_resolution(
+                target_patch_width, target_patch_height, current_num_tokens_available
+            )
+
+        if required_divisor > 1:
+            rem_h = target_patch_height % required_divisor
+            if rem_h != 0:
+                inc_h = required_divisor - rem_h
+                if (
+                    target_patch_height + inc_h
+                ) * target_patch_width <= current_num_tokens_available:
+                    target_patch_height += inc_h
+                else:
+                    target_patch_height = max(required_divisor, target_patch_height - rem_h)
+
+            rem_w = target_patch_width % required_divisor
+            if rem_w != 0:
+                inc_w = required_divisor - rem_w
+                if (
+                    target_patch_height * (target_patch_width + inc_w)
+                    <= current_num_tokens_available
+                ):
+                    target_patch_width += inc_w
+                else:
+                    target_patch_width = max(required_divisor, target_patch_width - rem_w)
+
+        # Video frame resolution handling, overrides code above
+        if is_video:
+            # aug_scale_frames_up > 1: more frames, fewer patches per frame (lower resolution)
+            # aug_scale_frames_up < 1: fewer frames, more patches per frame (higher resolution)
+            aug_scale_frames_up = (
+                media.metadata.get("video_aug_scale_frames_up", 1.0) if media.metadata else 1.0
+            )
+
+            # Compute base target patches from target image size
+            if self._video_target_patches is not None:
+                assert (
+                    self._video_target_img_size is None
+                ), "Expected video_target_num_patches = None"
+                target_patches = int(self._video_target_patches / aug_scale_frames_up)
+            else:
+                assert (
+                    self._video_target_img_size > self._patch_size
+                ), f"Expected video_target_img_size={self._video_target_img_size} to be greater than patch_size={self._patch_size}"
+
+                # NOTE: With python this rounds down if even, e.g. 512/16 = 32 + 0.5 = 32.5 -> 32
+                #       Only doing it like this to follow the convention above
+                base_patches = round(self._video_target_img_size / self._patch_size + 0.5)
+                target_patches = int(base_patches * base_patches / aug_scale_frames_up)
+
+            if self._video_maintain_aspect_ratio:
+                # Resize to matching aspect ratio, while preserving target area
+                video_aspect_wh = media.video_width / media.video_height
+                # Solve for h,w -> h * w = area,  w / h = aspect
+                #         gives -> h * (h * aspect) = area -> h = sqrt(area / aspect)
+                #           and -> w * (w / aspect) = area -> w = sqrt(area * aspect)
+                target_patch_height = round(math.sqrt(target_patches / video_aspect_wh))
+                target_patch_width = round(math.sqrt(target_patches * video_aspect_wh))
+                # Ensure minimum of 1
+                target_patch_height = max(1, target_patch_height)
+                target_patch_width = max(1, target_patch_width)
+            else:
+                # Resize to square (or near-square when aug_scale_frames_up makes it non-square)
+                side = int(math.sqrt(target_patches))
+                if side * side != target_patches and aug_scale_frames_up == 1.0:
+                    raise ValueError(
+                        f"Expected target_patches={target_patches} to be a perfect square if not"
+                        f" using --video-maintain-aspect-ratio, got {side} * {side}"
+                    )
+                target_patch_height = max(1, side)
+                target_patch_width = max(1, side)
+
+            # Apply divisibility constraints for video, only rounding down if we're over target
+            if required_divisor > 1:
+                rem_h = target_patch_height % required_divisor
+                target_patch_height_up = target_patch_height_down = target_patch_height
+                if rem_h != 0:
+                    inc_h = required_divisor - rem_h
+                    target_patch_height_down = target_patch_height - rem_h
+                    target_patch_height_up = target_patch_height + inc_h
+
+                rem_w = target_patch_width % required_divisor
+                target_patch_width_down = target_patch_width_up = target_patch_width
+                if rem_w != 0:
+                    inc_w = required_divisor - rem_w
+                    target_patch_width_down = target_patch_width - rem_w
+                    target_patch_width_up = target_patch_width + inc_w
+
+                if target_patch_height_up * target_patch_width_up <= target_patches:
+                    target_patch_height = target_patch_height_up
+                    target_patch_width = target_patch_width_up
+                else:
+                    target_patch_height = target_patch_height_down
+                    target_patch_width = target_patch_width_down
+
+        # Calculate spatial embeddings for this frame/tile (E)
+        # Note: Temporal compression is handled externally in task_encoder.py
+        # via _group_video_frame_params_into_tubelets, which groups T frames
+        # into tubelets (each tubelet has E embeddings, not T × E)
+        num_embeddings = self._get_num_embeddings(
+            width=target_patch_width * self._patch_size,
+            height=target_patch_height * self._patch_size,
+            is_video=is_video,
+        )
+
+        token_count = target_patch_width * target_patch_height
+
+        # Add thumbnail embeddings if enabled and image area is below threshold
+        num_tiles = 1  # Base dynamic resolution image
+        if self._use_thumbnail:
+            # Calculate areas
+            resized_area = (target_patch_width * self._patch_size) * (
+                target_patch_height * self._patch_size
+            )
+            thumbnail_area = self._thumbnail_size * self._thumbnail_size
+            area_ratio = resized_area / thumbnail_area
+
+            # Only add thumbnail if resized image area is less than threshold % of thumbnail area
+            if area_ratio < self._thumbnail_area_threshold:
+                num_tiles += 1  # Add 1 for thumbnail
+                # Add embeddings for thumbnail (thumbnail_size x thumbnail_size)
+                num_embeddings += self._get_num_embeddings(
+                    width=self._thumbnail_size, height=self._thumbnail_size, is_video=False
+                )
+                token_count += (
+                    self._thumbnail_size
+                    // self._patch_size
+                    * self._thumbnail_size
+                    // self._patch_size
+                )
+
+        return (
+            DynamicResolutionParams(
+                media=media,
+                num_tiles=num_tiles,
+                num_embeddings=num_embeddings,
+                patch_size=(target_patch_width, target_patch_height),
+            ),
+            token_count,
+        )
+
+    def augment_resolution(
+        self, target_patch_width: int, target_patch_height: int, current_num_tokens_available: int
+    ) -> tuple[int, int]:
+
+        min_num_patch_one_side = 32
+
+        if random.random() < 0.5:
+            # Minus one
+            if (
+                target_patch_width <= min_num_patch_one_side
+                and target_patch_height <= min_num_patch_one_side
+            ):
+                return target_patch_width, target_patch_height
+            elif target_patch_width <= min_num_patch_one_side:
+                return target_patch_width, target_patch_height - min_num_patch_one_side
+            elif target_patch_height <= min_num_patch_one_side:
+                return target_patch_width - min_num_patch_one_side, target_patch_height
+            else:
+                if random.random() < 0.5:
+                    return target_patch_width - min_num_patch_one_side, target_patch_height
+                else:
+                    return target_patch_width, target_patch_height - min_num_patch_one_side
+        else:
+            # Plus one
+            if target_patch_width * target_patch_height < current_num_tokens_available:
+                if random.random() < 0.5:
+                    return target_patch_width + min_num_patch_one_side, target_patch_height
+                else:
+                    return target_patch_width, target_patch_height + min_num_patch_one_side
+            return target_patch_width, target_patch_height
+
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: int | None = None,
+        max_num_tiles: int | None = None,
+        data_augment: bool = False,
+        **kwargs,
+    ) -> list[ImageTilingParams]:
+        """Compute parameters for all media with iterative token budgeting.
+
+        Args:
+            media_list: List of media items to process
+            num_tokens_available: Total number of tokens available across all media
+            max_num_tiles: Maximum number of tiles (unused in this implementation)
+            data_augment: Whether to apply data augmentation to the image. Defaults to False.
+        Returns:
+            List of ImageTilingParams for each media item
+        """
+        # Expand token budget by reduction factors (tokens available before reduction)
+        num_tokens_available = num_tokens_available * (4 if self._pixel_shuffle else 1)
+        num_images = sum(1 for m in media_list if isinstance(m, ImageMedia))
+        num_video_frames = sum(1 for m in media_list if isinstance(m, VideoFrameMedia))
+        assert num_images + num_video_frames == len(
+            media_list
+        ), "Expected all media to be either image or video"
+
+        # For temporal compression, video frames get grouped (T frames → 1 output), so we can
+        # process more patches within the same LLM token budget. Scale the video frame portion.
+        if self._video_temporal_patch_size > 1 and num_video_frames > 0:
+            if num_images == 0:
+                # All videos: scale entire budget
+                num_tokens_available *= self._video_temporal_patch_size
+            else:
+                # Mixed: scale only the video portion (uncommon, may never happen)
+                imgs_fraction = num_images / len(media_list)
+                video_fraction = num_video_frames / len(media_list)
+                scale_factor = (imgs_fraction * 1) + (
+                    video_fraction * self._video_temporal_patch_size
+                )
+                num_tokens_available = int(num_tokens_available * scale_factor)
+
+        # Always allow at least min_num_patches per media; if this is > num_tokens_avail, update
+        #   num_tokens_avail to this, which will end up truncating the sample but keeping img sizes
+        #   reasonable enough (>= min_num_patches)
+        num_tokens_available = max(num_tokens_available, self._min_num_patches * len(media_list))
+
+        # Initialize the number of tokens available per media to be between min and max patches.
+        num_tokens_available_per_media = [
+            max(min(num_tokens_available, self._max_num_patches), self._min_num_patches)
+            for _ in range(len(media_list))
+        ]
+
+        # In theory this could be a while True loop, but in case the process_media method slightly
+        # changes, I want to make sure we don't get stuck in an infinite loop.
+        for _ in range(10):
+            # Step 1: Process each media with current token budget
+            params = []
+            token_counts = []
+
+            for media, tokens_for_media in zip(media_list, num_tokens_available_per_media):
+                param, token_count = self.process_media(
+                    media, tokens_for_media, data_augment=data_augment
+                )
+                params.append(param)
+                token_counts.append(token_count)
+
+            # Step 2: Check if total tokens is within budget
+            total_tokens = sum(token_counts)
+
+            if total_tokens <= num_tokens_available:
+                # We're within budget, return the params
+                return params
+
+            # Step 3: We're over budget, need to scale down
+            # Calculate scaling factor to get under budget
+            scaling_factor = num_tokens_available / total_tokens
+
+            # Recalculate token budgets for each media based on scaling
+            # Each media gets a proportional share of the total budget
+            scaled_down_num_tokens_available_per_media = [
+                max(self._min_num_patches, int(token_count * scaling_factor))
+                for token_count in token_counts
+            ]
+            scaled_down = any(
+                [
+                    scaled_down_num_tokens_available_per_media[i]
+                    < num_tokens_available_per_media[i]
+                    for i in range(len(num_tokens_available_per_media))
+                ]
+            )
+            # If there was not scaling down, we're stuck just use min_num_patches per media, else
+            # try with the scaled down num_tokens_available_per_media.
+            if not scaled_down:
+                num_tokens_available_per_media = [self._min_num_patches] * len(media_list)
+            else:
+                num_tokens_available_per_media = scaled_down_num_tokens_available_per_media
+        return params
+
+    def stack(
+        self, images: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, list[tuple[int, int]], list[int] | None, list[int] | None]:
+        imgs_sizes = torch.tensor(
+            [[img.shape[1], img.shape[2]] for img in images], dtype=torch.int32
+        )
+
+        if len(images) > 0:
+            # Patchify: (3,H,W) -> (L,3*patch_dim*patch_dim)
+            imgs = [patchify_image(img, self._patch_size) for img in images]
+
+            current_length = 0
+            max_length = 0
+            vision_cu_lengths = [0]
+            for img in imgs:
+                if max_length < img.shape[0]:
+                    max_length = img.shape[0]
+                current_length += img.shape[0]
+                vision_cu_lengths.append(current_length)
+
+            vision_cu_lengths = torch.tensor(vision_cu_lengths, dtype=torch.int32)
+            vision_max_lengths = torch.tensor(max_length, dtype=torch.int32)
+
+            return (
+                torch.cat(imgs, dim=0).unsqueeze(0),
+                imgs_sizes,
+                vision_cu_lengths,
+                vision_max_lengths,
+            )
+        else:
+            return (
+                torch.tensor([[0]], dtype=torch.float32),
+                torch.tensor([[0, 0]], dtype=torch.int32),
+                None,
+                None,
+            )
+
+    def __str__(self):
+        return f"DynamicResolutionImageTransform(vision_model_type={self._vision_model_type}, min_num_patches={self._min_num_patches}, patch_size={self._patch_size}, pixel_shuffle={self._pixel_shuffle}, use_thumbnail={self._use_thumbnail}, thumbnail_size={self._thumbnail_size}, thumbnail_area_threshold={self._thumbnail_area_threshold})"
+
+
+@dataclass
+class MatchTilingDynamicResolutionParams(ImageTilingParams):
+    tiling: tuple[int, int]
+
+
+class MatchTilingDynamicResolutionStrategy(ImageTilingStrategy):
+    """
+    Strategy that uses tiling logic to determine optimal image dimensions but processes
+    the image as a single dynamic resolution image instead of splitting into tiles.
+
+    This combines the aspect ratio optimization from ImageTilingStrategyV1 with the
+    dynamic resolution processing from DynamicResolutionImageTilingStrategy.
+
+    Also includes tile degradation logic similar to TileDegradationStrategy.
+    """
+
+    def __init__(
+        self,
+        vision_model_type: str,
+        tile_size: int,
+        use_thumbnail: bool,
+        min_num_tiles: int,
+        max_num_tiles: int,
+        embeddings_per_tile: int,
+        patch_size: int,
+        get_num_embeddings: Callable[[int, int], int],
+        find_closest_aspect_ratio_fn=find_closest_aspect_ratio,
+        pixel_shuffle: bool = False,
+        tile_degradation_map: dict[int, int] = None,
+        video_frame_strategy: ImageTilingStrategy = None,
+        enable_tile_degradation: bool = True,
+    ):
+        """
+        Args:
+            vision_model_type: Vision model type (should support dynamic resolution)
+            tile_size: Size of each tile for tiling calculation
+            use_thumbnail: Whether tiling logic should include thumbnail
+            min_num_tiles: Minimum number of tiles for tiling calculation
+            max_num_tiles: Maximum number of tiles for tiling calculation
+            embeddings_per_tile: Embeddings per tile for tiling calculation
+            patch_size: Patch size for dynamic resolution processing
+            get_num_embeddings: Function to get number of embeddings from dimensions
+            find_closest_aspect_ratio_fn: Function to find closest aspect ratio
+            pixel_shuffle: Whether to ensure compatibility with pixel shuffle
+            tile_degradation_map: Map for degrading tiles when tokens are insufficient
+            video_frame_strategy: Strategy for processing video frames
+            enable_tile_degradation: Whether to enable tile degradation (default: True)
+        """
+        assert (
+            "radio" in vision_model_type
+        ), "MatchTilingDynamicResolution is only supported for radio models"
+
+        self._vision_model_type = vision_model_type
+        self._tile_size = tile_size
+        self._use_thumbnail = use_thumbnail
+        self._min_num_tiles = min_num_tiles
+        self._max_num_tiles = max_num_tiles
+        self._embeddings_per_tile = embeddings_per_tile
+        self._patch_size = patch_size
+        self._get_num_embeddings = get_num_embeddings
+        self._find_closest_aspect_ratio_fn = find_closest_aspect_ratio_fn
+        self._pixel_shuffle = pixel_shuffle
+        self._enable_tile_degradation = enable_tile_degradation
+
+        # Tile degradation logic (similar to TileDegradationStrategy)
+        if tile_degradation_map is None:
+            self._tile_degradation_map = {12: 8, 8: 6, 6: 4, 4: 2, 2: 1}
+        else:
+            self._tile_degradation_map = tile_degradation_map
+
+        # Video frame strategy (similar to TileDegradationStrategy)
+        if video_frame_strategy is None:
+            self._video_frame_strategy = NoTilingStrategy(
+                vision_model_type=vision_model_type,
+                target_width=tile_size,
+                target_height=tile_size,
+                embeddings_per_image=embeddings_per_tile,
+            )
+        else:
+            self._video_frame_strategy = video_frame_strategy
+
+        # Calculate all possible aspect ratios for each max_num_tiles (borrowed from ImageTilingStrategyV1)
+        self.target_ratios = {
+            max_num_tiles: sorted(
+                set(
+                    (x, y)
+                    for n in range(self._min_num_tiles, max_num_tiles + 1)
+                    for x in range(1, n + 1)
+                    for y in range(1, n + 1)
+                    if x * y <= max_num_tiles and x * y >= self._min_num_tiles
+                ),
+                key=lambda x: x[0] * x[1],
+            )
+            for max_num_tiles in range(self._min_num_tiles, self._max_num_tiles + 1)
+        }
+
+        # Set up transform for dynamic resolution processing
+        pixel_mean, pixel_std = pixel_statistics[self._vision_model_type]
+        self._transform = T.Compose(
+            [
+                T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+                T.ToTensor(),
+                T.Normalize(mean=pixel_mean, std=pixel_std),
+            ]
+        )
+
+    def apply_params(
+        self, params: MatchTilingDynamicResolutionParams, **kwargs
+    ) -> list[torch.Tensor]:
+        # Handle video frames using the video frame strategy
+        if isinstance(params.media, VideoFrameMedia):
+            return self._video_frame_strategy.apply_params(params, **kwargs)
+
+        # Handle images with dynamic resolution processing
+        image = params.media.value
+        # Calculate the target width and height (same logic as ImageTilingStrategyV1)
+        target_width = self._tile_size * params.tiling[0]
+        target_height = self._tile_size * params.tiling[1]
+
+        # Resize the image to the target dimensions (same as ImageTilingStrategyV1)
+        resized_img = image.resize((target_width, target_height))
+
+        # Process as single dynamic resolution image
+        processed_images = [resized_img]
+
+        # Add thumbnail if use_thumbnail=True and there's more than 1 tile (same as ImageTilingStrategyV1)
+        blocks = params.tiling[0] * params.tiling[1]
+        if self._use_thumbnail and blocks != 1:
+            thumbnail_img = image.resize((self._tile_size, self._tile_size))
+            processed_images.append(thumbnail_img)
+
+        return [self._transform(img) for img in processed_images]
+
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: int | None = None,
+        max_num_tiles: int | None = None,
+        **kwargs,
+    ) -> list[MatchTilingDynamicResolutionParams]:
+        # Implement tile degradation logic similar to TileDegradationStrategy
+        # Use provided max_num_tiles or fall back to instance's max_num_tiles
+        # Clamp to self._max_num_tiles since target_ratios are only pre-computed up to that value
+        effective_max_num_tiles = (
+            max_num_tiles if max_num_tiles is not None else self._max_num_tiles
+        )
+        effective_max_num_tiles = min(effective_max_num_tiles, self._max_num_tiles)
+        max_num_tiles_to_use = effective_max_num_tiles
+        degradation_map = self._tile_degradation_map
+
+        while True:
+            params = []
+            total_embeddings_needed = 0
+
+            for media in media_list:
+                if isinstance(media, ImageMedia):
+                    # Use tiling logic for images
+                    img_size = (media.width, media.height)
+                    aspect_ratio = img_size[0] / img_size[1]
+
+                    # Find the closest aspect ratio to the target
+                    target_ratios = self.target_ratios[max_num_tiles_to_use]
+                    tiling = self._find_closest_aspect_ratio_fn(
+                        aspect_ratio, target_ratios, img_size[0], img_size[1], self._tile_size
+                    )
+
+                    # Calculate target dimensions for dynamic resolution processing
+                    target_width = self._tile_size * tiling[0]
+                    target_height = self._tile_size * tiling[1]
+                    num_embeddings = self._get_num_embeddings(
+                        target_width, target_height, is_video=False
+                    )
+
+                    # Account for thumbnail (same logic as ImageTilingStrategyV1)
+                    num_tiles = 1  # Base dynamic resolution image
+                    blocks = tiling[0] * tiling[1]
+                    if self._use_thumbnail and blocks != 1:
+                        num_tiles += 1  # Add 1 for thumbnail
+                        # Add embeddings for thumbnail (tile_size x tile_size)
+                        num_embeddings += self._get_num_embeddings(
+                            self._tile_size, self._tile_size, is_video=False
+                        )
+
+                    media_params = MatchTilingDynamicResolutionParams(
+                        media=media,
+                        num_tiles=num_tiles,
+                        num_embeddings=num_embeddings,
+                        tiling=tiling,
+                    )
+                elif isinstance(media, VideoFrameMedia):
+                    # Use video frame strategy for video frames (always 1 tile)
+                    video_params = self._video_frame_strategy.compute_params(
+                        [media], 1 * self._embeddings_per_tile
+                    )[0]
+                    media_params = MatchTilingDynamicResolutionParams(
+                        media=media,
+                        num_tiles=video_params.num_tiles,
+                        num_embeddings=video_params.num_embeddings,
+                        tiling=(1, 1),  # Video frames always use 1x1 tiling
+                    )
+                else:
+                    raise ValueError(f"Unsupported media type: {type(media)}")
+
+                params.append(media_params)
+                total_embeddings_needed += media_params.num_embeddings
+
+            # Check if we need to degrade (only if degradation is enabled)
+            if not self._enable_tile_degradation:
+                break
+            if max_num_tiles_to_use == 1 or num_tokens_available is None:
+                break
+            if total_embeddings_needed > num_tokens_available:
+                if max_num_tiles_to_use in degradation_map:
+                    max_num_tiles_to_use = degradation_map[max_num_tiles_to_use]
+                    # Recalculate target ratios for the new max_num_tiles_to_use
+                    if max_num_tiles_to_use not in self.target_ratios:
+                        self.target_ratios[max_num_tiles_to_use] = sorted(
+                            set(
+                                (x, y)
+                                for n in range(self._min_num_tiles, max_num_tiles_to_use + 1)
+                                for x in range(1, n + 1)
+                                for y in range(1, n + 1)
+                                if x * y <= max_num_tiles_to_use and x * y >= self._min_num_tiles
+                            ),
+                            key=lambda x: x[0] * x[1],
+                        )
+                else:
+                    # End of degradation
+                    break
+            else:
+                break
+
+        return params
+
+    def stack(
+        self, images: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, list[tuple[int, int]], list[int], list[int]]:
+        """Stack images using dynamic resolution approach with sequence packing"""
+        imgs_sizes = torch.tensor(
+            [[img.shape[1], img.shape[2]] for img in images], dtype=torch.int32
+        )
+
+        def rearrange_img(x):
+            py = x.shape[-2] // self._patch_size
+            px = x.shape[-1] // self._patch_size
+            x = einops.rearrange(
+                x,
+                "c (py yy) (px xx) -> (py px) (c yy xx)",
+                py=py,
+                yy=self._patch_size,
+                px=px,
+                xx=self._patch_size,
+            )
+            return x
+
+        if len(images) > 0:
+            imgs = [rearrange_img(img) for img in images]
+
+            current_length = 0
+            max_length = 0
+            vision_cu_lengths = [0]
+            for img in imgs:
+                if max_length < img.shape[0]:
+                    max_length = img.shape[0]
+                current_length += img.shape[0]
+                vision_cu_lengths.append(current_length)
+
+            vision_cu_lengths = torch.tensor(vision_cu_lengths, dtype=torch.int32)
+            vision_max_lengths = torch.tensor(max_length, dtype=torch.int32)
+
+            return (
+                torch.cat(imgs, dim=0).unsqueeze(0),
+                imgs_sizes,
+                vision_cu_lengths,
+                vision_max_lengths,
+            )
+        else:
+            return (
+                torch.tensor([[0]], dtype=torch.float32),
+                torch.tensor([[0, 0]], dtype=torch.int32),
+                None,
+                None,
+            )
+
+    def __str__(self):
+        return f"MatchTilingDynamicResolutionStrategy(vision_model_type={self._vision_model_type}, tile_size={self._tile_size}, use_thumbnail={self._use_thumbnail}, min_num_tiles={self._min_num_tiles}, max_num_tiles={self._max_num_tiles}, patch_size={self._patch_size}, pixel_shuffle={self._pixel_shuffle}, enable_tile_degradation={self._enable_tile_degradation}, video_frame_strategy={self._video_frame_strategy})"
+
+
+@dataclass
+class MaskedTilingDynamicResolutionParams(ImageTilingParams):
+    tiling: tuple[int, int]
+
+
+class MaskedTilingDynamicResolutionStrategy(ImageTilingStrategy):
+    """
+    Like MatchTilingDynamicResolutionStrategy, but ensures tiles are isolated in the
+    vision encoder by emitting per-tile packed samples (block-diagonal attention across tiles).
+    """
+
+    def __init__(
+        self,
+        vision_model_type: str,
+        tile_size: int,
+        use_thumbnail: bool,
+        min_num_tiles: int,
+        max_num_tiles: int,
+        embeddings_per_tile: int,
+        patch_size: int,
+        get_num_embeddings: Callable[[int, int], int],
+        find_closest_aspect_ratio_fn=find_closest_aspect_ratio,
+        pixel_shuffle: bool = False,
+        tile_degradation_map: dict[int, int] = None,
+        video_frame_strategy: ImageTilingStrategy = None,
+        enable_tile_degradation: bool = True,
+    ):
+        assert (
+            "radio" in vision_model_type
+        ), "MaskedTilingDynamicResolution is only supported for radio models"
+
+        self._vision_model_type = vision_model_type
+        self._tile_size = tile_size
+        self._use_thumbnail = use_thumbnail
+        self._min_num_tiles = min_num_tiles
+        self._max_num_tiles = max_num_tiles
+        self._embeddings_per_tile = embeddings_per_tile
+        self._patch_size = patch_size
+        self._get_num_embeddings = get_num_embeddings
+        self._find_closest_aspect_ratio_fn = find_closest_aspect_ratio_fn
+        self._pixel_shuffle = pixel_shuffle
+        self._enable_tile_degradation = enable_tile_degradation
+
+        if tile_degradation_map is None:
+            self._tile_degradation_map = {12: 8, 8: 6, 6: 4, 4: 2, 2: 1}
+        else:
+            self._tile_degradation_map = tile_degradation_map
+
+        if video_frame_strategy is None:
+            self._video_frame_strategy = NoTilingStrategy(
+                vision_model_type=vision_model_type,
+                target_width=tile_size,
+                target_height=tile_size,
+                embeddings_per_image=embeddings_per_tile,
+            )
+        else:
+            self._video_frame_strategy = video_frame_strategy
+
+        self.target_ratios = {
+            max_num_tiles: sorted(
+                set(
+                    (x, y)
+                    for n in range(self._min_num_tiles, max_num_tiles + 1)
+                    for x in range(1, n + 1)
+                    for y in range(1, n + 1)
+                    if x * y <= max_num_tiles and x * y >= self._min_num_tiles
+                ),
+                key=lambda x: x[0] * x[1],
+            )
+            for max_num_tiles in range(self._min_num_tiles, self._max_num_tiles + 1)
+        }
+
+        pixel_mean, pixel_std = pixel_statistics[self._vision_model_type]
+        self._transform = T.Compose(
+            [
+                T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+                T.ToTensor(),
+                T.Normalize(mean=pixel_mean, std=pixel_std),
+            ]
+        )
+
+    def apply_params(
+        self, params: MaskedTilingDynamicResolutionParams, **kwargs
+    ) -> list[torch.Tensor]:
+        # Handle video frames using the video frame strategy
+        if isinstance(params.media, VideoFrameMedia):
+            return self._video_frame_strategy.apply_params(params, **kwargs)
+
+        image = params.media.value
+        nx, ny = params.tiling
+        target_width = self._tile_size * nx
+        target_height = self._tile_size * ny
+
+        resized_img = image.resize((target_width, target_height))
+
+        processed_images = []
+        # Emit per-tile images (each becomes an isolated packed sample later)
+        for j in range(ny):
+            for i in range(nx):
+                box = (
+                    i * self._tile_size,
+                    j * self._tile_size,
+                    (i + 1) * self._tile_size,
+                    (j + 1) * self._tile_size,
+                )
+                tile_img = resized_img.crop(box)
+                processed_images.append(tile_img)
+
+        if self._use_thumbnail and (nx * ny) != 1:
+            thumbnail_img = image.resize((self._tile_size, self._tile_size))
+            processed_images.append(thumbnail_img)
+
+        return [self._transform(img) for img in processed_images]
+
+    def compute_params(
+        self,
+        media_list: list[ImageMedia | VideoFrameMedia],
+        num_tokens_available: int | None = None,
+        max_num_tiles: int | None = None,
+        data_augment: bool = False,
+        tiling_augment_prob: float = 0.4,
+        **kwargs,
+    ) -> list[MaskedTilingDynamicResolutionParams]:
+        effective_max_num_tiles = (
+            max_num_tiles if max_num_tiles is not None else self._max_num_tiles
+        )
+        effective_max_num_tiles = min(effective_max_num_tiles, self._max_num_tiles)
+        max_num_tiles_to_use = effective_max_num_tiles
+        degradation_map = self._tile_degradation_map
+
+        while True:
+            params = []
+            total_embeddings_needed = 0
+
+            for media in media_list:
+                if isinstance(media, ImageMedia):
+                    img_size = (media.width, media.height)
+                    aspect_ratio = img_size[0] / img_size[1]
+
+                    target_ratios = self.target_ratios[max_num_tiles_to_use]
+                    tiling = self._find_closest_aspect_ratio_fn(
+                        aspect_ratio, target_ratios, img_size[0], img_size[1], self._tile_size
+                    )
+
+                    # Apply tiling augmentation if enabled
+                    if (
+                        data_augment
+                        and isinstance(media, ImageMedia)
+                        and random.random() < tiling_augment_prob
+                    ):
+                        tiling = self.augment_tiling(tiling)
+
+                    blocks = tiling[0] * tiling[1]
+                    # Each tile is tile_size x tile_size
+                    per_tile_emb = self._get_num_embeddings(
+                        self._tile_size, self._tile_size, is_video=False
+                    )
+                    num_embeddings = blocks * per_tile_emb
+
+                    num_tiles = blocks
+                    if self._use_thumbnail and blocks != 1:
+                        num_tiles += 1
+                        num_embeddings += self._get_num_embeddings(
+                            self._tile_size, self._tile_size, is_video=False
+                        )
+
+                    media_params = MaskedTilingDynamicResolutionParams(
+                        media=media,
+                        num_tiles=num_tiles,
+                        num_embeddings=num_embeddings,
+                        tiling=tiling,
+                    )
+                elif isinstance(media, VideoFrameMedia):
+                    video_params = self._video_frame_strategy.compute_params(
+                        [media], 1 * self._embeddings_per_tile
+                    )[0]
+                    media_params = MaskedTilingDynamicResolutionParams(
+                        media=media,
+                        num_tiles=video_params.num_tiles,
+                        num_embeddings=video_params.num_embeddings,
+                        tiling=(1, 1),
+                    )
+                else:
+                    raise ValueError(f"Unsupported media type: {type(media)}")
+
+                params.append(media_params)
+                total_embeddings_needed += media_params.num_embeddings
+
+            if not self._enable_tile_degradation:
+                break
+            if max_num_tiles_to_use == 1 or num_tokens_available is None:
+                break
+            if total_embeddings_needed > num_tokens_available:
+                if max_num_tiles_to_use in degradation_map:
+                    max_num_tiles_to_use = degradation_map[max_num_tiles_to_use]
+                    if max_num_tiles_to_use not in self.target_ratios:
+                        self.target_ratios[max_num_tiles_to_use] = sorted(
+                            set(
+                                (x, y)
+                                for n in range(self._min_num_tiles, max_num_tiles_to_use + 1)
+                                for x in range(1, n + 1)
+                                for y in range(1, n + 1)
+                                if x * y <= max_num_tiles_to_use and x * y >= self._min_num_tiles
+                            ),
+                            key=lambda x: x[0] * x[1],
+                        )
+                else:
+                    break
+            else:
+                break
+
+        return params
+
+    def augment_tiling(self, tiling: tuple[int, int]) -> tuple[int, int]:
+        def num_tiles(tiling: tuple[int, int]) -> int:
+            return tiling[0] * tiling[1]
+
+        def plus_minus_one(tiling: tuple[int, int], minus_prob: float = 0.65) -> tuple[int, int]:
+            if random.random() < minus_prob:
+                # Minus one
+                if tiling[0] == 1 and tiling[1] == 1:
+                    return tiling
+                elif tiling[0] == 1:
+                    return (tiling[0], tiling[1] - 1)
+                elif tiling[1] == 1:
+                    return (tiling[0] - 1, tiling[1])
+                else:
+                    if random.random() < 0.5:
+                        return (tiling[0] - 1, tiling[1])
+                    else:
+                        return (tiling[0], tiling[1] - 1)
+            else:
+                # Plus one
+                if num_tiles(tiling) < self._max_num_tiles:
+                    tiling0 = (tiling[0] + 1, tiling[1])
+                    tiling1 = (tiling[0], tiling[1] + 1)
+                    if (
+                        num_tiles(tiling0) > self._max_num_tiles
+                        and num_tiles(tiling1) > self._max_num_tiles
+                    ):
+                        return tiling
+                    elif num_tiles(tiling0) > self._max_num_tiles:
+                        return tiling1
+                    elif num_tiles(tiling1) > self._max_num_tiles:
+                        return tiling0
+                    else:
+                        if random.random() < 0.5:
+                            return tiling0
+                        else:
+                            return tiling1
+                return tiling
+
+        new_tiling = plus_minus_one(tiling)
+        return new_tiling
+
+    def stack(
+        self, images: list[torch.Tensor]
+    ) -> tuple[torch.Tensor, list[tuple[int, int]], list[int], list[int]]:
+        # Identical to dynamic resolution packing; each tile is already an independent image sample
+        imgs_sizes = torch.tensor(
+            [[img.shape[1], img.shape[2]] for img in images], dtype=torch.int32
+        )
+
+        def rearrange_img(x):
+            py = x.shape[-2] // self._patch_size
+            px = x.shape[-1] // self._patch_size
+            x = einops.rearrange(
+                x,
+                "c (py yy) (px xx) -> (py px) (c yy xx)",
+                py=py,
+                yy=self._patch_size,
+                px=px,
+                xx=self._patch_size,
+            )
+            return x
+
+        if len(images) > 0:
+            imgs = [rearrange_img(img) for img in images]
+
+            current_length = 0
+            max_length = 0
+            vision_cu_lengths = [0]
+            for img in imgs:
+                if max_length < img.shape[0]:
+                    max_length = img.shape[0]
+                current_length += img.shape[0]
+                vision_cu_lengths.append(current_length)
+
+            vision_cu_lengths = torch.tensor(vision_cu_lengths, dtype=torch.int32)
+            vision_max_lengths = torch.tensor(max_length, dtype=torch.int32)
+
+            return (
+                torch.cat(imgs, dim=0).unsqueeze(0),
+                imgs_sizes,
+                vision_cu_lengths,
+                vision_max_lengths,
+            )
+        else:
+            return (
+                torch.tensor([[0]], dtype=torch.float32),
+                torch.tensor([[0, 0]], dtype=torch.int32),
+                None,
+                None,
+            )
+
+    def __str__(self):
+        return f"MaskedTilingDynamicResolutionStrategy(vision_model_type={self._vision_model_type}, tile_size={self._tile_size}, use_thumbnail={self._use_thumbnail}, min_num_tiles={self._min_num_tiles}, max_num_tiles={self._max_num_tiles}, patch_size={self._patch_size}, pixel_shuffle={self._pixel_shuffle}, enable_tile_degradation={self._enable_tile_degradation}, video_frame_strategy={self._video_frame_strategy})"
+
+
+def create_image_tiling_strategy(args):
+    """
+    Create an image tiling strategy based on the provided arguments.
+
+    This function encapsulates the logic for creating the appropriate image tiling strategy
+    based on the training/evaluation configuration. It can be used by both training (task_encoder)
+    and evaluation code outside of data_loading/.
+
+    Args:
+        args: Arguments object with the following relevant attributes:
+            - img_h, img_w: Image height and width
+            - patch_dim: Patch dimension
+            - vision_model_type: Vision model type (e.g., 'radio', 'clip', 'siglip')
+            - disable_vision_class_token: Whether to disable vision class token
+            - pixel_shuffle: Whether to use pixel shuffle
+            - use_tile_tags: Whether to use tile tags
+            - max_num_tiles: Maximum number of tiles
+            - tokenizer_prompt_format: Tokenizer prompt format
+            - dynamic_resolution: Whether to use dynamic resolution
+            - match_tiling_dynamic_resolution: Whether to match tiling with dynamic resolution
+            - use_area_weighted_aspect_ratio: Whether to use area-weighted aspect ratio
+            - use_thumbnail: Whether to use thumbnail
+            - dynamic_resolution_min_patches: Minimum number of patches for dynamic resolution
+            - dynamic_resolution_min_side: Minimum side length for dynamic resolution (optional)
+            - thumbnail_area_threshold: Thumbnail area threshold (optional)
+            - use_tiling: Whether to use tiling
+
+    Returns:
+        ImageTilingStrategy: The created image tiling strategy
+    """
+    from megatron.core.models.vision.clip_vit_model import get_num_image_embeddings
+
+    assert args.img_h == args.img_w, "img_h and img_w must be the same"
+
+    match_tiling_dynamic_resolution = args.match_tiling_dynamic_resolution
+    masked_tiling_dynamic_resolution = getattr(args, "masked_tiling_dynamic_resolution", False)
+    dynamic_resolution = args.dynamic_resolution
+    use_tiling = args.use_tiling
+    use_area_weighted_aspect_ratio = args.use_area_weighted_aspect_ratio
+
+    if match_tiling_dynamic_resolution:
+        assert (
+            dynamic_resolution
+        ), "must enable --dynamic-resolution if using --match-tiling-dynamic-resolution"
+        assert (
+            not use_tiling
+        ), "cannot use --use-tiling and --match-tiling-dynamic-resolution together"
+    if masked_tiling_dynamic_resolution:
+        assert (
+            dynamic_resolution
+        ), "must enable --dynamic-resolution if using --masked-tiling-dynamic-resolution"
+        assert (
+            not use_tiling
+        ), "cannot use --use-tiling and --masked-tiling-dynamic-resolution together"
+        assert (
+            not match_tiling_dynamic_resolution
+        ), "cannot combine --masked-tiling-dynamic-resolution with --match-tiling-dynamic-resolution"
+
+    video_temporal_patch_size = getattr(args, 'video_temporal_patch_size', 1)
+
+    if dynamic_resolution:
+        # The version of `get_num_image_embeddings()` passed to the tiling strategy is used per-frame
+        #   via `process_media()`. To support temporal compression the `compute_params()` method must
+        #   aggregate this, and the tiling strategy must handle any temporal patch size adjustments
+        #   from there. This is a limitation of calling `process_media()` on each individual video
+        #   frame instead of the whole sequence, and thus cannot be avoided without a larger refactor.
+        # During eval, we call get_num_video_embeddings() directly for video sequences
+        dynamic_get_num_embeddings = lambda width, height, is_video=False: (
+            get_num_image_embeddings(
+                img_h=height,
+                img_w=width,
+                patch_dim=args.patch_dim,
+                vision_model_type=args.vision_model_type,
+                disable_vision_class_token=args.disable_vision_class_token,
+                class_token_len=1,
+                pixel_shuffle=args.pixel_shuffle,
+                use_tile_tags=args.use_tile_tags,
+                max_num_tiles=args.max_num_tiles,
+                tokenizer_type=args.tokenizer_prompt_format,
+                allow_non_spatial_embeddings=False if is_video else True,
+            )
+        )
+
+        if masked_tiling_dynamic_resolution:
+            if video_temporal_patch_size != 1:
+                raise NotImplementedError(
+                    f"When using tiling, temporal compression is not supported."
+                    f" Found video_temporal_patch_size={video_temporal_patch_size}."
+                )
+
+            num_image_embeddings_per_tile = get_num_image_embeddings(
+                img_h=args.img_h,
+                img_w=args.img_w,
+                patch_dim=args.patch_dim,
+                vision_model_type=args.vision_model_type,
+                disable_vision_class_token=args.disable_vision_class_token,
+                class_token_len=1,
+                pixel_shuffle=args.pixel_shuffle,
+                use_tile_tags=args.use_tile_tags,
+                max_num_tiles=args.max_num_tiles,
+                tokenizer_type=args.tokenizer_prompt_format,
+            )
+            image_tiling_strategy = MaskedTilingDynamicResolutionStrategy(
+                vision_model_type=args.vision_model_type,
+                tile_size=args.img_h,
+                use_thumbnail=args.use_thumbnail,
+                min_num_tiles=1,
+                max_num_tiles=args.max_num_tiles,
+                embeddings_per_tile=num_image_embeddings_per_tile,
+                patch_size=args.patch_dim,
+                get_num_embeddings=dynamic_get_num_embeddings,
+                find_closest_aspect_ratio_fn=(
+                    find_closest_area_weighted_aspect_ratio
+                    if use_area_weighted_aspect_ratio
+                    else find_closest_aspect_ratio
+                ),
+                pixel_shuffle=args.pixel_shuffle,
+            )
+        elif match_tiling_dynamic_resolution:
+            if video_temporal_patch_size != 1:
+                raise NotImplementedError(
+                    f"When using tiling, temporal compression is not supported."
+                    f" Found video_temporal_patch_size={video_temporal_patch_size}."
+                )
+
+            num_image_embeddings_per_tile = get_num_image_embeddings(
+                img_h=args.img_h,
+                img_w=args.img_w,
+                patch_dim=args.patch_dim,
+                vision_model_type=args.vision_model_type,
+                disable_vision_class_token=args.disable_vision_class_token,
+                class_token_len=1,
+                pixel_shuffle=args.pixel_shuffle,
+                use_tile_tags=args.use_tile_tags,
+                max_num_tiles=args.max_num_tiles,
+                tokenizer_type=args.tokenizer_prompt_format,
+            )
+            image_tiling_strategy = MatchTilingDynamicResolutionStrategy(
+                vision_model_type=args.vision_model_type,
+                tile_size=args.img_h,
+                use_thumbnail=args.use_thumbnail,
+                min_num_tiles=1,
+                max_num_tiles=args.max_num_tiles,
+                embeddings_per_tile=num_image_embeddings_per_tile,
+                patch_size=args.patch_dim,
+                get_num_embeddings=dynamic_get_num_embeddings,
+                find_closest_aspect_ratio_fn=(
+                    find_closest_area_weighted_aspect_ratio
+                    if use_area_weighted_aspect_ratio
+                    else find_closest_aspect_ratio
+                ),
+                pixel_shuffle=args.pixel_shuffle,
+            )
+        else:
+            image_tiling_strategy = DynamicResolutionImageTilingStrategy(
+                vision_model_type=args.vision_model_type,
+                min_num_patches=args.dynamic_resolution_min_patches,
+                patch_size=args.patch_dim,
+                get_num_embeddings=dynamic_get_num_embeddings,
+                pixel_shuffle=args.pixel_shuffle,
+                min_side=args.dynamic_resolution_min_side,
+                use_thumbnail=args.use_thumbnail,
+                thumbnail_size=args.img_h,
+                thumbnail_area_threshold=args.thumbnail_area_threshold,
+                max_num_patches=args.dynamic_resolution_max_patches,
+                apply_data_augment=args.apply_data_augment,
+                video_target_img_size=getattr(args, 'video_target_img_size', 512),
+                video_target_num_patches=getattr(args, 'video_target_num_patches', None),
+                video_maintain_aspect_ratio=getattr(args, 'video_maintain_aspect_ratio', False),
+                video_temporal_patch_size=video_temporal_patch_size,
+            )
+    else:
+        if video_temporal_patch_size != 1:
+            raise NotImplementedError(
+                f"When using tiling, temporal compression is not supported."
+                f" Found video_temporal_patch_size={video_temporal_patch_size}."
+            )
+
+        num_image_embeddings_per_tile = get_num_image_embeddings(
+            img_h=args.img_h,
+            img_w=args.img_w,
+            patch_dim=args.patch_dim,
+            vision_model_type=args.vision_model_type,
+            disable_vision_class_token=args.disable_vision_class_token,
+            class_token_len=1,
+            pixel_shuffle=args.pixel_shuffle,
+            use_tile_tags=args.use_tile_tags,
+            max_num_tiles=args.max_num_tiles,
+            tokenizer_type=args.tokenizer_prompt_format,
+        )
+        if use_tiling:
+            image_strategy = ImageTilingStrategyV1(
+                vision_model_type=args.vision_model_type,
+                tile_size=args.img_h,
+                use_thumbnail=args.use_thumbnail,
+                min_num_tiles=1,
+                max_num_tiles=args.max_num_tiles,
+                embeddings_per_tile=num_image_embeddings_per_tile,
+                find_closest_aspect_ratio_fn=(
+                    find_closest_area_weighted_aspect_ratio
+                    if use_area_weighted_aspect_ratio
+                    else find_closest_aspect_ratio
+                ),
+            )
+        else:
+            image_strategy = NoTilingStrategy(
+                vision_model_type=args.vision_model_type,
+                embeddings_per_image=num_image_embeddings_per_tile,
+                target_width=args.img_w,
+                target_height=args.img_h,
+            )
+        image_tiling_strategy = TileDegradationStrategy(
+            image_strategy=image_strategy,
+            video_frame_strategy=NoTilingStrategy(
+                vision_model_type=args.vision_model_type,
+                embeddings_per_image=num_image_embeddings_per_tile,
+                target_width=args.img_w,
+                target_height=args.img_h,
+            ),
+            embeddings_per_tile=num_image_embeddings_per_tile,
+            max_num_tiles=args.max_num_tiles,
+        )
+
+    return image_tiling_strategy

--- a/examples/multimodal/data_loading/knapsacks.py
+++ b/examples/multimodal/data_loading/knapsacks.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import bisect
+from typing import List, TypeVar
+
+T = TypeVar("T")
+
+
+def search_for_fit(numbers: List[int], capacity: int) -> int:
+    """Finds the index of largest number that fits into the knapsack with the given capacity."""
+    import bisect
+
+    index = bisect.bisect(numbers, capacity)
+    return -1 if index == 0 else (index - 1)
+
+
+def greedy_knapsack(item_sizes: List[int], samples: List[T], max_capacity: int) -> List[List[T]]:
+    """Greedy algorithm with binary search for the knapsack problem.
+
+    Pack as many samples as possible given a maximum capacity and capacities of individual samples.
+    Used if sequence packing is enabled.
+    """
+    assert len(item_sizes) == len(samples), "sample lengths and samples must have the same length."
+
+    knapsacks = []
+
+    if len(item_sizes) == 0:
+        return knapsacks
+
+    # Sort sample lengths and samples together.
+    sorted_item_sizes, sorted_samples = zip(*sorted(zip(item_sizes, samples), key=lambda x: x[0]))
+    sorted_item_sizes = list(sorted_item_sizes)
+    sorted_samples = list(sorted_samples)
+
+    # Check if all samples fit in the knapsack capacity.
+    if sorted_item_sizes[-1] > max_capacity:
+        raise ValueError(
+            f"knapsack: A sample is larger {sorted_item_sizes[-1]} than the max_sequence_length {max_capacity}."
+        )
+
+    while sorted_item_sizes:
+        current_knapsack = []
+        remaining_capacity = max_capacity
+
+        while True:
+            idx = search_for_fit(sorted_item_sizes, remaining_capacity)
+            if idx == -1:
+                break  # Can't fit more samples.
+
+            remaining_capacity -= sorted_item_sizes[idx]
+
+            sorted_item_sizes.pop(idx)
+            sample = sorted_samples.pop(idx)
+            current_knapsack.append(sample)
+
+        knapsacks.append(current_knapsack)
+
+    return knapsacks
+
+
+def balanced_greedy_knapsack(
+    item_sizes: List[int], samples: List[T], max_capacity: int, delta: int = 20
+) -> List[List[T]]:
+    """Balanced greedy knapsack algorithm for distributing samples across knapsacks."""
+    item_size_samples = list(zip(item_sizes, samples))
+    item_size_samples.sort(key=lambda x: x[0], reverse=True)
+    item_sizes = [item_size for item_size, _ in item_size_samples]
+    samples = [sample for _, sample in item_size_samples]
+    total_length = sum(item_sizes)
+    min_knapsacks = int((total_length + max_capacity - 1) // max_capacity + delta)
+    knapsacks = [[] for _ in range(min_knapsacks)]
+    knapsack_lengths = [0] * min_knapsacks
+    ks_index = 0
+    sample_index = 0
+    while sample_index < len(item_sizes):
+        length = item_sizes[sample_index]
+        if length > max_capacity:
+            print(f"Warning: sample {sample_index} has length {length} > max_capacity. Skipping.")
+            sample_index += 1
+            continue
+        if knapsack_lengths[ks_index] + length <= max_capacity:
+            knapsacks[ks_index].append(samples[sample_index])
+            knapsack_lengths[ks_index] += length
+            sample_index += 1
+        else:
+            knapsacks.append([])
+            knapsack_lengths.append(0)
+        ks_index = knapsack_lengths.index(min(knapsack_lengths))
+    return knapsacks
+
+
+def bucketing_greedy_knapsack(
+    item_sizes: list[int], samples: list, max_capacity: int
+) -> list[list]:
+    """
+    Bucketing greedy knapsack algorithm for distributing samples across knapsacks.
+    Each packed sample will be composed of samples with similar lengths.
+    Bucketing is implicit - by sorting and packing greedily, similar-sized items
+    naturally end up in the same batches.
+
+    Note(pzelasko): This type of bucketing is inefficient hardware-wise because the 'max_capacity' heuristic
+    results in batches that do not utilize the GPU memory equally across different sequence length buckets.
+    This implementation can be improved through OOMptimizer, i.e. pre-computing a list of bucket bins (ideally with shapes aligned to hardware)
+    and finding the maximum batch size that can still fit in the GPU memory during the full training step, for each bin.
+
+    Args:
+        item_sizes: List of sizes for each sample
+        samples: List of samples to pack
+        max_capacity: Maximum capacity (sum of sizes) for each batch
+
+    Returns:
+        List of batches, where each batch contains samples with similar sizes
+    """
+    assert len(item_sizes) == len(samples), "item_sizes and samples must have the same length."
+
+    if len(item_sizes) == 0:
+        return []
+
+    # Check if any sample exceeds max_capacity
+    if max(item_sizes) > max_capacity:
+        raise ValueError(
+            f"bucketing_greedy_knapsack: A sample has size {max(item_sizes)} "
+            f"which exceeds max_capacity {max_capacity}."
+        )
+
+    # Sort by size (ascending)
+    item_size_samples = list(zip(item_sizes, samples))
+    item_size_samples.sort(key=lambda x: x[0])
+
+    # Build batches by iterating through sorted items
+    batches = []
+    current_batch = []
+    current_tot_size = 0
+
+    for size, sample in item_size_samples:
+        # If adding this item would exceed capacity, start a new batch
+        if current_tot_size + size > max_capacity:
+            if current_batch:
+                batches.append(current_batch)
+            current_batch = [sample]
+            current_tot_size = size
+        else:
+            # Add item to current batch
+            current_batch.append(sample)
+            current_tot_size += size
+
+    # Add the last batch if it has items
+    if current_batch:
+        batches.append(current_batch)
+
+    return batches
+
+
+def _sample_prompt_hash(sample: T, sample_idx: int) -> str:
+    prompt_hash = getattr(sample, "prompt_hash", None)
+    if prompt_hash is not None:
+        return str(prompt_hash)
+
+    sample_key = getattr(sample, "__key__", None)
+    if sample_key is not None:
+        return f"key:{sample_key}"
+
+    return f"idx:{sample_idx}"
+
+
+def streaming_prompt_dedup_first_fit_knapsack(
+    item_sizes: List[int], samples: List[T], max_capacity: int, tolerance: int = 1000
+) -> List[List[T]]:
+    """Streaming first-fit packing modeled after Nano 3.5 text SFT offline packing.
+
+    The algorithm preserves the incoming sample stream order more than the sorted
+    knapsack variants. It keeps one current pack and a sorted list of unfinished
+    packs, first trying to place a sample into the tightest unfinished pack that
+    has enough remaining capacity. A sample is not placed into a pack that already
+    contains the same prompt hash.
+    """
+    assert len(item_sizes) == len(samples), "sample lengths and samples must have the same length."
+
+    full_packs: list[list[T]] = []
+    unfinished_packs: list[dict] = []
+    current_pack: list[T] = []
+    current_prompt_hashes: set[str] = set()
+    current_pack_tokens = 0
+
+    def insert_unfinished_pack(pack: list[T], pack_tokens: int, prompt_hashes: set[str]) -> None:
+        if not pack:
+            return
+        remaining = max_capacity - pack_tokens
+        ranks = [unfinished_pack["num_tokens_to_full"] for unfinished_pack in unfinished_packs]
+        insert_idx = bisect.bisect(ranks, remaining)
+        unfinished_packs.insert(
+            insert_idx,
+            {
+                "current_pack": pack,
+                "current_pack_tokens": pack_tokens,
+                "num_tokens_to_full": remaining,
+                "current_prompt_hashes": prompt_hashes,
+            },
+        )
+
+    for sample_idx, (current_sample_tokens, sample) in enumerate(zip(item_sizes, samples)):
+        if current_sample_tokens > max_capacity:
+            raise ValueError(
+                "streaming_prompt_dedup_first_fit_knapsack: A sample has size "
+                f"{current_sample_tokens} which exceeds max_capacity {max_capacity}."
+            )
+
+        prompt_hash = _sample_prompt_hash(sample, sample_idx)
+
+        filled_unfinished_pack = None
+        for unfinished_idx, unfinished_pack in enumerate(unfinished_packs):
+            if (
+                unfinished_pack["num_tokens_to_full"] >= current_sample_tokens
+                and prompt_hash not in unfinished_pack["current_prompt_hashes"]
+            ):
+                unfinished_pack["current_pack"].append(sample)
+                unfinished_pack["current_pack_tokens"] += current_sample_tokens
+                unfinished_pack["num_tokens_to_full"] -= current_sample_tokens
+                unfinished_pack["current_prompt_hashes"].add(prompt_hash)
+                filled_unfinished_pack = unfinished_packs.pop(unfinished_idx)
+                break
+
+        if filled_unfinished_pack is not None:
+            if filled_unfinished_pack["num_tokens_to_full"] < tolerance:
+                full_packs.append(filled_unfinished_pack["current_pack"])
+            else:
+                insert_unfinished_pack(
+                    filled_unfinished_pack["current_pack"],
+                    filled_unfinished_pack["current_pack_tokens"],
+                    filled_unfinished_pack["current_prompt_hashes"],
+                )
+            continue
+
+        if current_pack and current_pack_tokens + current_sample_tokens > max_capacity:
+            num_tokens_to_full = max_capacity - current_pack_tokens
+            if num_tokens_to_full < tolerance:
+                full_packs.append(current_pack)
+            else:
+                insert_unfinished_pack(current_pack, current_pack_tokens, current_prompt_hashes)
+
+            current_pack = []
+            current_prompt_hashes = set()
+            current_pack_tokens = 0
+
+        if prompt_hash not in current_prompt_hashes:
+            current_prompt_hashes.add(prompt_hash)
+            current_pack.append(sample)
+            current_pack_tokens += current_sample_tokens
+        else:
+            insert_unfinished_pack(current_pack, current_pack_tokens, current_prompt_hashes)
+            current_pack = [sample]
+            current_prompt_hashes = {prompt_hash}
+            current_pack_tokens = current_sample_tokens
+
+    if current_pack:
+        full_packs.append(current_pack)
+
+    full_packs.extend(unfinished_pack["current_pack"] for unfinished_pack in unfinished_packs)
+
+    return full_packs

--- a/examples/multimodal/data_loading/misc.py
+++ b/examples/multimodal/data_loading/misc.py
@@ -1,0 +1,16 @@
+import re
+import tarfile
+
+re_clean_path = re.compile(r"(?:^\./|/\.(?=/))")
+
+
+def retrieve_media_source(media_path, media_sources, aux_data_prefixes):
+    """retrieve the appropriate media url so that media file can be
+    access with os.path.join(media_url, media_path)
+    """
+    path = re_clean_path.sub("", media_path)
+    for prefix, aux_key in aux_data_prefixes.items():
+        if path.startswith(prefix):
+            if aux_key in media_sources:
+                return media_sources[aux_key]
+    return None

--- a/examples/multimodal/data_loading/task_encoder.py
+++ b/examples/multimodal/data_loading/task_encoder.py
@@ -1,0 +1,1893 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+import ast
+import dataclasses
+import hashlib
+import importlib
+import json
+import os
+import random
+import re
+import threading
+from collections import defaultdict
+from functools import partial
+from typing import List, Literal, Tuple, TypedDict, Union
+
+import numpy as np
+import torch
+from PIL import Image
+from torchvision.transforms import ToPILImage
+
+from megatron.core.models.multimodal.llava_model import IGNORE_INDEX
+from megatron.core.models.vision.clip_vit_model import get_num_image_embeddings
+from megatron.energon import (
+    Batch,
+    Cooker,
+    DefaultTaskEncoder,
+    Lazy,
+    MapDataset,
+    Sample,
+    SampleDecoder,
+)
+from megatron.energon import __version__ as energon_version
+from megatron.energon import stateless
+from megatron.energon.av import AVDecoder
+from megatron.energon.edataclass import edataclass
+from megatron.training import get_args, get_tokenizer
+
+from .conversation_sample import ConversationSample, ImageMedia, Media, VideoFrameMedia, VideoMedia
+from .cookers.conversation import (
+    EXPLICIT_ASSISTANT_LOSS_FIELD,
+    EXPLICIT_ASSISTANT_LOSS_MODE,
+    _validate_loss_mask_subflavors,
+    cook_conversation,
+    cook_general_conversations_jsonl,
+    cook_general_conversations_jsonl_explicit_loss_v1,
+    cook_general_conversations_webdataset,
+    cook_openai_messages_jsonl,
+    cook_openai_messages_offline_packed_jsonl,
+)
+from .cookers.eagle import cook_eagle
+from .image_processing import ImageTilingParams, create_image_tiling_strategy
+from .knapsacks import (
+    balanced_greedy_knapsack,
+    bucketing_greedy_knapsack,
+    greedy_knapsack,
+    streaming_prompt_dedup_first_fit_knapsack,
+)
+
+IDENTITY_FILTER_DATASETS = ("apps, taco", "new sft problems", "NemotronX RL")
+_ENERGON_AV_OPEN_LOCK = threading.Lock()
+
+
+def _parse_packing_algorithm_parameters(raw_parameters: object) -> dict[str, str]:
+    """Parse packing algorithm parameters from a dict-like or key=value string."""
+    if raw_parameters is None:
+        return {}
+    if isinstance(raw_parameters, dict):
+        parameters = raw_parameters
+    elif isinstance(raw_parameters, str):
+        raw_parameters = raw_parameters.strip()
+        if not raw_parameters:
+            return {}
+        if raw_parameters.startswith("{"):
+            try:
+                parameters = json.loads(raw_parameters)
+            except json.JSONDecodeError:
+                try:
+                    parameters = ast.literal_eval(raw_parameters)
+                except (SyntaxError, ValueError) as exc:
+                    raise ValueError(
+                        "packing_algorithm_parameters must be a JSON/Python dict or "
+                        "a comma-separated key=value string"
+                    ) from exc
+            if not isinstance(parameters, dict):
+                raise ValueError("packing_algorithm_parameters dict input must parse to a dict")
+        else:
+            parameters = {}
+            for item in raw_parameters.replace(",", " ").split():
+                if "=" not in item:
+                    raise ValueError(
+                        "packing_algorithm_parameters entries must use key=value syntax"
+                    )
+                key, value = item.split("=", 1)
+                parameters[key] = value
+    else:
+        raise TypeError("packing_algorithm_parameters must be a string or dict")
+
+    normalized_parameters = {}
+    for key, value in parameters.items():
+        normalized_key = str(key).strip()
+        if not normalized_key:
+            raise ValueError("packing_algorithm_parameters contains an empty key")
+        normalized_parameters[normalized_key] = str(value).strip()
+    return normalized_parameters
+
+
+def _pop_int_packing_algorithm_parameter(parameters: dict[str, str], key: str, default: int) -> int:
+    raw_value = parameters.pop(key, None)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"packing algorithm parameter {key} must be an integer") from exc
+    if value < 0:
+        raise ValueError(f"packing algorithm parameter {key} must be non-negative")
+    return value
+
+
+def _clean_think(match: re.Match, *, newline_before_close: bool) -> str:
+    """Strip whitespace inside <think> tags and format a non-empty trace."""
+    clean_content = match.group(1).strip()
+    if not clean_content:
+        return "<think></think>"
+
+    close_prefix = "\n" if newline_before_close else ""
+    return f"<think>\n{clean_content}{close_prefix}</think>"
+
+
+def _normalize_thinking_trace(content: str, *, thinking_trace_format: str) -> str:
+    """Normalize a tagged thinking trace for the Nemotron 6 serialization contract."""
+    ultra_format = thinking_trace_format == "ultra"
+    content = re.sub(
+        r"<think>(.*?)</think>",
+        partial(_clean_think, newline_before_close=not ultra_format),
+        content,
+        flags=re.DOTALL,
+    )
+
+    if ultra_format:
+        # Ultra serializes the answer directly after the closing thinking tag.
+        replacement = "</think>"
+    else:
+        replacement = "</think>\n"
+    return re.sub(r"</think>\s*", replacement, content)
+
+
+def _has_filtered_identity_keyword(sample: ConversationSample, keywords: list[str]) -> bool:
+    """Match configured identity keywords for datasets that need identity filtering."""
+    normalized_keywords = tuple(keyword.lower() for keyword in keywords if keyword)
+    if not normalized_keywords:
+        return False
+    if sample.__subflavors__.get("dataset") not in IDENTITY_FILTER_DATASETS:
+        return False
+
+    for message in sample.conversation:
+        if message.sender != "assistant":
+            continue
+        for fragment in message.fragments:
+            if isinstance(fragment, str):
+                content_lower = fragment.lower()
+                if any(keyword in content_lower for keyword in normalized_keywords):
+                    return True
+    return False
+
+
+try:
+    from megatron.core.models.multimodal.context_parallel import get_padding
+except ImportError:
+    get_padding = None
+
+
+class NoTrainableTokensError(ValueError):
+    """Raised when an SFT sample has no labels that should contribute to loss."""
+
+
+@edataclass
+class ConversationTaskSample(Sample):
+    # (c, h, w)
+    imgs: List[torch.Tensor]
+    num_tiles: torch.Tensor
+    tokens: torch.Tensor
+    total_len: int  # Total token count in the sample, including text and image tokens
+    total_len_padded: int  # Total token count in the sample, including text and image tokens, padded to the context parallel size
+    labels: torch.Tensor = None
+
+
+@edataclass
+class PreEncodedTaskSample(Sample):
+    tokens: torch.Tensor
+    labels: torch.Tensor
+    images: list[ImageTilingParams]
+    total_len: int
+    total_len_padded: int
+    num_frames: list[int]
+    prompt_hash: str
+
+
+@edataclass
+class PreEncodedOfflinePackedTextSample(Sample):
+    tokens: torch.Tensor
+    labels: torch.Tensor
+    max_length: int
+    cu_lengths: torch.Tensor
+    cu_lengths_padded: torch.Tensor
+    samples_seen: torch.Tensor
+    sample_lengths: torch.Tensor
+
+
+@edataclass
+class PackedTaskSample(Sample):
+    """Dataclass to store a single packed sample (not a batch).
+
+    P = Number of sub-samples in the packed sample
+    seq_len = Total sequence length
+    num_imgs = Number of images across all samples in the packed sample
+    """
+
+    # Sample name
+    __key__: list[str]
+    # Input tokens packed into a single tensor (seq_len,)
+    tokens: torch.Tensor
+    # Target tokens packed into a single tensor (seq_len,)
+    labels: torch.Tensor
+    # Maximum length across sub-samples.
+    max_length: int
+    # Cumulative length of each sub-sample in this packed sample incl. text and image tokens (P,)
+    cu_lengths: list[int]
+    # Cumulative length of each sub-sample in this packed sample incl. text and image tokens (P,)
+    cu_lengths_padded: list[int]
+
+    # Input images
+    imgs: list[torch.Tensor]
+    # Number of tiles for each image of each sample (num_imgs)
+    num_tiles: list[int]
+
+    # Number of frames used per VideoMedia / ImageMedia (1 frame for ImageMedia)
+    num_frames: list[int]
+
+    # Number of samples in the packed sample
+    samples_seen: int
+    # Real lengths of the original samples before packing.
+    sample_lengths: torch.Tensor
+
+# Typing for the resulting batch data after encode_batch()
+@edataclass
+class BatchedPackedTaskSample(Batch):
+    """Dataclass to store a batch of packed samples.
+
+    N = Batch size
+    P = Number of samples in the packed sample
+    seq_len = Maximum sequence length
+    num_imgs = Number of images across all samples in the packed sample
+    """
+
+    # Input tokens packed and padded (N, seq_len)
+    tokens: torch.Tensor
+    # Target tokens packed and padded (N, seq_len)
+    labels: torch.Tensor
+    # Maximum length across sub-samples (N,)
+    max_lengths: list[int]
+    # Cumulative length of each sub-sample in each packed sample of the batch (N, P)
+    cu_lengths: list[list[int]]
+    # Cumulative length of each sub-sample in each packed sample of the batch (N, P)
+    cu_lengths_padded: list[list[int]]
+
+    # All image tiles stacked into a single tensor (num_tiles, C, H, W)
+    imgs: torch.Tensor
+    # Number of tiles per image (N, num_imgs)
+    num_tiles: list[list[int]]
+    # Size of each image tile
+    imgs_sizes: list[tuple[int, int]]
+    # Maximum length across sub-samples. (N,)
+    vision_max_lengths: list[int]
+    # Cumulative length of each sub-sample in this packed sample incl. text and image tokens (N, num_imgs)
+    vision_cu_lengths: list[list[int]]
+
+    # Number of samples in the packed batch
+    samples_seen: int
+    # Original sample lengths, padded with zeros along the batch dimension.
+    sample_lengths: torch.Tensor
+
+    # Whether the batch has a padded image
+    has_pad_img: bool
+
+    # "Batched" version of number of frames used per VideoMedia / ImageMedia (1 frame for ImageMedia)
+    num_frames: list[list[int]]
+
+class ConversationTurn(TypedDict):
+    """One turn of a conversation passed to the multimodal tokenizer."""
+
+    role: Literal["user", "assistant", "system", "tool"]
+    content: Union[str, list[dict[str, Union[str, int]]]]
+
+
+class MultiModalTaskEncoder(
+    DefaultTaskEncoder[
+        ConversationSample,
+        Union[ConversationTaskSample, PackedTaskSample],
+        BatchedPackedTaskSample,
+        dict,
+    ]
+):
+    """A simple task encoder for VLMs (LlavaSample only)."""
+
+    decoder = SampleDecoder(image_decode="pil", av_decode="AVDecoder", guess_content=True)
+
+    cookers = [
+        Cooker(cook_eagle, has_subflavors={"cook": "eagle"}),
+        Cooker(cook_conversation, has_subflavors={"cook": "conversation"}),
+        Cooker(
+            cook_general_conversations_webdataset,
+            has_subflavors={"cook": "general_conversations_webdataset"},
+        ),
+        Cooker(
+            cook_general_conversations_jsonl, has_subflavors={"cook": "general_conversations_jsonl"}
+        ),
+        Cooker(
+            cook_general_conversations_jsonl_explicit_loss_v1,
+            has_subflavors={"cook": "general_conversations_jsonl_explicit_loss_v1"},
+        ),
+        Cooker(cook_openai_messages_jsonl, has_subflavors={"cook": "openai_messages_jsonl"}),
+        Cooker(
+            cook_openai_messages_offline_packed_jsonl,
+            has_subflavors={"cook": "openai_messages_offline_packed_jsonl"},
+        ),
+    ]
+
+    def __init__(self, is_val: bool = False, tiling_augment_prob: float = 0.4):
+        super().__init__()
+        self.is_val = is_val
+        self.args = get_args()
+        self.tokenizer = get_tokenizer()
+        with open(self.args.prompt_path, "r") as f:
+            self.manual_prompts = json.load(f)
+        # TODO: There is four seq lengths now: seq_length, decoder_seq_length, dataloader_seq_length, packing_seq_length
+        # Why do we need all of these? Can we simplify?
+        # The docs are not clear.
+        self.dataloader_seq_length = self.args.dataloader_seq_length
+        # TODO: It's unclear why we need this separately. This should be the same as dataloader_seq_length which should be decoder_seq_length?
+        self.packing_seq_length = self.args.packing_seq_length
+        self.is_packing_enabled = (
+            self.args.packing_buffer_size is not None
+            and self.args.packing_buffer_size > 0
+            and not is_val
+        )
+        if self.dataloader_seq_length and self.packing_seq_length:
+            assert (
+                self.dataloader_seq_length >= self.packing_seq_length
+            ), "dataloader sequence length must be greater than or equal to the packing sequence length"
+
+        if self.is_packing_enabled:
+            assert self.packing_seq_length > 0, "packing sequence length must be set"
+
+        self.txt_to_token_dict = {}
+
+        self.img_h, self.img_w = self.args.img_h, self.args.img_w
+        self.img_token_id = self.tokenizer.image_token_index
+        # This map is used to reduce the number of tiles used per image if the number of tokens is
+        # larger than the decoder_seq_length.
+        self.num_tiles_degradation_map = {12: 8, 8: 6, 6: 4, 4: 2, 2: 1, 1: 1}
+
+        self.tiling_augment_prob = tiling_augment_prob
+
+        # Create the image tiling strategy using the refactored function
+        self.image_tiling_strategy = create_image_tiling_strategy(self.args)
+
+        # Validate temporal compression settings
+        temporal_patch_size = getattr(self.args, 'video_temporal_patch_size', 1)
+        if temporal_patch_size > 1:
+            # video_min_num_frames must be at least temporal_patch_size
+            assert self.args.video_min_num_frames >= temporal_patch_size, (
+                f"video_min_num_frames ({self.args.video_min_num_frames}) must be >= "
+                f"video_temporal_patch_size ({temporal_patch_size})"
+            )
+            # video_max_num_frames should be a multiple of temporal_patch_size
+            assert self.args.video_max_num_frames % temporal_patch_size == 0, (
+                f"video_max_num_frames ({self.args.video_max_num_frames}) must be a multiple of "
+                f"video_temporal_patch_size ({temporal_patch_size})"
+            )
+
+        packing_algorithm_parameters = _parse_packing_algorithm_parameters(
+            getattr(self.args, "packing_algorithm_parameters", "")
+        )
+        if self.args.packing_knapsack_algorithm == "greedy_knapsack":
+            self.packing_knapsack_algorithm = greedy_knapsack
+        elif self.args.packing_knapsack_algorithm == "balanced_greedy_knapsack":
+            balanced_knapsack_delta = _pop_int_packing_algorithm_parameter(
+                packing_algorithm_parameters, "balanced_knapsack_delta", 20
+            )
+            self.packing_knapsack_algorithm = partial(
+                balanced_greedy_knapsack, delta=balanced_knapsack_delta
+            )
+        elif self.args.packing_knapsack_algorithm == "bucketing_greedy_knapsack":
+            self.packing_knapsack_algorithm = bucketing_greedy_knapsack
+        elif self.args.packing_knapsack_algorithm == "streaming_prompt_dedup_first_fit_knapsack":
+            self.packing_knapsack_algorithm = streaming_prompt_dedup_first_fit_knapsack
+        else:
+            raise ValueError(f"Unknown knapsack algorithm: {self.args.packing_knapsack_algorithm}")
+        if packing_algorithm_parameters:
+            unused_parameters = ", ".join(sorted(packing_algorithm_parameters))
+            raise ValueError(f"Unused packing algorithm parameter(s): {unused_parameters}")
+        self.shuffle_packed_samples = (
+            self.args.packing_knapsack_algorithm != "streaming_prompt_dedup_first_fit_knapsack"
+        )
+
+        print(f"{type(self).__name__} initialized. Energon Version: {energon_version}")
+
+    @staticmethod
+    def get_seq_frames_v3(
+        total_duration: float, desired_num_frames: int = 0, temporal_jitter: bool = False
+    ) -> torch.Tensor:
+        """
+        Calculate the timestamps of frames to extract from a video.
+
+        Parameters:
+            total_duration: Total duration of the video.
+            desired_num_frames: Desired number of frames to extract.
+            temporal_jitter: Whether to jitter the frames.
+
+        Returns:
+            List of timestamps of frames to extract.
+        """
+        # Calculate the size of each segment from which a frame will be extracted
+        seg_size = float(total_duration - 1) / desired_num_frames
+        # print(f"seg_size: {seg_size}")
+
+        # Middle of each segment
+        seq = seg_size * (torch.arange(desired_num_frames).to(dtype=torch.float32) + 0.5)
+
+        if temporal_jitter:
+            jitter_size = seg_size * 0.5
+            # Generate random shifts for all frames at once
+            seq += torch.rand(len(seq), dtype=torch.float32) * (jitter_size * 2) - jitter_size
+            # Clip values to valid range
+            seq = torch.clamp(seq, 0, total_duration)
+
+        return seq
+
+    def video_to_frames(self, video: VideoMedia) -> Tuple[list[Media], int]:
+        """Convert a video to a list of video frame and text according to the settings."""
+        video_duration = video.metadata["video_duration"]
+        video_num_frames = video.metadata["video_num_frames"]
+
+        if video_num_frames is None or video_duration is None:
+            raise ValueError(
+                f"Missing video metadata (num_frames={video_num_frames}, duration={video_duration}) for {video.value}"
+            )
+
+        start_time = 0
+        if video.start_time is not None:
+            if video.end_time is not None:
+                video_duration = video.end_time - video.start_time
+            else:
+                video_duration = video_duration - video.start_time
+            start_time = video.start_time
+        elif video.end_time is not None:
+            video_duration = video.end_time
+
+        temporal_patch_size = getattr(self.args, 'video_temporal_patch_size', 1)
+
+        # Build unified set of possible aug_scale_frames_up values and draw once.
+        # aug_scale_frames_up > 1 = scale UP frames (more frames, lower resolution per frame)
+        # aug_scale_frames_up < 1 = scale DOWN frames (fewer frames, higher resolution per frame)
+        # aug_scale_frames_up = 1 = identity (no augmentation)
+        # E.g. --video-aug-scale-frames-up 4 --video-aug-scale-resolution-up 3
+        #   gives {1/3, 1/2, 1, 2, 3, 4} (6 values, uniform draw)
+        video_aug_scale_frames_up = getattr(self.args, 'video_aug_scale_frames_up', None)
+        video_aug_scale_resolution_up = getattr(self.args, 'video_aug_scale_resolution_up', None)
+
+        scale_values = [1.0]
+        if video_aug_scale_frames_up is not None and video_aug_scale_frames_up > 1:
+            scale_values.extend(float(s) for s in range(2, video_aug_scale_frames_up + 1))
+        if video_aug_scale_resolution_up is not None and video_aug_scale_resolution_up > 1:
+            scale_values.extend(1.0 / s for s in range(2, video_aug_scale_resolution_up + 1))
+
+        aug_scale_frames_up = random.choice(scale_values)
+
+        resolution_only = getattr(self.args, 'video_aug_scale_resolution_only', False)
+
+        if video_num_frames < self.args.video_min_num_frames:
+            # Some videos are too short or low-fps, just use the whole video, like sthv2, smit, llava-hound (2fps)
+            sample_num_frames = video_num_frames
+            aug_scale_frames_up = 1.0  # Reset to not change image size unnecessarily
+            effective_max_num_frames = self.args.video_max_num_frames
+            effective_fps = self.args.video_default_fps
+        else:
+            # We sample frames like: sample_num_frames = min(max(fps * duration, min_frames), max_frames)
+            #   where `fps` and `max_frames` are hyperparameters. To always increase `sample_num_frames`
+            #   by `scale`, we have to scale both `fps` and `max_frames` and then we apply the min/max
+            #   which ensures exactly one is chosen (and either way the scaling factor is applied)
+            if resolution_only:
+                # Resolution-only mode: only change patch count, keep frame count unchanged
+                effective_max_num_frames = self.args.video_max_num_frames
+                effective_fps = self.args.video_default_fps
+            else:
+                # aug_scale_frames_up > 1: more frames, lower resolution per frame
+                # aug_scale_frames_up < 1: fewer frames, higher resolution per frame
+                effective_max_num_frames = max(
+                    self.args.video_min_num_frames,
+                    int(self.args.video_max_num_frames * aug_scale_frames_up),
+                )
+                effective_fps = max(1, int(self.args.video_default_fps * aug_scale_frames_up))
+
+            default_sample_num_frames = int(effective_fps * video_duration)
+            sample_num_frames = min(
+                max(default_sample_num_frames, self.args.video_min_num_frames),
+                effective_max_num_frames,
+            )
+
+        # Round to multiple of temporal patch size for temporal compression
+        # Only round if not already a multiple; prefer rounding up if within limits, else round down
+        if temporal_patch_size > 1:
+            if sample_num_frames % temporal_patch_size != 0:
+                rounded_down = (sample_num_frames // temporal_patch_size) * temporal_patch_size
+                rounded_up = rounded_down + temporal_patch_size
+                if rounded_up <= video_num_frames and rounded_up <= effective_max_num_frames:
+                    sample_num_frames = rounded_up
+                else:
+                    sample_num_frames = max(temporal_patch_size, rounded_down)
+
+            # Verify the final num frames is valid (whether we rounded or not)
+            assert sample_num_frames % temporal_patch_size == 0, (
+                f"sample_num_frames ({sample_num_frames}) must be a multiple of "
+                f"temporal_patch_size ({temporal_patch_size})"
+            )
+            assert sample_num_frames >= temporal_patch_size, (
+                f"sample_num_frames ({sample_num_frames}) must be at least "
+                f"temporal_patch_size ({temporal_patch_size})"
+            )
+            assert sample_num_frames <= effective_max_num_frames, (
+                f"sample_num_frames ({sample_num_frames}) exceeds "
+                f"effective_max_num_frames ({effective_max_num_frames})"
+            )
+
+        frame_timestamps = self.get_seq_frames_v3(
+            video_duration, sample_num_frames, self.args.video_frame_temporal_jitter
+        )
+        frame_timestamps += start_time
+
+        video_fps = video.video_fps
+        video_prompt_version = getattr(self.args, 'video_prompt_version', 2)
+
+        def make_video_frame_media(i, timestamp):
+            metadata = {"video_width": video.video_width, "video_height": video.video_height}
+            if aug_scale_frames_up != 1.0:
+                metadata["video_aug_scale_frames_up"] = aug_scale_frames_up
+            return VideoFrameMedia(
+                value=video.value,
+                timestamp=float(timestamp),
+                frame_index=float(timestamp * video_fps),
+                sample_index=i,
+                metadata=metadata,
+            )
+
+        if video_prompt_version == 1 or temporal_patch_size == 1:
+            # Version 1 (previous): Each frame on its own line.
+            #
+            # This returns a list like:
+            #   ["This is a video:\n", "Frame 1 sampled at 0.00 seconds: ", VideoFrameMedia(0), "\n",
+            #    "Frame 2 sampled at 0.88 seconds: ", VideoFrameMedia(1), "\n", ...]
+            #
+            # During preencode_sample(), each VideoFrameMedia is processed:
+            #   - If (sample_index + 1) % temporal_patch_size == 0: adds IMAGE_TOKEN to text
+            #   - Always appends to image_media list (for image processing)
+            #   - This works because we ensure len(frame_timestamps) % temporal_patch_size == 0
+            #
+            # So with temporal_patch_size=2, the final TEXT prompt becomes:
+            #   "This is a video:\n"
+            #   "Frame 1 sampled at 0.00 seconds: <image>\n"  <- token added (0 % 2 == 0)
+            #   "Frame 2 sampled at 0.88 seconds: \n"         <- no token (1 % 2 != 0)
+            #   "Frame 3 sampled at 1.76 seconds: <image>\n"  <- token added (2 % 2 == 0)
+            #   "Frame 4 sampled at 2.64 seconds: \n"         <- no token (3 % 2 != 0)
+            #   "Frame 5 sampled at 3.52 seconds: <image>\n"  <- token added (4 % 2 == 0)
+            #
+            # All 5 frames' image data is still processed; frames 0+1 are combined into tubelet 0,
+            # frames 2+3 into tubelet 1, etc. Each tubelet embedding replaces one <image> token.
+            return ["This is a video:\n"] + [
+                media
+                for i, timestamp in enumerate(frame_timestamps)
+                for media in (
+                    f"Frame {i + 1} sampled at {timestamp:.2f} seconds: ",
+                    # TODO: Orginal eagle repro
+                    # f"Frame {i + 1} sampled at {timestamp:.2f} seconds: <image-{i}>",
+                    make_video_frame_media(i, timestamp),
+                    "\n",
+                )
+            ], len(frame_timestamps)
+        elif video_prompt_version == 2 and temporal_patch_size > 1:
+            # Version 2 (new default): Group T frames with "and", one <image> per group.
+            # This also produces the same output as version 1 if temporal_patch_size == 1
+
+            # This returns a list like:
+            #   ["This is a video:\n",
+            #    "Frame 1 sampled at 0.00 seconds and frame 2 sampled at 0.88 seconds: ",
+            #    VideoFrameMedia(0), VideoFrameMedia(1), "\n",
+            #    "Frame 3 sampled at 1.76 seconds and frame 4 sampled at 2.64 seconds: ",
+            #    VideoFrameMedia(2), VideoFrameMedia(3), "\n",
+            #    "Frame 5 sampled at 3.52 seconds: ", VideoFrameMedia(4), "\n"]
+            #
+            # Same processing as version 1: IMAGE_TOKEN added only when sample_index % T == 0.
+            # Final TEXT prompt becomes:
+            #   "This is a video:\n"
+            #   "Frame 1 sampled at 0.00 seconds and frame 2 sampled at 0.88 seconds: <image>\n"
+            #   "Frame 3 sampled at 1.76 seconds and frame 4 sampled at 2.64 seconds: <image>\n"
+            #   "Frame 5 sampled at 3.52 seconds: <image>\n"
+            result = ["This is a video:\n"]
+            T = temporal_patch_size
+            for group_start in range(0, len(frame_timestamps), T):
+                # Build text for this group
+                group_text_parts = []
+                group_media = []
+                for j in range(T):
+                    sample_idx = group_start + j
+                    if sample_idx < len(frame_timestamps):
+                        timestamp = frame_timestamps[sample_idx]
+                        frame_str = "Frame" if j == 0 else "frame"
+                        group_text_parts.append(
+                            f"{frame_str} {sample_idx + 1} sampled at {timestamp:.2f} seconds"
+                        )
+                        group_media.append(make_video_frame_media(sample_idx, timestamp))
+                if group_text_parts:
+                    result.append(" and ".join(group_text_parts) + ": ")
+                    result.extend(group_media)
+                    result.append("\n")
+            return result, len(frame_timestamps)
+        else:
+            raise NotImplementedError(
+                f"Video prompt version {video_prompt_version} with"
+                f" temporal patch size {temporal_patch_size} is not implemented"
+            )
+
+    @staticmethod
+    def _get_prompt_hash(sample: ConversationSample) -> str:
+        prompt_text_parts = []
+        for message in sample.conversation:
+            if message.sender not in ("user", "tool"):
+                continue
+            prompt_text_parts.extend(
+                fragment for fragment in message.fragments if isinstance(fragment, str)
+            )
+        prompt_text = "".join(prompt_text_parts)
+        return hashlib.md5(prompt_text.encode("utf-8")).hexdigest()
+
+    @stateless(restore_seeds=True)
+    def preencode_sample(
+        self, sample: ConversationSample
+    ) -> PreEncodedTaskSample | PreEncodedOfflinePackedTextSample:
+        """Encode sample."""
+
+        identity_filter_keywords = getattr(self.args, "filter_identity_keywords", None) or []
+        if _has_filtered_identity_keyword(sample, identity_filter_keywords):
+            raise ValueError(
+                "Sample from identity-filtered dataset contains a filtered "
+                f"assistant identity keyword: {sample.__key__}"
+            )
+
+        explicit_assistant_loss = _validate_loss_mask_subflavors(sample.__subflavors__)
+        if sample.__subflavors__.get("offline_packed_messages", False):
+            return self._preencode_offline_packed_text_sample(sample)
+
+        # In-place convert VideoMedia to VideoFrameMedia (and text)
+        # Some really large video files cause decoding to take a long time potentially leading to issues.
+        allow_large_videos = getattr(self.args, "allow_large_videos", False)
+        data_augment = sample.__subflavors__.get("data_augment", False) and not self.is_val
+        tiling_augment_prob = sample.__subflavors__.get(
+            "tiling_augment_prob", self.tiling_augment_prob
+        )
+        train_only_on_last_assistant_turn = sample.__subflavors__.get(
+            "train_only_on_last_assistant_turn", False
+        )
+        tool_response_as_turn_boundary = sample.__subflavors__.get(
+            "tool_response_as_turn_boundary", False
+        )
+        skip_chat_template = sample.__subflavors__.get("skip_chat_template", False)
+        aggregated_num_frames = []
+        prompt_hash = self._get_prompt_hash(sample)
+
+        assistant_turn_loss: list[bool] | None = None
+        if explicit_assistant_loss:
+            if (
+                sample.__subflavors__.get("assistant_loss_mask_field")
+                != EXPLICIT_ASSISTANT_LOSS_FIELD
+            ):
+                raise ValueError(
+                    "explicit assistant loss requires "
+                    f"assistant_loss_mask_field={EXPLICIT_ASSISTANT_LOSS_FIELD}"
+                )
+            if train_only_on_last_assistant_turn:
+                raise ValueError(
+                    "explicit assistant loss is incompatible with "
+                    "train_only_on_last_assistant_turn"
+                )
+            assistant_turn_loss = []
+            for message in sample.conversation:
+                if message.sender == "assistant":
+                    if type(message.loss) is not bool:
+                        raise ValueError(
+                            "explicit assistant loss requires a boolean loss flag "
+                            f"on every assistant turn in sample {sample.__key__}"
+                        )
+                    assistant_turn_loss.append(message.loss)
+                elif message.loss is not None:
+                    raise ValueError(
+                        "explicit assistant loss flags are only valid on assistant "
+                        f"turns in sample {sample.__key__}"
+                    )
+            if not any(assistant_turn_loss):
+                raise ValueError(
+                    f"explicit assistant loss has no loss=true turn in sample {sample.__key__}"
+                )
+        elif any(message.loss is not None for message in sample.conversation):
+            raise ValueError(
+                "conversation contains explicit loss flags without "
+                f"loss_mask_mode={EXPLICIT_ASSISTANT_LOSS_MODE}"
+            )
+
+        # We tentatively extract the first message if it's a system prompt and use this rather than
+        # the default. After this, we expect no system prompt in the conversation.
+
+        has_system_message = sample.conversation[0].sender == "system"
+        system_prompt = ""
+        if has_system_message:
+            system_prompt = sample.conversation[0].fragments[0]
+            sample.conversation = sample.conversation[1:]
+
+        structured_conversation: list[ConversationTurn] = [
+            {"role": "system", "content": system_prompt}
+        ]
+
+        for message in sample.conversation:
+            idx = 0
+            while idx < len(message.fragments):
+                fragment = message.fragments[idx]
+
+                if isinstance(fragment, VideoMedia):
+                    if not allow_large_videos and fragment.clip_duration > 60 * 10:
+                        raise ValueError(f"Video is too large: {fragment.value}")
+
+                    frames, num_frames = self.video_to_frames(fragment)
+                    message.fragments[idx : idx + 1] = frames
+                    idx += len(frames)
+                    aggregated_num_frames.append(num_frames)
+                else:
+                    if isinstance(fragment, (ImageMedia, VideoFrameMedia)):
+                        # Image or a single frame
+                        aggregated_num_frames.append(1)
+                    elif isinstance(fragment, str):
+                        # Text fragment
+                        pass
+                    elif isinstance(fragment, bytes):
+                        raise ValueError(
+                            f"Could not convert bytes to known media type: {fragment[:100]!r}"
+                        )
+                    else:
+                        raise ValueError(
+                            f"Unexpected media type: {type(fragment)}. Fragment: {fragment}"
+                        )
+                    idx += 1
+
+        image_media: list[ImageMedia | VideoFrameMedia] = []
+        # For temporal compression: track video frame count to emit one IMAGE_TOKEN per tubelet
+        temporal_patch_size = getattr(self.args, 'video_temporal_patch_size', 1)
+
+        # Format the conversation as a list of "user" / "assistant" turns.
+        for message in sample.conversation:
+            if not self.args.relax_sender_check:
+                assert message.sender in [
+                    "user",
+                    "assistant",
+                    "tool",
+                ], f"unexpected sender {message.sender} in {sample.conversation}"
+
+            content_parts: list[dict[str, Union[str, int]]] = []
+
+            for fragment in message.fragments:
+                if isinstance(fragment, str):
+                    if not fragment:
+                        continue
+                    content_parts.append({"type": "text", "text": fragment})
+                elif isinstance(fragment, ImageMedia):
+                    content_parts.append({"type": "image"})
+                    image_media.append(fragment)
+                elif isinstance(fragment, VideoFrameMedia):
+                    # With temporal compression, only add IMAGE_TOKEN at tubelet boundaries
+                    #   (every T frames). Use sample_index which is the consecutive index within
+                    #   sampled frames (0, 1, 2, ...) and resets to 0 for each video.
+                    # This works because:
+                    #   1) _group_video_frame_params_into_tubelets() groups per-frame params to match IMAGE_TOKEN count
+                    #   2) Grouped params used for sequence length calculations and padding
+                    #   3) All frames (un-grouped) are passed as pixels to RADIO.forward()
+                    #   4) RADIO._apply_temporal_grouping() combines every T frames
+                    #   5) RADIO returns updated imgs_sizes/num_frames for LLaVAModel
+                    if temporal_patch_size > 1:
+                        # Add the image token for last frame in every group of T
+                        if (
+                            fragment.sample_index + 1
+                        ) % temporal_patch_size == 0:  # Next frame == new group
+                            content_parts.append({"type": "image"})
+                    else:
+                        # Add the image token for every frame
+                        content_parts.append({"type": "image"})
+                    image_media.append(fragment)
+                elif isinstance(fragment, VideoMedia):
+                    raise ValueError("VideoMedia should have been converted to VideoFrameMedia.")
+            if self.args.only_keep_samples_with_img and len(image_media) == 0:
+                raise ValueError(f"Sample has no image: {sample.__key__}")
+
+            prompt_format = self.args.tokenizer_prompt_format
+
+            if (
+                not skip_chat_template
+                and prompt_format == "nemotron6-moe"
+                and message.sender == "assistant"
+                and not self.args.relax_thinking_trace_check
+            ):
+                if any(part["type"] != "text" for part in content_parts):
+                    raise ValueError(
+                        f"Assistant turns with multimodal content are not supported in sample {sample.__key__}"
+                    )
+                content = "".join(part["text"] for part in content_parts)
+                think_start_count = content.count("<think>")
+                think_end_count = content.count("</think>")
+                if think_start_count == 0 and think_end_count == 0:
+                    # Add think tags in non-reasoning mode, if missing
+                    content = "<think></think>" + content.strip()
+                else:
+                    # There should be exactly one of each, otherwise it's invalid
+                    assert think_start_count == 1 and think_end_count == 1, (
+                        f"Found sample with {think_start_count} <think> tags and {think_end_count} </think> tags in sample with "
+                        f"key: {sample.__key__} and subflavors: {sample.__subflavors__}"
+                    )
+
+                    # </think> should come after <think>, otherwise it's invalid
+                    start_idx = content.find("<think>")
+                    end_idx = content.find("</think>")
+                    assert start_idx < end_idx, (
+                        f"Found sample with </think> tags before </think> tags in sample with "
+                        f"key: {sample.__key__} and subflavors: {sample.__subflavors__}"
+                    )
+
+                    content = _normalize_thinking_trace(
+                        content,
+                        thinking_trace_format=getattr(
+                            self.args, "thinking_trace_format", "normalized"
+                        ),
+                    )
+                content_parts = [{"type": "text", "text": content}]
+
+            structured_conversation.append({"role": message.sender, "content": content_parts})
+
+        input_ids, target = self.tokenizer.tokenize_conversation(
+            structured_conversation,
+            True,
+            False,
+            train_only_on_last_assistant_turn=train_only_on_last_assistant_turn,
+            tool_response_as_turn_boundary=tool_response_as_turn_boundary,
+            assistant_turn_loss=assistant_turn_loss,
+            skip_chat_template=skip_chat_template,
+        )
+        input_ids = torch.as_tensor(input_ids)
+        target = torch.as_tensor(target)
+        if assistant_turn_loss is not None:
+            self._validate_explicit_loss_target_spans(
+                target,
+                expected_span_count=sum(assistant_turn_loss),
+                sample_key=sample.__key__,
+                phase="tokenization",
+            )
+        if len(target) == 0 or not bool((target != IGNORE_INDEX).any().item()):
+            raise NoTrainableTokensError(
+                f"target is empty: {target}, DETOKENIZED:\n\n{self.tokenizer.detokenize(input_ids)}\n\nCONVERSATION:\n\n"
+                + "".join([f"{m.sender}: {m.fragments}\n" for m in sample.conversation])
+            )
+
+        max_image_token_allowed = self.args.decoder_seq_length - len(input_ids) - 4
+        image_media_params = self.image_tiling_strategy.compute_params(
+            image_media,
+            max_image_token_allowed,
+            data_augment=data_augment,
+            tiling_augment_prob=tiling_augment_prob,
+        )
+
+        # With temporal compression, we emit one IMAGE_TOKEN per tubelet (grouped frame), not per frame.
+        # Create grouped params for token counting (one per IMAGE_TOKEN), but keep
+        #   ungrouped params for storage (one per frame, needed for frame loading).
+        # This is necessary to get accurate token / embedding / image counts when we're calling
+        #   compute_params() and process_media() on individual video frames, rather than entire videos
+        if temporal_patch_size > 1:
+            grouped_params_for_tokens = self._group_video_frame_params_into_tubelets(
+                image_media, image_media_params, temporal_patch_size
+            )
+        else:
+            grouped_params_for_tokens = image_media_params
+
+        input_ids, target = self._truncate_to_decoder_seq_len(
+            input_ids=input_ids,
+            target=target,
+            image_tiling_params=grouped_params_for_tokens,
+            sample_key=sample.__key__,
+            sample_subflavors=sample.__subflavors__,
+        )
+
+        if assistant_turn_loss is not None:
+            self._validate_explicit_loss_target_spans(
+                target,
+                expected_span_count=sum(assistant_turn_loss),
+                sample_key=sample.__key__,
+                phase="truncation",
+            )
+
+        # We need to ensure that there are at least some trainable tokens in the sample.
+        has_trainable_tokens = self._target_has_trainable_tokens(
+            input_ids, target, grouped_params_for_tokens
+        )
+
+        if not has_trainable_tokens:
+            raise NoTrainableTokensError(
+                f"Sample has no trainable tokens: {self.tokenizer.detokenize(input_ids)}"
+            )
+
+        total_len, total_len_padded, input_ids, target = self._pad_for_context_parallel_and_fp8(
+            input_ids, target, grouped_params_for_tokens
+        )
+
+        # Store UNGROUPED params (one per frame) for frame loading in _load_media()
+        # The reason we must use ungrouped params for `images` here is that if we used the
+        #   grouped params, the line `frame_clips = media_value.get_clips(` in _load_media() would
+        #   only load one of the frames in the group (the last one) instead of both, breaking things
+        # The reason we must use grouped params for `sample` and the other metadata is that those
+        #   are used for the LLM's packed seq params and thus must reflect the sequence lengths and
+        #   other metadata that will come out of the vision encoder, post temporal compression
+        # This whole metadata tracking for grouped vs. ungrouped params is unfortunate, and only
+        #   necessary because we're passing single frames to RADIO and doing the temporal grouping
+        #   there. In the near-future we should refactor this so we always pass (T,B,C,H,W) tensors
+        #   to the vision encoder, to simplify everything.
+        return PreEncodedTaskSample.derive_from(
+            sample,  # UNGROUPED (need per-image metadata for vision encoder)
+            tokens=input_ids,  # Grouped
+            labels=target,  # Grouped
+            images=image_media_params,  # UNGROUPED (need per-image metadata for vision encoder)
+            total_len=total_len,  # Grouped
+            total_len_padded=total_len_padded,  # Grouped
+            num_frames=aggregated_num_frames,  # UNGROUPED (need per-image metadata for vision encoder)
+            prompt_hash=prompt_hash,
+        )
+
+    def _split_offline_packed_conversations(
+        self, sample: ConversationSample
+    ) -> list[list[ConversationTurn]]:
+        conversations: list[list[ConversationTurn]] = []
+        current: list[ConversationTurn] = []
+
+        for message in sample.conversation:
+            if message.loss is not None:
+                raise ValueError(
+                    "openai_messages_offline_packed_jsonl does not support "
+                    f"explicit assistant loss in sample {sample.__key__}"
+                )
+            if message.sender == "system" and current:
+                conversations.append(current)
+                current = []
+
+            if any(not isinstance(fragment, str) for fragment in message.fragments):
+                raise ValueError(
+                    "openai_messages_offline_packed_jsonl supports text-only messages; "
+                    f"got {message.fragments!r} in sample {sample.__key__}"
+                )
+            current.append({"role": message.sender, "content": "".join(message.fragments)})
+
+        if current:
+            conversations.append(current)
+        if not conversations:
+            raise ValueError(f"Offline packed sample has no conversations: {sample.__key__}")
+        return conversations
+
+    def _preencode_offline_packed_text_sample(
+        self, sample: ConversationSample
+    ) -> PreEncodedOfflinePackedTextSample:
+        """Tokenize one already-packed Nano SFT row without online repacking."""
+        assert not self.is_packing_enabled, (
+            "openai_messages_offline_packed_jsonl rows are already packed; "
+            "do not pass --packing-buffer-size with this cooker."
+        )
+
+        pack_length = self.args.decoder_seq_length
+        pad = self.tokenizer.pad
+
+        pack_tokens: list[int] = []
+        pack_targets: list[int] = []
+        cu_lengths = [0]
+        sample_lengths: list[int] = []
+
+        for conversation in self._split_offline_packed_conversations(sample):
+            tokens, targets = self.tokenizer.tokenize_conversation(
+                conversation,
+                True,
+                False,
+                train_only_on_last_assistant_turn=sample.__subflavors__.get(
+                    "train_only_on_last_assistant_turn", False
+                ),
+                tool_response_as_turn_boundary=sample.__subflavors__.get(
+                    "tool_response_as_turn_boundary", False
+                ),
+                skip_chat_template=sample.__subflavors__.get("skip_chat_template", False),
+            )
+            tokens = torch.as_tensor(tokens, dtype=torch.int64)
+            targets = torch.as_tensor(targets, dtype=torch.int64)
+            if len(targets) == 0 or (targets != IGNORE_INDEX).sum() == 0:
+                continue
+
+            tokens_list = [int(token) for token in tokens.tolist()]
+            targets_list = [int(target) for target in targets.tolist()]
+            pack_tokens.extend(tokens_list)
+            pack_targets.extend(targets_list)
+
+            if getattr(self.args, "context_parallel_size", 1) > 1:
+                pad_granularity = self.args.context_parallel_size * 2
+                mod_token_count = len(pack_tokens) % pad_granularity
+                if mod_token_count != 0:
+                    pad_len = pad_granularity - mod_token_count
+                    pack_tokens.extend([pad] * pad_len)
+                    pack_targets.extend([pad] * pad_len)
+
+            current_length = len(pack_tokens)
+            cu_lengths.append(current_length)
+            sample_lengths.append(current_length - cu_lengths[-2])
+
+            if len(pack_tokens) >= pack_length + 1:
+                pack_tokens = pack_tokens[:pack_length]
+                pack_targets = pack_targets[:pack_length]
+                pack_tokens.append(pad)
+                pack_targets.append(pad)
+                cu_lengths[-1] = len(pack_tokens) - 1
+                sample_lengths[-1] = cu_lengths[-1] - cu_lengths[-2]
+                break
+
+        if len(cu_lengths) < 2:
+            raise NoTrainableTokensError(
+                f"Offline packed sample has no trainable conversations: {sample.__key__}"
+            )
+
+        if len(pack_tokens) < pack_length + 1:
+            pad_len = pack_length + 1 - len(pack_tokens)
+            pack_tokens.extend([pad] * pad_len)
+            pack_targets.extend([pad] * pad_len)
+            cu_lengths[-1] = len(pack_tokens) - 1
+            sample_lengths[-1] = cu_lengths[-1] - cu_lengths[-2]
+
+        assert len(pack_tokens) == pack_length + 1
+        assert len(pack_targets) == pack_length + 1
+
+        cu_lengths_tensor = torch.tensor(cu_lengths, dtype=torch.int32)
+        adjacent_diffs = cu_lengths_tensor[1:] - cu_lengths_tensor[:-1]
+        max_length = int(adjacent_diffs.max().item())
+
+        return PreEncodedOfflinePackedTextSample.derive_from(
+            sample,
+            tokens=torch.tensor(pack_tokens[:-1], dtype=torch.int64),
+            labels=torch.tensor(pack_targets, dtype=torch.int64),
+            max_length=max_length,
+            cu_lengths=cu_lengths_tensor,
+            cu_lengths_padded=cu_lengths_tensor.clone(),
+            samples_seen=torch.tensor(len(sample_lengths), dtype=torch.int32),
+            sample_lengths=torch.tensor(sample_lengths, dtype=torch.int32),
+        )
+
+    @stateless(restore_seeds=True)
+    def preencode_sample_for_packing(self, sample: ConversationSample):
+        encoded_sample = self.preencode_sample(sample)
+        samples = getattr(encoded_sample, "samples", None)
+        if samples is not None:
+            yield from samples
+        else:
+            yield encoded_sample
+
+    def build_encode_sample(self, dataset, *, worker_config):
+        if self.is_packing_enabled:
+            return MapDataset(
+                dataset,
+                self.preencode_sample_for_packing,
+                worker_config=worker_config,
+                stateless_map_fn=True,
+            )
+        return super().build_encode_sample(dataset, worker_config=worker_config)
+
+    @stateless(restore_seeds=True)
+    def postencode_sample(
+        self, sample: PreEncodedTaskSample | PreEncodedOfflinePackedTextSample
+    ) -> PackedTaskSample:
+        if isinstance(sample, PreEncodedOfflinePackedTextSample):
+            return PackedTaskSample.derive_from(
+                sample,
+                __key__=[sample.__key__],
+                tokens=sample.tokens,
+                labels=sample.labels,
+                imgs=[],
+                num_tiles=[],
+                num_frames=[],
+                max_length=sample.max_length,
+                cu_lengths=sample.cu_lengths,
+                cu_lengths_padded=sample.cu_lengths_padded,
+                samples_seen=sample.samples_seen,
+                sample_lengths=sample.sample_lengths,
+            )
+
+        self._load_media(sample)
+
+        data_augment = sample.__subflavors__.get("data_augment", False) and not self.is_val
+
+        # Transform the images
+        image_tiles = []
+        for media_idx, media in enumerate(sample.images):
+            # Debug: Save images if DEBUG environment variable is set to 1
+            if os.environ.get("DEBUG_DATALOADER", "0") == "1":
+                try:
+                    self._debug_save_image(media, media_idx, sample.__key__, data_augment)
+                except Exception as e:
+                    print(f"[DEBUG] Failed to save debug image: {e}")
+
+            image_tiles.extend(
+                self.image_tiling_strategy.apply_params(media, data_augment=data_augment)
+            )
+
+        # Make this a packed sample (if used without packing, it will be the same next code)
+        return PackedTaskSample.derive_from(
+            sample,
+            __key__=[sample.__key__],
+            tokens=sample.tokens,
+            labels=sample.labels,
+            imgs=image_tiles,
+            num_tiles=[media.num_tiles for media in sample.images],
+            num_frames=sample.num_frames,
+            max_length=sample.total_len_padded,
+            cu_lengths=torch.tensor([0, sample.total_len], dtype=torch.int32),
+            cu_lengths_padded=torch.tensor([0, sample.total_len_padded], dtype=torch.int32),
+            samples_seen=torch.tensor(1, dtype=torch.int32),
+            sample_lengths=torch.tensor([sample.total_len], dtype=torch.int32),
+        )
+
+    def _debug_save_image(self, media, media_idx, sample_key, data_augment):
+        """Save debug images with original and transformed sizes."""
+        from datetime import datetime
+
+        import matplotlib.patches as patches
+        import matplotlib.pyplot as plt
+
+        # Create debug directory if it doesn't exist
+        debug_dir = os.environ.get(
+            "DEBUG_DATALOADER_DIR", os.path.join(os.getcwd(), "debug_images")
+        )
+        os.makedirs(debug_dir, exist_ok=True)
+
+        # Get original image and size
+        original_image = media.media.value
+
+        if isinstance(media.media, ImageMedia):
+            orig_width, orig_height = media.media.width, media.media.height
+            media_type = "image"
+            if os.environ.get("DEBUG_DATALOADER_VIDEO_ONLY", "0") == "1":
+                return
+        elif isinstance(media.media, VideoFrameMedia):
+            orig_width, orig_height = media.media.video_width, media.media.video_height
+            media_type = "video"
+            if os.environ.get("DEBUG_DATALOADER_IMAGE_ONLY", "0") == "1":
+                return
+        else:
+            return  # Skip if not a supported media type
+
+        # Apply the transformation to get the processed tiles
+        transformed_tiles = self.image_tiling_strategy.apply_params(
+            media, data_augment=data_augment
+        )
+
+        # Get the normalization stats for denormalization
+        from .image_processing import pixel_statistics
+
+        pixel_mean, pixel_std = pixel_statistics.get(
+            self.args.vision_model_type, ([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+        )
+
+        # Convert lists to tensors for denormalization
+        mean = torch.tensor(pixel_mean).view(3, 1, 1)
+        std = torch.tensor(pixel_std).view(3, 1, 1)
+
+        # Create a figure with subplots
+        num_tiles = len(transformed_tiles)
+        fig, axes = plt.subplots(1, num_tiles + 1, figsize=(5 * (num_tiles + 1), 5))
+        if num_tiles == 0:
+            axes = [axes]
+
+        # Plot original image
+        ax = axes[0] if num_tiles > 0 else axes
+        ax.imshow(original_image)
+        ax.set_title(
+            f"Original Image\nSize: {orig_width}x{orig_height}", fontsize=10, fontweight='bold'
+        )
+        ax.axis('off')
+
+        # Plot transformed tiles
+        for tile_idx, tile_tensor in enumerate(transformed_tiles):
+            ax = axes[tile_idx + 1]
+
+            # Denormalize the tensor: img = img * std + mean
+            denormalized = tile_tensor * std + mean
+
+            # Clamp to [0, 1] range
+            denormalized = torch.clamp(denormalized, 0, 1)
+
+            # Convert to numpy and transpose from CxHxW to HxWxC
+            tile_image = denormalized.permute(1, 2, 0).cpu().numpy()
+
+            # Get the new size
+            new_height, new_width = tile_image.shape[:2]
+
+            ax.imshow(tile_image)
+            ax.set_title(
+                f"Tile {tile_idx + 1}/{num_tiles}\n"
+                f"Size: {tile_tensor.shape[2]}x{tile_tensor.shape[1]}\n"
+                f"Original: {orig_width}x{orig_height}",
+                fontsize=9,
+                fontweight='bold',
+            )
+            ax.axis('off')
+
+        # Create a unique filename with timestamp
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        safe_key = str(sample_key).replace("/", "_").replace("\\", "_")[:50]
+        filename = f"{safe_key}_{media_type}_media{media_idx}_{timestamp}.png"
+        filepath = os.path.join(debug_dir, filename)
+
+        plt.tight_layout()
+        plt.savefig(filepath, dpi=150, bbox_inches='tight')
+        plt.close(fig)
+
+        print(f"[DEBUG] Saved debug image to: {filepath}")
+
+    @stateless(restore_seeds=True)
+    def select_samples_to_pack(
+        self, samples: List[PreEncodedTaskSample]
+    ) -> List[List[PreEncodedTaskSample]]:
+        """Selects which samples will be packed together.
+
+        NOTE: Energon dataloader calls this method internally if packing is used.
+        Please see https://nvidia.github.io/Megatron-Energon/packing.html
+        """
+        lengths = [sample.total_len_padded for sample in samples]
+
+        packed_samples = self.packing_knapsack_algorithm(lengths, samples, self.packing_seq_length)
+        if self.shuffle_packed_samples:
+            random.shuffle(packed_samples)
+
+        # TODO: Save iterated samples
+        # with open(f"tmpdata/packed_samples_{os.getpid()}.json", "a") as f:
+        #     f.write(json.dumps(
+        #         {
+        #             "lengths": [int(sample.total_len_padded) for sample in samples],
+        #             "samples": [
+        #                 {
+        #                     "key": sample.__key__,
+        #                     "images": [img.media.value.fname for img in sample.images],
+        #                     "image_sizes": [(img.media.metadata.get("width", img.media.metadata.get("video_width")), img.media.metadata.get("height", img.media.metadata.get("video_height"))) for img in sample.images],
+        #                     "length": int(sample.total_len_padded),
+        #                     "tokens": [int(token) for token in sample.tokens],
+        #                     "detokens": [self.tokenizer.detokenize([token]) for token in sample.tokens],
+        #                     "tiling": [img.tiling for img in sample.images],
+        #                     "num_tiles": sample.num_tiles,
+        #                     "name": sample.__subflavors__["name"],
+        #                 } for sample in samples
+        #             ],
+        #         }
+        #     ) + "\n")
+
+        print(
+            f"[pid={os.getpid()}] Computed packing from {len(samples)} samples to {len(packed_samples)} packed samples (avg {len(samples) / len(packed_samples)} samples per packed sample)"
+        )
+        print(
+            f"[pid={os.getpid()}] Computed packing from {sum(lengths)} tokens (avg {sum(lengths) / len(samples)} tokens per sample, avg {sum(lengths) / len(packed_samples)} tokens per packed sample)"
+        )
+        print(
+            f"[pid={os.getpid()}] Packing efficiency: {sum(lengths)} / {len(packed_samples) * self.packing_seq_length} = {sum(lengths) / (len(packed_samples) * self.packing_seq_length) * 100:.2f}%"
+        )
+        assert sum(len(s) for s in packed_samples) == len(
+            samples
+        ), "knapsack discarded some samples"
+        # Print the 5% - 50% - 95% percentiles of the lengths
+        print(f"[pid={os.getpid()}] 5% percentile of lengths: {np.percentile(lengths, 5)}")
+        print(f"[pid={os.getpid()}] 50% percentile of lengths: {np.percentile(lengths, 50)}")
+        print(f"[pid={os.getpid()}] 95% percentile of lengths: {np.percentile(lengths, 95)}")
+
+        # trainable_tokens = [len([int(token) for token in sample.labels if token != IGNORE_INDEX]) for sample in samples]
+        # print(f"[pid={os.getpid()}] 5% percentile of trainable tokens: {np.percentile(trainable_tokens, 5)}")
+        # print(f"[pid={os.getpid()}] 50% percentile of trainable tokens: {np.percentile(trainable_tokens, 50)}")
+        # print(f"[pid={os.getpid()}] 95% percentile of trainable tokens: {np.percentile(trainable_tokens, 95)}")
+
+        return packed_samples
+
+    @stateless
+    def pack_selected_samples(self, samples: List[PackedTaskSample]) -> PackedTaskSample:
+        """
+        Function to pack a list of ImageTaskSamplePacked into a single ImageTaskSamplePacked.
+
+        NOTE: Energon dataloader calls this method internally if packing is used.
+        Please see https://nvidia.github.io/Megatron-Energon/packing.html
+
+        Args:
+            samples: List of ImageTaskSamplePacked instances to pack into one sample.
+
+        Returns:
+            ImageTaskSamplePacked instance.
+        """
+        cu_lengths = [0]
+        cu_lengths_padded = [0]
+        # Process each sample and build lists that we will concatenate to create the packed sample.
+        for sample in samples:
+            sample_len = sample.cu_lengths[-1]
+            sample_len_padded = sample.cu_lengths_padded[-1]
+
+            cu_lengths.append(cu_lengths_padded[-1] + sample_len)
+            cu_lengths_padded.append(cu_lengths_padded[-1] + sample_len_padded)
+
+        assert (
+            cu_lengths_padded[-1] <= self.packing_seq_length
+        ), f"Packed sample exceeds the maximum sequence length of {self.packing_seq_length}: {samples}"
+        assert all(
+            isinstance(sample.imgs, list) for sample in samples
+        ), "All images must be tensors"
+        assert all(
+            isinstance(img, torch.Tensor) for sample in samples for img in sample.imgs
+        ), f"All images must be tensors: {[type(img) for sample in samples for img in sample.imgs]}"
+
+        if self.args.allow_cross_sample_attention:
+            cu_lengths = [0, cu_lengths[-1]]
+            cu_lengths_padded = [0, cu_lengths_padded[-1]]
+            max_length = sum(sample.max_length for sample in samples)
+        else:
+            max_length = max(sample.max_length for sample in samples)
+
+        return PackedTaskSample(
+            __key__=[k for s in samples for k in s.__key__],
+            __restore_key__=(),  # Will be set by energon based on `samples`
+            __subflavors__={idx: sample.__subflavors__ for idx, sample in enumerate(samples)},
+            tokens=torch.cat([sample.tokens for sample in samples], dim=0),
+            labels=torch.cat([sample.labels for sample in samples], dim=0),
+            imgs=[img for sample in samples for img in sample.imgs],
+            cu_lengths=torch.tensor(cu_lengths, dtype=torch.int32),
+            cu_lengths_padded=torch.tensor(cu_lengths_padded, dtype=torch.int32),
+            max_length=max_length,
+            num_tiles=[n for s in samples for n in s.num_tiles],
+            num_frames=[n for s in samples for n in s.num_frames],
+            samples_seen=sum(s.samples_seen for s in samples),
+            sample_lengths=torch.cat([s.sample_lengths for s in samples], dim=0),
+        )
+
+    def batch(self, samples: List[PackedTaskSample]) -> BatchedPackedTaskSample:
+        # Stack images to [num_tiles, c, h, w]. If there are no images (text-only), then use a dummy image.
+        imgs = [img for s in samples for img in s.imgs]
+
+        # Pad image packed seq length to be % 16 if using fp8 and dynamic resolution
+        has_fp8 = self.args.fp8 is not None
+        has_pad_img = torch.tensor(False)
+        # CP pads each local vision partition immediately before the encoder.
+        no_cp = self.args.context_parallel_size == 1
+        if has_fp8 and self.args.dynamic_resolution and no_cp:
+            img_seq_len = 0
+            for img in imgs:
+                img_seq_len += (img.shape[1] // self.args.patch_dim) * (
+                    img.shape[2] // self.args.patch_dim
+                )
+            padding_needed = get_padding(
+                img_seq_len,
+                self.args.context_parallel_size,
+                self.args.tensor_model_parallel_size,
+                self.args.sequence_parallel,
+                self.args.tp_comm_overlap,
+                self.args.decoder_seq_length,
+                fp8_enabled=has_fp8,
+            )
+            if padding_needed > 0:
+                pad_img = torch.zeros(
+                    [3, self.args.patch_dim, padding_needed * self.args.patch_dim]
+                )
+                imgs.append(pad_img)
+                has_pad_img = torch.tensor(True)
+
+        imgs, imgs_sizes, vision_cu_lengths, vision_max_lengths = self.image_tiling_strategy.stack(
+            imgs
+        )
+
+        # For batch mode, wrap in additional dimension for consistency
+        if imgs is None:
+            imgs = torch.tensor([[0]], dtype=torch.float32)
+        if imgs_sizes is None:
+            imgs_sizes = torch.tensor([[0, 0]], dtype=torch.int32)
+        # Set default values if no vision metadata was returned (static resolution case)
+        if vision_cu_lengths is None:
+            vision_cu_lengths = torch.tensor([[0]], dtype=torch.int32)
+        else:
+            # Shape: (1, batch_size + 1)
+            vision_cu_lengths = vision_cu_lengths.unsqueeze(0)
+        if vision_max_lengths is None:
+            vision_max_lengths = torch.tensor([[0]], dtype=torch.int32)
+        else:
+            # Shape: (1,)
+            vision_max_lengths = vision_max_lengths.unsqueeze(0)
+
+        # If the user hasn't defined a target dataloader sequence length, then use the max along the sample lengths.
+        max_seq_len = self.dataloader_seq_length
+        if not max_seq_len:
+            max_seq_len = max(len(s.tokens) for s in samples)
+
+        tokens = torch.full((len(samples), max_seq_len), self.tokenizer.pad, dtype=torch.int64)
+        # +1 to accommodate shift to left by one later.
+        labels = torch.full((len(samples), max_seq_len + 1), self.tokenizer.pad, dtype=torch.int64)
+
+        for i, s in enumerate(samples):
+            # If the sample/target length exceeds the target sequence length, then truncate.
+            text_len = min(max_seq_len, len(s.tokens))
+            target_len = min(max_seq_len + 1, len(s.labels))
+
+            tokens[i, :text_len] = s.tokens[:text_len]
+            labels[i, :target_len] = s.labels[:target_len]
+
+        num_tiles = torch.tensor([n for s in samples for n in s.num_tiles], dtype=torch.int32)
+        if len(num_tiles) == 0:
+            num_tiles = torch.tensor([[0]], dtype=torch.int32)
+
+        num_frames = torch.tensor([n for s in samples for n in s.num_frames], dtype=torch.int32)
+        if len(num_frames) == 0:
+            num_frames = torch.tensor([[0]], dtype=torch.int32)
+
+        cu_lengths = torch.stack([s.cu_lengths for s in samples])
+        cu_lengths_padded = torch.stack([s.cu_lengths_padded for s in samples])
+        max_lengths = torch.tensor([s.max_length for s in samples], dtype=torch.int32)
+        sample_lengths = torch.nn.utils.rnn.pad_sequence(
+            [s.sample_lengths.to(dtype=torch.int32) for s in samples],
+            batch_first=True,
+            padding_value=0,
+        )
+
+        if self.dataloader_seq_length is not None:
+            cu_lengths[0][-1] = self.dataloader_seq_length
+            cu_lengths_padded[0][-1] = self.dataloader_seq_length
+            new_max_length = cu_lengths_padded[0][-1] - cu_lengths[0][-2]
+            max_lengths = torch.max(max_lengths, new_max_length)
+
+        # Pad entire sequence to be a multiple of 16 if using fp8.
+        if has_fp8:
+            total_seq_len = cu_lengths_padded[0][-1]
+            padding_needed = get_padding(
+                total_seq_len,
+                self.args.context_parallel_size,
+                self.args.tensor_model_parallel_size,
+                self.args.sequence_parallel,
+                self.args.tp_comm_overlap,
+                self.args.decoder_seq_length,
+                fp8_enabled=has_fp8,
+            )
+            if padding_needed > 0:
+                tokens = torch.cat(
+                    [
+                        tokens,
+                        torch.full(
+                            (tokens.shape[0], padding_needed), self.tokenizer.pad, dtype=torch.int64
+                        ),
+                    ],
+                    dim=1,
+                )
+                labels = torch.cat(
+                    [
+                        labels,
+                        torch.full(
+                            (labels.shape[0], padding_needed), IGNORE_INDEX, dtype=torch.int64
+                        ),
+                    ],
+                    dim=1,
+                )
+                cu_lengths[0][-1] += padding_needed
+                cu_lengths_padded[0][-1] += padding_needed
+                new_max_length = cu_lengths_padded[0][-1] - cu_lengths[0][-2]
+                max_lengths = torch.max(max_lengths, new_max_length)
+
+        return BatchedPackedTaskSample(
+            __key__=[s.__key__ for s in samples],
+            __restore_key__=[s.__restore_key__ for s in samples],
+            __subflavors__=samples[0].__subflavors__,
+            tokens=tokens,
+            labels=labels,
+            imgs=imgs,
+            num_tiles=num_tiles,
+            num_frames=num_frames,
+            cu_lengths=cu_lengths,
+            cu_lengths_padded=cu_lengths_padded,
+            max_lengths=max_lengths,
+            imgs_sizes=imgs_sizes,
+            vision_cu_lengths=vision_cu_lengths,
+            vision_max_lengths=vision_max_lengths,
+            has_pad_img=has_pad_img,
+            samples_seen=sum(s.samples_seen for s in samples),
+            sample_lengths=sample_lengths,
+        )
+
+    def encode_batch(self, batch: BatchedPackedTaskSample) -> dict:
+        return dataclasses.asdict(batch)
+
+    def _decode_video_frames_with_energon(
+        self,
+        av_decoder: AVDecoder,
+        targets: list[float],
+        *,
+        thread_count: int = 0,
+    ) -> list[Image.Image]:
+        """Use Energon's seek policy with optional worker-local codec threads."""
+        if thread_count < 0:
+            raise ValueError("video_decode_thread_count must be non-negative")
+        if not targets:
+            return []
+
+        def get_clips():
+            return av_decoder.get_clips(
+                video_clip_ranges=[(timestamp, timestamp) for timestamp in targets],
+                video_unit="seconds",
+            )
+
+        if thread_count == 0:
+            frame_clips = get_clips()
+        else:
+            # Patch only the worker-local container open while preserving
+            # Energon's indexing, seeking, and frame-selection behavior.
+            decoder_module = importlib.import_module(AVDecoder.__module__)
+            with _ENERGON_AV_OPEN_LOCK:
+                original_av_open = getattr(decoder_module, "av_open", None)
+                if not callable(original_av_open):
+                    frame_clips = get_clips()
+                else:
+
+                    def threaded_av_open(*args, **kwargs):
+                        container = original_av_open(*args, **kwargs)
+                        try:
+                            for media_stream in container.streams:
+                                if media_stream.type != "video":
+                                    continue
+                                codec_context = media_stream.codec_context
+                                if codec_context is None:
+                                    continue
+                                codec_context.thread_type = "FRAME"
+                                codec_context.thread_count = thread_count
+                        except Exception:
+                            container.close()
+                            raise
+                        return container
+
+                    decoder_module.av_open = threaded_av_open
+                    try:
+                        frame_clips = get_clips()
+                    finally:
+                        decoder_module.av_open = original_av_open
+
+                    # Some codecs retain delayed frames with FRAME threading.
+                    # Retry only that video through the exact unthreaded path.
+                    if len(frame_clips.video_clips) < len(targets):
+                        frame_clips = get_clips()
+
+        images = [tensor_to_pil(image[0]) for image in frame_clips.video_clips]
+        if not images:
+            raise ValueError("Unable to decode video frames: Energon returned no frames")
+        if len(images) < len(targets):
+            images.extend([images[-1]] * (len(targets) - len(images)))
+        return images
+
+    def _decode_video_frames(
+        self, av_decoder: AVDecoder, targets: list[float]
+    ) -> list[Image.Image]:
+        """Decode target frames with Energon-exact worker-local frame threads."""
+        thread_count = int(getattr(self.args, "video_decode_thread_count", 8))
+        return self._decode_video_frames_with_energon(
+            av_decoder, targets, thread_count=thread_count
+        )
+
+    def _load_media(self, sample: PreEncodedTaskSample) -> None:
+        """Loads all lazy media in the sample."""
+        if len(sample.images) > 1:
+            medias: dict[Lazy[AVDecoder] | Lazy[Image.Image], list[ImageTilingParams]] = (
+                defaultdict(list)
+            )
+            # Group by video and frame index
+            for media in sample.images:
+                # video is a Lazy[AVDecoder] (it's hashable, all pointing to the same file are the same object)
+                medias[media.media.value].append(media)
+
+            for media, frames in medias.items():
+                media_value = media.get(sample)
+                if isinstance(media_value, (tuple, list)):
+                    media_value = media_value[0]
+                if isinstance(media_value, AVDecoder):
+                    media_value.suppress_warnings = True
+                    images = self._decode_video_frames(
+                        media_value, [frame.media.timestamp for frame in frames]
+                    )
+                    for frame, image in zip(frames, images):
+                        frame.media.value = image
+                elif isinstance(media_value, Image.Image):
+                    for frame in frames:
+                        frame.media.value = media_value
+                elif isinstance(media_value, str):
+                    # Text fragment
+                    pass
+                elif isinstance(media_value, bytes):
+                    raise ValueError(
+                        f"Unable to parse bytes as known media type: {media_value[:100]!r}"
+                    )
+                else:
+                    raise ValueError(f"Unexpected media type: {type(media_value)}. Media: {media}")
+        else:
+            for media in sample.images:
+                value = media.media.value.get(sample)
+                if isinstance(value, (tuple, list)):
+                    value = value[0]
+                media.media.value = value
+    @staticmethod
+    def _count_trainable_target_spans(target: torch.Tensor) -> int:
+        """Count contiguous non-ignored target regions."""
+        if target.numel() == 0:
+            return 0
+        trainable = target != IGNORE_INDEX
+        span_starts = trainable.clone()
+        span_starts[1:] = trainable[1:] & ~trainable[:-1]
+        return int(span_starts.sum().item())
+
+    @classmethod
+    def _validate_explicit_loss_target_spans(
+        cls, target: torch.Tensor, *, expected_span_count: int, sample_key: str, phase: str
+    ) -> None:
+        """Require every explicitly selected assistant target span to survive."""
+        actual_span_count = cls._count_trainable_target_spans(target)
+        if actual_span_count != expected_span_count:
+            raise ValueError(
+                "explicit assistant loss target span mismatch after "
+                f"{phase} for sample {sample_key}: expected "
+                f"{expected_span_count}, found {actual_span_count}"
+            )
+
+    def _group_video_frame_params_into_tubelets(
+        self, image_media: list, image_media_params: list, temporal_patch_size: int
+    ) -> list:
+        """
+        Group video frame params into tubelet params to match the number of IMAGE_TOKENs.
+
+        With temporal compression, we emit one IMAGE_TOKEN per tubelet (every T frames),
+        not per frame. This function groups the params accordingly, summing num_embeddings
+        for each tubelet.
+
+        Note: Because we ensure that the number of video frames is a multiple of T, it each group
+        is guaranteed to be from a unique video, even if there are multiple videos in the sample.
+
+        Args:
+            image_media: List of ImageMedia and VideoFrameMedia objects.
+            image_media_params: List of params, one per media item.
+            temporal_patch_size: Number of frames per tubelet (T).
+
+        Returns:
+            List of params with video frames grouped into tubelets.
+        """
+        # Phase 1: Build groups - map each index i in image_media to a group ID
+        # Images get their own group, video frames are grouped by tubelet (every T frames)
+        groups: list[list[int]] = []  # List of index lists, one per group
+
+        for i, media in enumerate(image_media):
+            if isinstance(media, VideoFrameMedia):
+                # Video frame: group by tubelet (every T frames)
+                if media.sample_index % temporal_patch_size == 0:
+                    # Start of a new tubelet
+                    groups.append([i])
+                else:
+                    # Continue current tubelet (add to last group)
+                    groups[-1].append(i)
+            else:
+                # Image: each gets its own group
+                groups.append([i])
+
+        # Phase 2: Create grouped params
+        # For video tubelets: use first frame's embeddings (E), NOT sum (T × E)
+        # Model groups T frames into 1 tubelet with E patches (features are T× larger, count is same)
+        grouped_params = []
+        for group_indices in groups:
+            # Use first item's params as base
+            base_params = image_media_params[group_indices[0]]
+
+            # Verify all items in the group have the same embeddings and tiles
+            # (all video frames in a tubelet should have same spatial size)
+            assert all(
+                [
+                    image_media_params[idx].num_embeddings == base_params.num_embeddings
+                    for idx in group_indices
+                ]
+            ), (
+                f"All items in the group must have the same num_embeddings: {group_indices}, "
+                f"got {[image_media_params[idx].num_embeddings for idx in group_indices]}"
+            )
+            assert all(
+                [
+                    image_media_params[idx].num_tiles == base_params.num_tiles
+                    for idx in group_indices
+                ]
+            ), f"All items in the group must have the same num_tiles: {group_indices}"
+
+            # Use first frame's embeddings (model produces E patches per tubelet, not T × E)
+            grouped_params.append(base_params)
+
+        return grouped_params
+
+    def _target_has_trainable_tokens(
+        self,
+        input_ids: torch.Tensor,
+        target: torch.Tensor,
+        image_tiling_params: list[ImageTilingParams],
+    ) -> bool:
+        """
+        Check if the target has trainable tokens.
+
+        Args:
+            input_ids: Input tokens.
+            target: Target tokens.
+            image_tiling_params: Image tiling parameters.
+        Returns:
+            True if the target has trainable tokens, False otherwise.
+        """
+        # Compute the loss mask based on extending the image tags with the proper
+        # number of image tokens, extracting the first self.args.decoder_seq_length tokens, and
+        # ensuring that some of these tokens have a loss mask > 0.
+        # Note that this is a bit hacky because we reproduce here parts of the logics which are in
+        # the model itself. Ideally, the data sampler would return the already processed inputs
+        # and targets to avoid this duplication.
+        expanded_target = target.clone()
+        expanded_target[input_ids == self.img_token_id] = self.img_token_id
+        expanded_target = self._replace_value_with_repetition(
+            expanded_target,
+            self.img_token_id,
+            torch.tensor([media.num_embeddings for media in image_tiling_params]),
+            IGNORE_INDEX,
+        )
+        loss_mask = torch.ones(expanded_target.size(), dtype=torch.float)
+        loss_mask[expanded_target == self.tokenizer.pad] = 0.0  # mask paddings
+        loss_mask[expanded_target == IGNORE_INDEX] = 0.0  # mask prompts
+        loss_mask = torch.cat((loss_mask[1:], torch.zeros((1,))))
+        loss_mask = loss_mask[: self.args.decoder_seq_length]
+        return torch.sum(loss_mask) > 0
+
+    def _replace_value_with_repetition(
+        self, arr: torch.Tensor, token_to_replace: int, num_repetition: torch.Tensor, new_token: int
+    ) -> torch.Tensor:
+        """
+        Replace every occurrence of value V in the input array with R repetitions of W.
+
+        Args:
+            arr: Input array to be modified
+            token_to_replace: Token to be replaced
+            num_repetition: Number of repetition of new token. Size must match the number of `token_to_replace` in the
+                input array.
+            new_token: New token to replace the `token_to_replace` with.
+
+        Returns:
+            Array: New array with token_to_replace replaced by num_repetition repetitions of new_token
+        """
+        assert torch.sum(arr == token_to_replace) == len(
+            num_repetition
+        ), "The number of tokens to replace must match the length of the tile tensor."
+
+        # Convert to list for easier manipulation
+        arr_list = arr.tolist()
+        result = []
+        idx = 0
+        for item in arr_list:
+            if item == token_to_replace:
+                # If the current item matches token_to_replace, add R copies of new_token
+                result.extend([new_token] * num_repetition[idx].item())
+                idx += 1
+            else:
+                # Otherwise, keep the original item
+                result.append(item)
+
+        return torch.tensor(result, dtype=arr.dtype, device=arr.device)
+
+    def _pad_for_context_parallel_and_fp8(
+        self,
+        input_ids: torch.Tensor,
+        target: torch.Tensor,
+        image_tiling_params: list[ImageTilingParams],
+    ) -> tuple[int, int, torch.Tensor, torch.Tensor]:
+        total_len = self._get_total_seq_length(input_ids, image_tiling_params)
+        total_len_padded = total_len
+        # With context parallel or sequence parallel, we need to pad individual sequences.
+        # However, with FP8, we need to only pad the entire sequence to be a multiple of 16.
+        if getattr(self.args, "context_parallel_size", 1) > 1 or self.args.sequence_parallel:
+            padding_needed = get_padding(
+                total_len,
+                self.args.context_parallel_size,
+                self.args.tensor_model_parallel_size,
+                self.args.sequence_parallel,
+                self.args.tp_comm_overlap,
+                self.args.decoder_seq_length,
+                fp8_enabled=False,
+            )
+            # Build padding directly on the token/label tensors' dtype and device;
+            # torch.ones(...)*value would create default float CPU tensors before cat().
+            padding1 = torch.full(
+                (padding_needed,),
+                self.tokenizer.pad,
+                dtype=input_ids.dtype,
+                device=input_ids.device,
+            )
+            padding2 = torch.full(
+                (padding_needed,), IGNORE_INDEX, dtype=target.dtype, device=target.device
+            )
+            input_ids = torch.cat([input_ids, padding1])
+            target = torch.cat([target, padding2])
+
+            # A100 doesn't support cu_seqlens != cu_seqlens_padded. hack=True forces them to be same.
+            # hack=False only supported on H100.
+            hack = True
+            if hack:
+                # Pad everything
+                total_len = total_len + padding_needed
+                total_len_padded = total_len
+            else:
+                # Pad only padding.
+                total_len_padded = total_len + padding_needed
+        return total_len, total_len_padded, input_ids, target
+
+    def _get_total_seq_length(
+        self,
+        input_ids: torch.Tensor,
+        image_tiling_params: list[ImageTilingParams],
+    ):
+        """Calculate expected sequence length given text tokens length and number of tiles."""
+        total_num_images = len(image_tiling_params)
+        total_num_image_embeddings = sum(media.num_embeddings for media in image_tiling_params)
+        total_len = len(input_ids) + total_num_image_embeddings - total_num_images
+        return total_len
+
+    def _truncate_to_decoder_seq_len(
+        self,
+        input_ids: torch.Tensor,
+        target: torch.Tensor,
+        image_tiling_params: list[ImageTilingParams],
+        sample_key: str = "",
+        sample_subflavors: dict | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Truncate tokens and labels if they exceed sequence length."""
+        total_img_embeddings_len = sum(media.num_embeddings for media in image_tiling_params)
+        total_num_images = len(image_tiling_params)
+        packing_seq_length = (
+            self.args.packing_seq_length
+            if self.args.packing_seq_length > 0
+            else self.args.decoder_seq_length
+        )
+        max_text_tokens = packing_seq_length - total_img_embeddings_len + total_num_images
+
+        truncated_input_ids = input_ids[:max_text_tokens]
+        truncated_target = target[:max_text_tokens]
+
+        assert len(truncated_input_ids) == len(
+            truncated_target
+        ), "Input and target must have the same length"
+        inputs_are_truncated = len(truncated_input_ids) < len(input_ids)
+        if self.args.dynamic_resolution_no_truncate and inputs_are_truncated:
+            raise ValueError(
+                "Truncation required but --dynamic-resolution-no-truncate is set, skipping sample: \n"
+                f"sample_key: {sample_key} \n"
+                f"sample_subflavors: {sample_subflavors} \n"
+                f"original input length: {len(input_ids)} \n"
+                f"truncated input length: {len(truncated_input_ids)} \n"
+                f"max_text_tokens: {max_text_tokens} \n"
+                f"total_img_embeddings_len: {total_img_embeddings_len} \n"
+                f"total_num_images: {total_num_images} \n"
+            )
+
+        # If truncate causes all labels to be ignored, then skip the sample
+        if len(truncated_target) == 0 or (truncated_target == IGNORE_INDEX).all():
+            raise NoTrainableTokensError(
+                "All targets will be ignored after truncation: \n"
+                f"original input: {input_ids} \n"
+                f"original target: {target} \n"
+                f"truncated input:  {truncated_input_ids} \n"
+                f"truncated target: {truncated_target} \n"
+                f"max_text_tokens: {max_text_tokens} \n"
+                f"total_img_embeddings_len: {total_img_embeddings_len} \n"
+                f"total_num_images: {total_num_images} \n"
+            )
+
+        return truncated_input_ids, truncated_target
+
+
+tensor_to_pil = ToPILImage()

--- a/examples/multimodal/dataloader_provider.py
+++ b/examples/multimodal/dataloader_provider.py
@@ -1,93 +1,127 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 import os
+from typing import Any
 
 import torch
-from dataset_helpers import TaskEncoder, print_error_handler
+from data_loading.task_encoder import MultiModalTaskEncoder
+from dataloader_resume import (
+    is_initial_checkpoint_load_without_dataloader_state,
+    should_strictly_load_dataloader_state,
+)
+from dataset_helpers import TaskEncoder
 
 from megatron.core import parallel_state
 from megatron.core.num_microbatches_calculator import get_num_microbatches
 from megatron.core.parallel_state import (
+    get_context_parallel_rank,
     get_pipeline_model_parallel_rank,
     get_pipeline_model_parallel_world_size,
     get_tensor_model_parallel_rank,
 )
 from megatron.energon import (
+    FileStoreCachePool,
     LimitDataset,
     RepeatDataset,
+    SourceInfo,
     WorkerConfig,
     get_loader,
     get_savable_loader,
     get_train_dataset,
     get_val_datasets,
 )
+from megatron.energon.errors import log_exception
 from megatron.training import get_args
 from megatron.training.checkpointing import get_checkpoint_name
 
 
-def datasets_provider(task_encoder,worker_config=None):
+def use_new_dataloader_path():
+    args = get_args()
+    return args.packing_buffer_size is not None or getattr(args, "use_new_dataloader_path", False)
+
+
+def datasets_provider(task_encoder, worker_config=None):
     """Create multimodal train, validation and test datasets."""
     args = get_args()
+
+    if use_new_dataloader_path():
+        train_task_encoder = MultiModalTaskEncoder()
+        val_task_encoder = MultiModalTaskEncoder(is_val=True)
+    else:
+        train_task_encoder = TaskEncoder()
+        val_task_encoder = TaskEncoder()
 
     dname = args.data_path[0] if type(args.data_path) is list else args.data_path
     train_dataset = get_train_dataset(
         dname,
         batch_size=args.micro_batch_size,
-        task_encoder=task_encoder,
-        virtual_epoch_length=1000,
+        task_encoder=train_task_encoder,
         max_samples_per_sequence=100,
         shuffle_buffer_size=100,
         worker_config=worker_config,
         packing_buffer_size=args.packing_buffer_size,
-        handler=print_error_handler,
-        image_decode="pil",
     )
 
-    val_datasets = get_val_datasets(
-        dname,
-        batch_size=args.micro_batch_size,
-        # This is the total number over all workers
-        # limit=args.eval_iters * get_num_microbatches(),
-        task_encoder=task_encoder,
-        worker_config=worker_config,
-        packing_buffer_size=args.packing_buffer_size,
-        handler=print_error_handler,
-        image_decode="pil",
-    )
-    val_datasets_without_source_datasets = [
-        # Limit the dataset to eval_iters * num_microbatches
-        LimitDataset(
-            # Repeat the inner dataset in case it's too short
-            RepeatDataset(val_ds, worker_config=worker_config),
-            length=args.eval_iters * get_num_microbatches(),
+    val_datasets_without_source_datasets = None
+    if args.eval_iters > 0:
+        val_datasets = get_val_datasets(
+            dname,
+            batch_size=args.micro_batch_size,
+            # This is the total number over all workers
+            # limit=args.eval_iters * get_num_microbatches(),
+            task_encoder=val_task_encoder,
             worker_config=worker_config,
-            reset_after_epoch=True,
+            # TODO: Currently disabled for val, there is no non-packed val dataset yet.
+            # packing_buffer_size=args.packing_buffer_size,
+            packing_buffer_size=None,
         )
-        for val_ds, _src_ds in val_datasets
-    ]
+        val_datasets_without_source_datasets = [
+            # Limit the dataset to eval_iters * num_microbatches
+            LimitDataset(
+                # Repeat the inner dataset in case it's too short
+                RepeatDataset(val_ds, worker_config=worker_config),
+                length=args.eval_iters * get_num_microbatches(),
+                worker_config=worker_config,
+                reset_after_epoch=True,
+            )
+            for val_ds, _src_ds in val_datasets
+        ]
 
     return train_dataset, val_datasets_without_source_datasets, None
 
 
-def is_first_or_last_stage(pp_size):
+def is_first_or_last_stage(pp_size, encoder_pipeline_model_parallel_size):
     """Check if the current pipeline parallel stage is the first or last stage."""
-    if pp_size == 1:    # No pipeline parallelism.
+    if pp_size == 1:  # No pipeline parallelism.
         return True
 
-    # With no separate pipeline stage for the vision model (epp=0), 
-    # run the dataloader on the first and last pipeline stage.
+    is_valid_rank = False
     pp_rank = get_pipeline_model_parallel_rank()
-    is_valid_rank = pp_rank in (0, pp_size-1)
+    if encoder_pipeline_model_parallel_size == 0:
+        # No separate pipeline stage for the vision model. Run the dataloader on the first and last pipeline stage.
+        is_valid_rank = pp_rank in (0, pp_size - 1)
+    elif encoder_pipeline_model_parallel_size == 1:
+        # Separate pipeline stage for the vision model. Run the dataloader on the first vision and LM stage and last LM stage.
+        is_valid_rank = pp_rank in (0, 1, pp_size - 1)
+    else:
+        raise NotImplementedError("encoder-pipeline-model-parallel-size > 1 is not supported yet")
 
     return is_valid_rank
 
 
-def is_dataloader_rank():
+def is_dataloader_rank(
+    encoder_pipeline_model_parallel_size,
+    deduplicate_across_context_parallel=False,
+):
     """Check if we should have the dataloader on this tensor and pipeline parallel rank."""
     # Run dataloader only on the first tensor parallel rank (will be broadcasted to others).
     is_first_rank = get_tensor_model_parallel_rank() == 0
+    if deduplicate_across_context_parallel:
+        is_first_rank = is_first_rank and get_context_parallel_rank() == 0
 
     pp_size = get_pipeline_model_parallel_world_size()
-    is_first_rank = is_first_rank and is_first_or_last_stage(pp_size)
+    is_first_rank = is_first_rank and is_first_or_last_stage(
+        pp_size, encoder_pipeline_model_parallel_size
+    )
 
     return is_first_rank
 
@@ -95,12 +129,24 @@ def is_dataloader_rank():
 def train_valid_test_dataloaders_provider(train_val_test_num_samples, task_encoder=None):
     """Build multimodal train, validation and test dataloaders."""
     args = get_args()
-    
+
+    dataloader_prefetch_factor = getattr(args, "dataloader_prefetch_factor", 8)
+    if dataloader_prefetch_factor <= 0:
+        raise ValueError(
+            "--dataloader-prefetch-factor must be positive, "
+            f"got {dataloader_prefetch_factor}"
+        )
+
     if task_encoder is None:
         task_encoder = TaskEncoder()
 
     # Dataloader is only on specific ranks.
-    if not is_dataloader_rank():
+    if not is_dataloader_rank(
+        getattr(args, "encoder_pipeline_model_parallel_size", 0),
+        deduplicate_across_context_parallel=getattr(
+            args, "deduplicate_dataloader_across_context_parallel", False
+        ),
+    ):
         return None, None, None
 
     worker_debug_path = None
@@ -117,33 +163,97 @@ def train_valid_test_dataloaders_provider(train_val_test_num_samples, task_encod
         data_parallel_group=data_parallel_group,
         worker_debug_path=worker_debug_path,
         worker_log_level=worker_log_level,
+        seed_offset=args.dataloader_seed,
+        global_error_handler=compact_sample_error_handler,
+        restore_error_handler=compact_sample_error_handler,
     )
     train_ds, valid_ds1, test_ds = datasets_provider(task_encoder, worker_config)
 
-    train_dataloader = get_savable_loader(train_ds, worker_config=worker_config)
+    if use_new_dataloader_path():
+        prefetch_kwargs = {}
+        if args.num_workers > 0:
+            prefetch_kwargs["prefetch_factor"] = dataloader_prefetch_factor
+        train_dataloader = get_savable_loader(
+            train_ds,
+            cache_pool=FileStoreCachePool(
+                num_workers=8,
+                # max_cache_size_gbytes=8,
+                method="raw",
+            ),
+            watchdog_timeout_seconds=5 * 60,
+            watchdog_initial_timeout_seconds=5 * 60 + (args.packing_buffer_size or 0) * 0.0075,
+            **prefetch_kwargs,
+        )
+    else:
+        train_dataloader = get_savable_loader(train_ds, worker_config=worker_config)
+
     if args.load is not None:
         if getattr(args, "dataloader_save", None):
             dp_rank = parallel_state.get_data_parallel_rank()
+            strict_load = should_strictly_load_dataloader_state(args)
             data_save_name = get_checkpoint_name(
                 args.dataloader_save,
                 args.iteration,
-                pipeline_rank=0,    # Only the first pipeline parallel rank stores the dataloader checkpoint.
+                expert_parallel=False,
+                pipeline_rank=0,  # Only the first pipeline parallel rank stores the dataloader checkpoint.
                 basename=f"train_dataloader_dprank{dp_rank:03d}.pt",
             )
-            if os.path.exists(data_save_name):
+            if not os.path.exists(data_save_name):
+                if is_initial_checkpoint_load_without_dataloader_state(args):
+                    if dp_rank == 0:
+                        print(
+                            f"Dataset state {data_save_name} does not exist for the initial "
+                            "checkpoint load; starting the dataloader from the beginning."
+                        )
+                elif strict_load:
+                    raise FileNotFoundError(
+                        f"Dataset state {data_save_name} does not exist; refusing to resume "
+                        "without dataloader state."
+                    )
+                elif dp_rank == 0:
+                    print(
+                        f"Dataset state {data_save_name} does not exist; continuing without "
+                        "restoring dataloader state."
+                    )
+            else:
                 try:
-                    dataset_state_dict = torch.load(data_save_name, map_location="cpu")
+                    dataset_state_dict = torch.load(
+                        data_save_name, map_location="cpu", weights_only=False
+                    )
                     train_dataloader.restore_state_rank(dataset_state_dict["dataloader_state_dict"])
                     print(f"restored dataset state from {data_save_name}")
                 except Exception as e:
-                    print("loading dataset state failed. Skipping. " + str(e))
-            else:
-                print(f"dataset state {data_save_name} does not exist")
+                    if strict_load:
+                        raise RuntimeError(
+                            f"Failed to restore dataloader state from {data_save_name}"
+                        ) from e
+                    if dp_rank == 0:
+                        print(
+                            f"Failed to restore dataloader state from {data_save_name}: {e}. "
+                            "Continuing without restoring dataloader state."
+                        )
 
-    valid_dataloader = [
-        EnergonDataloader(get_loader(valid_ds, worker_config=worker_config))
-        for valid_ds in valid_ds1
-    ]
+    valid_dataloader = None
+    if valid_ds1 is not None:
+        if use_new_dataloader_path():
+            valid_dataloader = [
+                EnergonDataloader(
+                    get_loader(
+                        valid_ds,
+                        cache_pool=FileStoreCachePool(method="raw"),
+                        watchdog_initial_timeout_seconds=5 * 60
+                        + (args.packing_buffer_size or 0) * 0.0075,
+                        watchdog_timeout_seconds=5 * 60,
+                    )
+                )
+                for valid_ds in valid_ds1
+            ]
+        else:
+            valid_dataloader = [
+                EnergonDataloader(get_loader(valid_ds, worker_config=worker_config))
+                for valid_ds in valid_ds1
+            ]
+
     test_dataloader = None
 
     return EnergonDataloader(train_dataloader), valid_dataloader, EnergonDataloader(test_dataloader)
@@ -151,6 +261,7 @@ def train_valid_test_dataloaders_provider(train_val_test_num_samples, task_encod
 
 class EnergonDataloader:
     """A wrapper to use Megatron Energon dataloader with the Megatron-LM training loop."""
+
     def __init__(self, dataloader):
         self._dataloader = dataloader
         self._iter = iter(cyclic_iter(dataloader))
@@ -169,3 +280,44 @@ def cyclic_iter(iter):
     while True:
         for x in iter:
             yield x
+
+
+FIRST_TIME_EXCEPTION_INFO = False
+
+
+def compact_sample_error_handler(
+    exception: Exception, sample: Any | list[Any], sources: list[SourceInfo] | None = None
+) -> None:
+    """Compact sample error handler."""
+    global FIRST_TIME_EXCEPTION_INFO
+
+    if sources is not None:
+        import json
+        import urllib.parse
+
+        # Create an energon viewer url:
+        # vscode://nvidia.energon-sample-viewer/open?data=<URL-encoded-JSON>
+        data_obj = [
+            {
+                "dataset_path": str(source.dataset_path),
+                "index": source.index,
+                "shard_name": source.shard_name,
+                "file_names": list(source.file_names),
+            }
+            for source in sources
+        ]
+        url = f"vscode://nvidia.energon-sample-viewer/open?data={urllib.parse.quote(json.dumps(data_obj))}"
+    if isinstance(exception, AssertionError):
+        if sources is None:
+            print(f"Assertion error in sample {str(sample)[:100]}: {exception}")
+        else:
+            print(f"Assertion error: {exception}")
+            print(f"(Ctrl+)Click to view sample in energon viewer: {url}")
+            if FIRST_TIME_EXCEPTION_INFO:
+                print("Opening the sample requires the Energon sample viewer extension for VS Code.")
+                FIRST_TIME_EXCEPTION_INFO = False
+    else:
+        import traceback
+
+        print(f"Ignoring error processing sample:")
+        traceback.print_exc()

--- a/examples/multimodal/dataloader_resume.py
+++ b/examples/multimodal/dataloader_resume.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+
+def is_initial_checkpoint_load_without_dataloader_state(args: object) -> bool:
+    """Return whether model weights are being loaded to start a fresh training run."""
+    return getattr(args, "iteration", None) == 0 and (
+        getattr(args, "finetune", False)
+        or getattr(args, "pretrained_checkpoint", None) is not None
+    )
+
+
+def should_strictly_load_dataloader_state(args: object) -> bool:
+    """Return whether missing or invalid dataloader state should fail the run."""
+    return getattr(args, "strict_dataloader_state_load", False)

--- a/examples/multimodal/dataset_helpers.py
+++ b/examples/multimodal/dataset_helpers.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 import bisect
 import dataclasses
+import functools
 import json
 import re
 import sys
@@ -8,13 +9,19 @@ import traceback
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
-from image_processing import ImageTransform, find_closest_aspect_ratio, find_closest_area_weighted_aspect_ratio
-from PIL import Image
-from torchvision.transforms import ToPILImage
 import numpy as np
 import torch
-
+from einops import rearrange
 from energon_util import OfflineTargetAspectRatioSample, SampleListSample
+from image_processing import (
+    ImageTransform,
+    find_closest_area_weighted_aspect_ratio,
+    find_closest_aspect_ratio,
+    process_images,
+)
+from PIL import Image
+from torchvision.transforms import ToPILImage
+
 from megatron.core.models.multimodal.context_parallel import get_padding
 from megatron.core.models.multimodal.llava_model import IGNORE_INDEX, IMAGE_TOKEN, VIDEO_TOKEN
 from megatron.core.models.vision.clip_vit_model import get_num_image_embeddings
@@ -22,11 +29,11 @@ from megatron.energon import (
     Batch,
     CaptioningSample,
     DefaultTaskEncoder,
+    MultiChoiceVQASample,
     OCRSample,
     Sample,
     SimilarityInterleavedSample,
     VQASample,
-    MultiChoiceVQASample
 )
 from megatron.energon.task_encoder.base import stateless
 from megatron.training import get_args, get_tokenizer
@@ -43,6 +50,7 @@ class ImageTaskSample(Sample):
     num_tiles: List[int]
     tokens: torch.Tensor
     total_len: int  # Total token count in the sample, including text and image tokens
+    total_len_padded: int  # Total padded token count in the sample.
     labels: torch.Tensor = None
 
 
@@ -50,21 +58,26 @@ class ImageTaskSample(Sample):
 class ImageTaskSamplePacked(Sample):
     """Dataclass to store a single packed sample (not a batch).
 
-        P = Number of sub-samples in the packed sample
-        seq_len = Total sequence length
-        num_imgs = Number of images across all samples in the packed sample
+    P = Number of sub-samples in the packed sample
+    seq_len = Total sequence length
+    num_imgs = Number of images across all samples in the packed sample
     """
 
-    __key__: str    # Sample name
+    __key__: str  # Sample name
     __restore_key__: Tuple[Union[str, int, tuple], ...]
-    __subflavor__: Dict     # Sample metadata. Deprecated.
-    __subflavors__: Dict    # Sample metadata.
+    __subflavor__: Dict  # Sample metadata. Deprecated.
+    __subflavors__: Dict  # Sample metadata.
     tokens: torch.Tensor  # Input tokens packed into a single tensor (seq_len,)
-    labels: torch.Tensor # Target tokens packed into a single tensor (seq_len,)
-    imgs: List[torch.Tensor]    # Input images
+    labels: torch.Tensor  # Target tokens packed into a single tensor (seq_len,)
+    imgs: List[torch.Tensor]  # Input images
     num_tiles: List[int]  # Number of tiles for each image of each sample (num_imgs)
-    max_length: int    # Maximum length across sub-samples.
-    cu_lengths: List[int]  # Cumulative length of each sub-sample in this packed sample incl. text and image tokens (P,)
+    max_length: int  # Maximum length across sub-samples.
+    cu_lengths: List[
+        int
+    ]  # Cumulative length of each sub-sample in this packed sample incl. text and image tokens (P,)
+    cu_lengths_padded: List[
+        int
+    ]  # Cumulative padded length of each sub-sample in this packed sample incl. text and image tokens (P,)
 
 
 # Typing for the resulting batch data after encode_batch()
@@ -72,23 +85,31 @@ class ImageTaskSamplePacked(Sample):
 class ImageTaskBatchPacked(Batch):
     """Dataclass to store a batch of packed samples.
 
-        N = Batch size
-        P = Number of samples in the packed sample
-        seq_len = Maximum sequence length
-        num_imgs = Number of images across all samples in the packed sample
+    N = Batch size
+    P = Number of samples in the packed sample
+    seq_len = Maximum sequence length
+    num_imgs = Number of images across all samples in the packed sample
     """
 
     __key__: List[str]  # Sample names
     __restore_key__: Tuple[Union[str, int, tuple], ...]
-    __subflavor__: Dict     # Sample metadata. Deprecated.
+    __subflavor__: Dict  # Sample metadata. Deprecated.
     __subflavors__: List[Dict]  # Sample metadatas.
     tokens: torch.Tensor  # Input tokens packed and padded (N, seq_len)
-    labels: torch.Tensor # Target tokens packed and padded (N, seq_len)
+    labels: torch.Tensor  # Target tokens packed and padded (N, seq_len)
     imgs: torch.Tensor  # All image tiles stacked into a single tensor (num_tiles, C, H, W)
     num_tiles: List[List[int]]  # Number of tiles per image (N, num_imgs)
     max_lengths: List[int]  # Maximum length across sub-samples (N,)
-    cu_lengths: List[List[int]]  # Cumulative length of each sub-sample in each packed sample of the batch (N, P)
-
+    cu_lengths: List[
+        List[int]
+    ]  # Cumulative length of each sub-sample in each packed sample of the batch (N, P)
+    cu_lengths_padded: List[
+        List[int]
+    ]  # Cumulative padded length of each sub-sample in each packed sample of the batch (N, P)
+    imgs_sizes: List[Tuple[int, int]]
+    vision_max_lengths: List[int]
+    vision_cu_lengths: List[List[int]]
+    has_pad_img: bool
 
 # Based on https://github.com/hiyouga/LLaMA-Factory/blob/641d0dab08d96a93c34657742213d8994d9ed476/src/llamafactory/data/processors/processor_utils.py#L19
 # Copyright (c) 2024 LLaMA-Factory. Apache license 2.0.
@@ -120,7 +141,9 @@ def greedy_knapsack(item_sizes: List[int], samples: List, max_capacity: int) -> 
 
     # Check if all samples fit in the knapsack capacity.
     if sorted_item_sizes[-1] > max_capacity:
-        raise ValueError(f"knapsack: A sample is larger {sorted_item_sizes[-1]} than the max_sequence_length {max_capacity}.")
+        raise ValueError(
+            f"knapsack: A sample is larger {sorted_item_sizes[-1]} than the max_sequence_length {max_capacity}."
+        )
 
     while sorted_item_sizes:
         current_knapsack = []
@@ -129,7 +152,7 @@ def greedy_knapsack(item_sizes: List[int], samples: List, max_capacity: int) -> 
         while True:
             idx = search_for_fit(sorted_item_sizes, remaining_capacity)
             if idx == -1:
-                break   # Can't fit more samples.
+                break  # Can't fit more samples.
 
             remaining_capacity -= sorted_item_sizes[idx]
 
@@ -145,65 +168,188 @@ def greedy_knapsack(item_sizes: List[int], samples: List, max_capacity: int) -> 
 class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked, dict]):
     """A simple task encoder for VLMs."""
 
-    def __init__(
-        self
-    ):
+    @staticmethod
+    def _content_parts_from_image_tokens(content: str) -> List[Dict[str, str]]:
+        """Convert legacy structural IMAGE_TOKEN markers into tokenizer content parts."""
+        parts: List[Dict[str, str]] = []
+        segments = content.split(IMAGE_TOKEN)
+        for idx, segment in enumerate(segments):
+            if segment:
+                parts.append({"type": "text", "text": segment})
+            if idx < len(segments) - 1:
+                parts.append({"type": "image"})
+        return parts or [{"type": "text", "text": ""}]
+
+    def _content_with_image_slot(self, content: str) -> List[Dict[str, str]]:
+        if IMAGE_TOKEN in content:
+            return self._content_parts_from_image_tokens(content)
+        return [{"type": "image"}, {"type": "text", "text": "\n" + content}]
+
+    def _conversation_with_structured_image_parts(self, conversation: List[Dict]) -> List[Dict]:
+        structured_conversation = []
+        for turn in conversation:
+            content = turn["content"]
+            if turn["role"] == "user" and isinstance(content, str) and IMAGE_TOKEN in content:
+                turn = {**turn, "content": self._content_parts_from_image_tokens(turn["content"])}
+            structured_conversation.append(turn)
+        return structured_conversation
+
+    def __init__(self):
         super().__init__()
 
         self.args = get_args()
 
         self.tokenizer = get_tokenizer()
-        with open(self.args.prompt_path, "r") as f:
-            self.manual_prompts = json.load(f)
-        self.dataloader_seq_length = self.args.dataloader_seq_length  # Always return samples of this length.
-        self.packing_seq_length = self.args.packing_seq_length     # Packing sequence length, if packing is enabled.
-        self.is_packing_enabled = self.args.packing_buffer_size is not None and self.args.packing_buffer_size > 0
+        self.manual_prompts = {}
+        if self.args.prompt_path:
+            with open(self.args.prompt_path, "r") as f:
+                self.manual_prompts = json.load(f)
+        self.dataloader_seq_length = (
+            self.args.dataloader_seq_length
+        )  # Always return samples of this length.
+        self.packing_seq_length = (
+            self.args.packing_seq_length
+        )  # Packing sequence length, if packing is enabled.
+        self.is_packing_enabled = (
+            self.args.packing_buffer_size is not None and self.args.packing_buffer_size > 0
+        )
 
         if self.dataloader_seq_length and self.packing_seq_length:
-            assert self.dataloader_seq_length >= self.packing_seq_length, "dataloader sequence length must be greater than or equal to the packing sequence length"
+            assert (
+                self.dataloader_seq_length >= self.packing_seq_length
+            ), "dataloader sequence length must be greater than or equal to the packing sequence length"
 
         if self.is_packing_enabled:
             assert self.packing_seq_length > 0, "packing sequence length must be set"
 
         self.num_image_embeddings_per_tile = get_num_image_embeddings(
-            self.args.img_h,
-            self.args.img_w,
-            self.args.patch_dim,
-            self.args.vision_model_type,
-            self.args.disable_vision_class_token,
-            1,
-            self.args.pixel_shuffle,
-            self.args.use_tile_tags,
-            self.args.max_num_tiles,
-            self.args.tokenizer_prompt_format,
+            img_h=self.args.img_h,
+            img_w=self.args.img_w,
+            patch_dim=self.args.patch_dim,
+            vision_model_type=self.args.vision_model_type,
+            disable_vision_class_token=self.args.disable_vision_class_token,
+            class_token_len=1,
+            pixel_shuffle=self.args.pixel_shuffle,
+            use_tile_tags=self.args.use_tile_tags,
+            max_num_tiles=self.args.max_num_tiles,
+            tokenizer_type=self.args.tokenizer_prompt_format,
+        )
+
+        # Create a partial function with all the self.args parameters pre-filled
+        # Only img_h and img_w need to be specified when calling this function
+        self._get_num_image_embeddings = functools.partial(
+            get_num_image_embeddings,
+            patch_dim=self.args.patch_dim,
+            vision_model_type=self.args.vision_model_type,
+            disable_vision_class_token=self.args.disable_vision_class_token,
+            class_token_len=1,
+            pixel_shuffle=self.args.pixel_shuffle,
+            use_tile_tags=self.args.use_tile_tags,
+            max_num_tiles=self.args.max_num_tiles,
+            tokenizer_type=self.args.tokenizer_prompt_format,
         )
 
         self.txt_to_token_dict = {}
 
         self.img_h, self.img_w = self.args.img_h, self.args.img_w
-        self.img_token_id = self.tokenizer.convert_tokens_to_ids(IMAGE_TOKEN)
+        self.img_token_id = self.tokenizer.image_token_index
         # This map is used to reduce the number of tiles used per image if the number of tokens is
         # larger than the decoder_seq_length.
-        self.num_tiles_degradation_map = {12:8, 8:6, 6:4, 4:2, 2:1, 1:1}
+        self.num_tiles_degradation_map = {12: 8, 8: 6, 6: 4, 4: 2, 2: 1, 1: 1}
 
         self.find_closest_aspect_ratio_fn = (
-            find_closest_area_weighted_aspect_ratio if self.args.use_area_weighted_aspect_ratio
-            else find_closest_aspect_ratio)
+            find_closest_area_weighted_aspect_ratio
+            if self.args.use_area_weighted_aspect_ratio
+            else find_closest_aspect_ratio
+        )
 
-        self.transform_img = ImageTransform(self.img_h, self.args.vision_model_type)
+        self.transform_img = ImageTransform(
+            self.img_h,
+            self.args.vision_model_type,
+            dynamic_resolution=self.args.dynamic_resolution,
+            res_step=self.args.patch_dim,
+            min_num_patches=self.args.dynamic_resolution_min_patches,
+            max_num_patches=self.args.seq_length
+            - (
+                1 if not self.args.disable_vision_class_token else 0
+            ),  # TODO: handle class toekn length correctly(not just use 1)
+            pixel_shuffle=self.args.pixel_shuffle,
+            min_side=self.args.dynamic_resolution_min_side,
+            match_tiling_dynamic_resolution=self.args.match_tiling_dynamic_resolution,
+            masked_tiling_dynamic_resolution=getattr(
+                self.args, "masked_tiling_dynamic_resolution", False
+            ),
+            thumbnail_area_threshold=self.args.thumbnail_area_threshold,
+        )
 
-    def _get_total_seq_length(self, input_ids, num_tiles):
+    def _verify_no_temporal_compression(self):
+        """
+        This TaskEncoder is not updated to support these features, but we still construct it during
+        training setup even when using MultiModalTaskEncoder, enen though we don't use it. So we
+        have to check this during runtime.
+        """
+        # For tiling only, need a fixed number of embeddings for num_image_embeddings_per_tile
+        # We don't pass in `is_video` to calculate `self.num_image_embeddings_per_tile`,
+        # so we currently require no temporal compression because we can't verify the number of frames
+        video_temporal_patch_size = getattr(self.args, 'video_temporal_patch_size', 1)
+        if video_temporal_patch_size != 1:
+            raise NotImplementedError(
+                f"When using TaskEncoder, temporal compression is not supported."
+                f" Found video_temporal_patch_size={video_temporal_patch_size}."
+            )
+
+    def _get_total_seq_length(self, input_ids, num_tiles, imgs=None):
         """Calculate expected sequence length given text tokens length and number of tiles."""
-        total_num_images = len(num_tiles)
-        total_num_tiles = sum(num_tiles)
-        total_len = len(input_ids) + total_num_tiles * self.num_image_embeddings_per_tile - total_num_images
+        self._verify_no_temporal_compression()
+
+        if self.args.dynamic_resolution:
+            assert imgs is not None
+
+            img_seq_len = 0
+            img_idx = 0
+            # For dynamic resolution, we need to group embeddings by conceptual image
+            # since match tiling can return multiple tensors (main + thumbnail) per image
+            for num_tiles_for_image in num_tiles:
+                # Sum embeddings for all tiles/images belonging to this conceptual image
+                for _ in range(num_tiles_for_image):
+                    img_seq_len += self._get_num_image_embeddings(
+                        img_h=imgs[img_idx].shape[1], img_w=imgs[img_idx].shape[2]
+                    )
+                    img_idx += 1
+
+            total_len = len(input_ids) + img_seq_len - len(num_tiles)
+        else:
+            total_num_images = len(num_tiles)
+            total_num_tiles = sum(num_tiles)
+            total_len = (
+                len(input_ids)
+                + total_num_tiles * self.num_image_embeddings_per_tile
+                - total_num_images
+            )
         return total_len
 
-    def _truncate_for_packing(self, input_ids, target, num_tiles):
+    def _truncate_for_packing(self, input_ids, target, num_tiles, imgs):
         """Truncate tokens and labels if they exceed packing sequence length."""
+        self._verify_no_temporal_compression()
+
         total_num_images = len(num_tiles)
         total_num_tiles = sum(num_tiles)
-        total_img_embeddings_len = total_num_tiles * self.num_image_embeddings_per_tile
+        if self.args.dynamic_resolution:
+            assert imgs is not None
+
+            total_img_embeddings_len = 0
+            img_idx = 0
+            # For dynamic resolution, we need to group embeddings by conceptual image
+            # since match tiling can return multiple tensors (main + thumbnail) per image
+            for num_tiles_for_image in num_tiles:
+                # Sum embeddings for all tiles/images belonging to this conceptual image
+                for _ in range(num_tiles_for_image):
+                    total_img_embeddings_len += self._get_num_image_embeddings(
+                        img_h=imgs[img_idx].shape[1], img_w=imgs[img_idx].shape[2]
+                    )
+                    img_idx += 1
+        else:
+            total_img_embeddings_len = total_num_tiles * self.num_image_embeddings_per_tile
         max_text_tokens = self.packing_seq_length - total_img_embeddings_len + total_num_images
 
         input_ids = input_ids[:max_text_tokens]
@@ -216,27 +362,9 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         return input_ids, target
 
     @stateless(restore_seeds=True)
-    def encode_sample(self, sample: Union[CaptioningSample, OCRSample, VQASample, SimilarityInterleavedSample]):
-        if isinstance(sample, OCRSample):
-            if "pdfa" in sample.__key__:
-                yield self.combined_ocr_encoder(sample, task_type='encode_pdf')
-            elif "multi" in sample.__key__:
-                yield self.combined_ocr_encoder(sample, task_type='_encode_ocr')
-            else:
-                yield self.combined_ocr_encoder(sample, task_type='encode_ocr_ref')
-        elif isinstance(sample, CaptioningSample):
-            yield self.encode_captioning(sample)
-        elif isinstance(sample, VQASample):
-            is_llava_training = sample.__subflavors__["is_llava_training"] if "is_llava_training" in sample.__subflavors__ else False
-
-            if "llava" in sample.__key__ or is_llava_training:
-                yield self.encode_llava_pretrain(sample)
-            else:
-                yield self.encode_any_single_turn_vqa(sample)
-        elif isinstance(sample, SimilarityInterleavedSample):
+    def encode_sample(self, sample: Union[SimilarityInterleavedSample]):
+        if isinstance(sample, SimilarityInterleavedSample):
             yield self.encode_llava_sft(sample)
-        elif isinstance(sample, MultiChoiceVQASample):
-            yield self.encode_any_single_turn_vqa(sample)
         # Because the SampleListSample is defined in the Megatron module but loaded by the Energon
         # library, we need to resort to the more brittle check:
         elif type(sample).__name__ == "SampleListSample":
@@ -249,8 +377,14 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         augment = sample.__subflavors__.get("augmentation")
 
         imgs = self.transform_img(
-            sample.image, self.img_h, self.img_w, self.args.use_tiling, self.args.max_num_tiles, self.args.use_thumbnail, augment,
-            find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn
+            sample.image,
+            self.img_h,
+            self.img_w,
+            self.args.use_tiling,
+            self.args.max_num_tiles,
+            self.args.use_thumbnail,
+            augment,
+            find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn,
         )
         num_tiles = [len(imgs)]
 
@@ -258,7 +392,6 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
 
         prompt_idx = np.random.randint(len(prompt_list))
         cur_prompt = prompt_list[prompt_idx]
-        cur_prompt = IMAGE_TOKEN + "\n" + cur_prompt + "\n"
 
         caption = sample.caption.strip()
 
@@ -269,14 +402,17 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
 
         conv = [
             # Note: no system message.
-            {"role": "user", "content": cur_prompt},
+            {
+                "role": "user",
+                "content": [{"type": "image"}, {"type": "text", "text": "\n" + cur_prompt + "\n"}],
+            },
             {"role": "assistant", "content": caption},
         ]
 
         input_ids, target = self.tokenizer.tokenize_conversation(conv, True, False)
 
         if self.is_packing_enabled:
-            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles)
+            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles, imgs)
 
         return ImageTaskSample(
             __key__=sample.__key__,
@@ -287,7 +423,7 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             num_tiles=num_tiles,
             tokens=torch.tensor(input_ids),
             labels=torch.tensor(target),
-            total_len=self._get_total_seq_length(input_ids, num_tiles),
+            total_len=self._get_total_seq_length(input_ids, num_tiles, imgs),
         )
 
     def encode_llava_pretrain(self, sample: VQASample):
@@ -295,22 +431,32 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         augment = sample.__subflavors__.get("augmentation", False)
 
         imgs = self.transform_img(
-            sample.image, self.img_h, self.img_w, self.args.use_tiling, self.args.max_num_tiles, self.args.use_thumbnail, augment,
-            find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn
+            sample.image,
+            self.img_h,
+            self.img_w,
+            self.args.use_tiling,
+            self.args.max_num_tiles,
+            self.args.use_thumbnail,
+            augment,
+            find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn,
         )
         num_tiles = [len(imgs)]
 
         # LLAVA training: override text-prompt with just the image.
         conv = [
             # Note: no system message.
-            {"role": "user", "content": IMAGE_TOKEN + "\n"},
+            {"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "\n"}]},
             {"role": "assistant", "content": sample.answers},
         ]
 
         input_ids, target = self.tokenizer.tokenize_conversation(conv, True, False)
 
         if self.is_packing_enabled:
-            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles)
+            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles, imgs)
+
+        assert (
+            self._get_total_seq_length(input_ids, num_tiles, imgs) < self.args.decoder_seq_length
+        ), f"total sequence length {self._get_total_seq_length(input_ids, num_tiles, imgs)} needs to be less than {self.args.decoder_seq_length}"
 
         return ImageTaskSample(
             __key__=sample.__key__,
@@ -321,21 +467,27 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             num_tiles=num_tiles,
             tokens=torch.tensor(input_ids),
             labels=torch.tensor(target),
-            total_len=self._get_total_seq_length(input_ids, num_tiles),
+            total_len=self._get_total_seq_length(input_ids, num_tiles, imgs),
         )
 
     def encode_sample_list(self, samples: SampleListSample):
         """We encode the list of samples using encode_llava_sft on each sample."""
-        error_msg = ("You probably don't want to use online packing since SampleListSample is "
-                     "usually used along offline packing.")
+        error_msg = (
+            "You probably don't want to use online packing since SampleListSample is "
+            "usually used along offline packing."
+        )
         assert not self.is_packing_enabled, error_msg
         encoded_samples = []
         current_length = 0
         for idx, sample in enumerate(samples.samples):
             try:
-                encoded_sample = self.encode_llava_sft(sample, truncate_for_sample_list_packing=True)
+                encoded_sample = self.encode_llava_sft(
+                    sample, truncate_for_sample_list_packing=True
+                )
                 if current_length + encoded_sample.total_len > self.packing_seq_length:
-                    print(f"Encoding list of samples: stopped at {idx} samples to stick to {self.packing_seq_length}. Last sample key: {sample.__key__}")
+                    print(
+                        f"Encoding list of samples: stopped at {idx} samples to stick to {self.packing_seq_length}. Last sample key: {sample.__key__}"
+                    )
                     break
                 else:
                     encoded_samples.append(encoded_sample)
@@ -344,17 +496,34 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
                 print(e)
         return self.pack_selected_samples(encoded_samples)
 
-    def encode_llava_sft(self, sample: Union[SimilarityInterleavedSample, OfflineTargetAspectRatioSample], truncate_for_sample_list_packing=False):
+    def encode_llava_sft(
+        self,
+        sample: Union[SimilarityInterleavedSample, OfflineTargetAspectRatioSample],
+        truncate_for_sample_list_packing=False,
+    ):
         """Encode SFT sample."""
-        augment = sample.__subflavors__['augmentation'] if 'augmentation' in sample.__subflavors__ else False
-        has_video = sample.__subflavors__['has_video'] if 'has_video' in sample.__subflavors__ else False
+        self._verify_no_temporal_compression()
+
+        augment = (
+            sample.__subflavors__['augmentation']
+            if 'augmentation' in sample.__subflavors__
+            else False
+        )
+        has_video = (
+            sample.__subflavors__['has_video'] if 'has_video' in sample.__subflavors__ else False
+        )
 
         # If the target aspect ratio are provided by the dataset, we use them instead of computing
         # them with the self.find_closest_aspect_ratio_fn function.
         local_find_closest_aspect_ratio_fn = self.find_closest_aspect_ratio_fn
-        if type(sample).__name__ == "OfflineTargetAspectRatioSample" and len(sample.target_aspect_ratio) > 0:
+        if (
+            type(sample).__name__ == "OfflineTargetAspectRatioSample"
+            and len(sample.target_aspect_ratio) > 0
+        ):
             target_aspect_ratio = tuple(sample.target_aspect_ratio[0])
-            assert target_aspect_ratio is not None, "Sample of type OfflineTargetAspectRatioSample needs to define the target aspect ratio."
+            assert (
+                target_aspect_ratio is not None
+            ), "Sample of type OfflineTargetAspectRatioSample needs to define the target aspect ratio."
             local_find_closest_aspect_ratio_fn = lambda *args, **kwargs: target_aspect_ratio
 
         has_image = False
@@ -374,9 +543,12 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         for text in sample.texts:
             error_msg = f"unexpected role {text['from']} in {sample.texts}"
             assert text["from"] in ["human", "gpt"], error_msg
-            conversation.append({
-                "role": "user" if text["from"] == "human" else "assistant",
-                "content": text["value"]})
+            conversation.append(
+                {
+                    "role": "user" if text["from"] == "human" else "assistant",
+                    "content": text["value"],
+                }
+            )
 
         # Replace the image tags <image-idx> with IMAGE_TOKEN and count the number of image tags
         number_image_tags = 0
@@ -411,7 +583,8 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         number_of_images = 1 if has_video else len(sample.images)
         # Fail if there are more image or video tags than image or videos:
         error_msg = (
-            f"Found {number_image_tags} image tags for {number_of_images} images. {sample.texts}")
+            f"Found {number_image_tags} image tags for {number_of_images} images. {sample.texts}"
+        )
         assert number_image_tags <= number_of_images, error_msg
 
         # If there are less image of video tags than image or videos, prepend the tags to the first
@@ -419,10 +592,17 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         if number_image_tags < number_of_images:
             for turn in conversation:
                 if turn["role"] == "user":
-                    turn["content"] = IMAGE_TOKEN*(number_of_images-number_image_tags) + "\n" + turn["content"]
+                    turn["content"] = (
+                        IMAGE_TOKEN * (number_of_images - number_image_tags)
+                        + "\n"
+                        + turn["content"]
+                    )
                     break
 
-        input_ids, target = self.tokenizer.tokenize_conversation(conversation, True, False)
+        structured_conversation = self._conversation_with_structured_image_parts(conversation)
+        input_ids, target = self.tokenizer.tokenize_conversation(
+            structured_conversation, True, False
+        )
 
         if has_image:
             imgs = []
@@ -442,76 +622,111 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
                     # the number of tokens to a reasonable value.
                     if isinstance(img, torch.Tensor) or isinstance(img, np.ndarray):
                         if len(img.shape) == 4:
-                            assert img.shape[0] == 1, f"When len(img.shape) == 4, we expect the first dimension to be 1, but got img.shape: {img.shape} instead."
+                            assert (
+                                img.shape[0] == 1
+                            ), f"When len(img.shape) == 4, we expect the first dimension to be 1, but got img.shape: {img.shape} instead."
                             img = img[0]
                             use_tiling = False
                         to_pil = ToPILImage()
                         img = to_pil(img)
                     img_tiles = self.transform_img(
-                        img, self.img_h, self.img_w, self.args.use_tiling, max_num_tiles,
-                        self.args.use_thumbnail, augment, find_closest_aspect_ratio_fn=local_find_closest_aspect_ratio_fn)
+                        img,
+                        self.img_h,
+                        self.img_w,
+                        self.args.use_tiling,
+                        max_num_tiles,
+                        self.args.use_thumbnail,
+                        augment,
+                        find_closest_aspect_ratio_fn=local_find_closest_aspect_ratio_fn,
+                    )
                     imgs += img_tiles
                     num_tiles += [len(img_tiles)]
-                if max_num_tiles == 1:
+                if max_num_tiles == 1 or self.args.dynamic_resolution:
                     break
                 if sum(num_tiles) * self.num_image_embeddings_per_tile > max_image_token_allowed:
                     if max_num_tiles in self.num_tiles_degradation_map:
                         max_num_tiles = self.num_tiles_degradation_map[max_num_tiles]
                     else:
-                        raise RuntimeError((
-                            f"Tried to decrease the number of tiles {max_num_tiles} but it's not ",
-                            f"defined in the degradation map {self.num_tiles_degradation_map}"))
+                        raise RuntimeError(
+                            (
+                                f"Tried to decrease the number of tiles {max_num_tiles} but it's not ",
+                                f"defined in the degradation map {self.num_tiles_degradation_map}",
+                            )
+                        )
                 else:
                     break
         elif has_video:
             # We don't use tiling for videos to limit the number of tokens.
-            use_tiling=False
+            use_tiling = False
             # Grab the selected frames of the video as a tensor with shape
             # fhwc: (num_frames, num_channels, height, width).
             video_fchw = sample.images.frames
             if video_fchw.shape[0] == 0:
-                raise ValueError(f"Video {sample.__key__} {sample.__restore_key__} {sample.texts} has no frames.")
+                raise ValueError(
+                    f"Video {sample.__key__} {sample.__restore_key__} {sample.texts} has no frames."
+                )
             selected_frames = torch.linspace(
-                0, video_fchw.shape[0] - 1,
-                min(self.args.num_frames, video_fchw.shape[0])).long()
+                0, video_fchw.shape[0] - 1, min(self.args.num_frames, video_fchw.shape[0])
+            ).long()
             video_fchw = video_fchw[selected_frames]
             imgs = []
             for video_chw in video_fchw:
                 to_pil = ToPILImage()
                 video_chw = to_pil(video_chw)
                 imgs += self.transform_img(
-                    video_chw, self.img_h, self.img_w, use_tiling, self.args.max_num_tiles,
-                    self.args.use_thumbnail, augment, find_closest_aspect_ratio_fn=local_find_closest_aspect_ratio_fn)
+                    video_chw,
+                    self.img_h,
+                    self.img_w,
+                    use_tiling,
+                    self.args.max_num_tiles,
+                    self.args.use_thumbnail,
+                    augment,
+                    find_closest_aspect_ratio_fn=local_find_closest_aspect_ratio_fn,
+                )
             num_tiles = [len(imgs)]
         else:
             imgs = num_tiles = []
 
         if self.is_packing_enabled or truncate_for_sample_list_packing:
-            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles)
+            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles, imgs)
 
         # Some final checks with respect to the number of image tokens and images on the tokenized
         # conversation. There can still be errors, for instance if a non-video sample happens to
         # have our pre-defined video token, or if the packing truncation removed a necessary image
         # tag.
         number_image_token = np.sum(input_ids == self.img_token_id)
-        error_msg = (
-            f"Found {number_image_token} image tokens for len({num_tiles}) = {len(num_tiles)} image tiles in {conversation}.")
+        error_msg = f"Found {number_image_token} image tokens for len({num_tiles}) = {len(num_tiles)} image tiles in {conversation}."
         assert number_image_token == len(num_tiles), error_msg
-        error_msg = (
-            f"Found sum({num_tiles}) = {np.sum(num_tiles)} tiles for {len(imgs)} images in {conversation}.")
+        error_msg = f"Found sum({num_tiles}) = {np.sum(num_tiles)} tiles for {len(imgs)} images in {conversation}."
         assert np.sum(num_tiles) == len(imgs), error_msg
 
         # We need to ensure that there are at least some trainable tokens in the sample.
-        assert self.target_has_trainable_tokens(input_ids, num_tiles, target), "Sample has no trainable tokens."
+        assert self.target_has_trainable_tokens(
+            input_ids, num_tiles, target, imgs
+        ), "Sample has no trainable tokens."
 
-        # Context parallel requires padding.
-        total_len = self._get_total_seq_length(input_ids, num_tiles)
+        assert (
+            self._get_total_seq_length(input_ids, num_tiles, imgs) < self.args.decoder_seq_length
+        ), f"total sequence length {self._get_total_seq_length(input_ids, num_tiles, imgs)} needs to be less than {self.args.decoder_seq_length}"
+
+        # Context parallel and FP8 require padding.
+        # TODO: Total sample len and padded len are kept the same here.
+        # H100 and newer cuDNN versions can handle different values for them.
+        total_len = self._get_total_seq_length(input_ids, num_tiles, imgs)
+
+        # Individual samples need to be padded if using context parallel or sequence parallel.
+        # Here we don't pad for FP8 because only the final sequence needs to be padded. That is done in batch().
         has_cp = self.args.context_parallel_size > 1
-
-        if has_cp:
-            # Note: FP8 requires padding only the total sequence length.
-            # We pad for FP8 when we have the final, possibly packed sample.
-            padding_needed = get_padding(total_len, self.args.context_parallel_size, self.args.tensor_model_parallel_size, self.args.sequence_parallel, fp8_enabled=False)
+        if has_cp or self.args.sequence_parallel:
+            padding_needed = get_padding(
+                total_len,
+                self.args.context_parallel_size,
+                self.args.tensor_model_parallel_size,
+                self.args.sequence_parallel,
+                self.args.tp_comm_overlap,
+                self.args.decoder_seq_length,
+                fp8_enabled=False,
+            )
             padding_input = np.ones(padding_needed) * self.tokenizer.pad
             padding_labels = np.ones(padding_needed) * IGNORE_INDEX
             input_ids = np.concatenate([input_ids, padding_input])
@@ -527,10 +742,13 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             num_tiles=num_tiles,
             tokens=torch.tensor(input_ids),
             labels=torch.tensor(target),
-            total_len=self._get_total_seq_length(input_ids, num_tiles),
+            total_len=total_len,
+            total_len_padded=total_len,
         )
 
-    def target_has_trainable_tokens(self, input_ids, num_tiles, target):
+    def target_has_trainable_tokens(self, input_ids, num_tiles, target, imgs):
+        self._verify_no_temporal_compression()
+
         # Compute the loss mask based on extending the image tags with the proper
         # number of image tokens, extracting the first self.args.decoder_seq_length tokens, and
         # ensuring that some of these tokens have a loss mask > 0.
@@ -538,15 +756,32 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         # the model itself. Ideally, the data sampler would return the already processed inputs
         # and targets to avoid this duplication.
         expanded_target = target.copy()
-        expanded_target[input_ids==self.img_token_id] = self.img_token_id
+        expanded_target[input_ids == self.img_token_id] = self.img_token_id
+        if self.args.dynamic_resolution:
+            img_embeddings_len = []
+            img_idx = 0
+            # For dynamic resolution, we need to group embeddings by conceptual image
+            # since match tiling can return multiple tensors (main + thumbnail) per image
+            for num_tiles_for_image in num_tiles:
+                total_embeddings_for_image = 0
+                # Sum embeddings for all tiles/images belonging to this conceptual image
+                for _ in range(num_tiles_for_image):
+                    total_embeddings_for_image += self._get_num_image_embeddings(
+                        img_h=imgs[img_idx].shape[1], img_w=imgs[img_idx].shape[2]
+                    )
+                    img_idx += 1
+                img_embeddings_len.append(total_embeddings_for_image)
+        else:
+            img_embeddings_len = np.array(num_tiles) * self.num_image_embeddings_per_tile
+
         expanded_target = self.replace_value_with_repetition(
-            expanded_target, self.img_token_id,
-            self.num_image_embeddings_per_tile * np.array(num_tiles), IGNORE_INDEX)
+            expanded_target, self.img_token_id, img_embeddings_len, IGNORE_INDEX
+        )
         loss_mask = torch.ones(torch.tensor(expanded_target).size(), dtype=torch.float)
-        loss_mask[expanded_target == self.tokenizer.pad] = 0.0 # mask paddings
-        loss_mask[expanded_target == IGNORE_INDEX] = 0.0 # mask prompts
+        loss_mask[expanded_target == self.tokenizer.pad] = 0.0  # mask paddings
+        loss_mask[expanded_target == IGNORE_INDEX] = 0.0  # mask prompts
         loss_mask = torch.cat((loss_mask[1:], torch.zeros((1,))))
-        loss_mask = loss_mask[:self.args.decoder_seq_length]
+        loss_mask = loss_mask[: self.args.decoder_seq_length]
         return torch.sum(loss_mask) > 0
 
     def replace_value_with_repetition(self, arr, token_to_replace, num_repetition, new_token):
@@ -564,7 +799,7 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
              new_token
         """
         error_msg = "The number of image tokens must match the length of the tile tensor."
-        assert np.sum(arr==token_to_replace) == len(num_repetition), error_msg
+        assert np.sum(arr == token_to_replace) == len(num_repetition), error_msg
         result = []
         idx = 0
         for item in arr:
@@ -580,27 +815,45 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
 
     def encode_any_single_turn_vqa(self, sample):
         """Encode MultiChoiceVQA or VQA sample."""
-        augment = sample.__subflavors__['augmentation'] if 'augmentation' in sample.__subflavors__ else False
-        has_video = sample.__subflavors__['has_video'] if 'has_video' in sample.__subflavors__ else False
+        augment = (
+            sample.__subflavors__['augmentation']
+            if 'augmentation' in sample.__subflavors__
+            else False
+        )
+        has_video = (
+            sample.__subflavors__['has_video'] if 'has_video' in sample.__subflavors__ else False
+        )
 
         if has_video:
             # Grab the selected frames of the video as a tensor with shape
             # fhwc: (num_frames, height, width, num_channels).
             video_fhwc = sample.image.permute(0, 2, 3, 1)
             selected_frames = torch.linspace(
-                0, video_fhwc.shape[0] - 1, self.args.num_frames).long()
+                0, video_fhwc.shape[0] - 1, self.args.num_frames
+            ).long()
             video_frame_fhwc = video_fhwc[selected_frames]
             imgs = []
             for video_frame_hwc in video_frame_fhwc:
                 imgs += self.transform_img(
-                    video_frame_hwc, self.img_h, self.img_w,
-                    self.args.use_tiling, self.args.max_num_tiles,
-                    self.args.use_thumbnail, augment, find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn
+                    video_frame_hwc,
+                    self.img_h,
+                    self.img_w,
+                    self.args.use_tiling,
+                    self.args.max_num_tiles,
+                    self.args.use_thumbnail,
+                    augment,
+                    find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn,
                 )
         else:
             imgs = self.transform_img(
-                sample.image, self.img_h, self.img_w, self.args.use_tiling, self.args.max_num_tiles,
-                self.args.use_thumbnail, augment, find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn
+                sample.image,
+                self.img_h,
+                self.img_w,
+                self.args.use_tiling,
+                self.args.max_num_tiles,
+                self.args.use_thumbnail,
+                augment,
+                find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn,
             )
 
         num_tiles = [len(imgs)]
@@ -639,14 +892,14 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
 
         conversation = [
             {"role": "system", "content": "Answer the questions."},
-            {"role": "user", "content": cur_prompt},
+            {"role": "user", "content": self._content_with_image_slot(cur_prompt)},
             {"role": "assistant", "content": str(cur_answer)},
         ]
 
         input_ids, target = self.tokenizer.tokenize_conversation(conversation, True, False)
 
         if self.is_packing_enabled:
-            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles)
+            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles, imgs)
 
         return ImageTaskSample(
             __key__=sample.__key__,
@@ -657,12 +910,16 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             num_tiles=num_tiles,
             tokens=torch.tensor(input_ids),
             labels=torch.tensor(target),
-            total_len=self._get_total_seq_length(input_ids, num_tiles),
+            total_len=self._get_total_seq_length(input_ids, num_tiles, imgs),
         )
 
     def combined_ocr_encoder(self, sample, task_type):
         """Encode OCR samples."""
-        augment = sample.__subflavors__['augmentation'] if 'augmentation' in sample.__subflavors__ else False
+        augment = (
+            sample.__subflavors__['augmentation']
+            if 'augmentation' in sample.__subflavors__
+            else False
+        )
 
         if task_type == "encode_pdf":
             sample, cur_prompt, cur_answer = self.encode_pdf_prompt(sample)
@@ -672,21 +929,27 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             sample, cur_prompt, cur_answer = self.encode_ocr_prompt(sample)
 
         imgs = self.transform_img(
-                sample.image, self.img_h, self.img_w, self.args.use_tiling, self.args.max_num_tiles,
-                self.args.use_thumbnail, augment, find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn
-            )
+            sample.image,
+            self.img_h,
+            self.img_w,
+            self.args.use_tiling,
+            self.args.max_num_tiles,
+            self.args.use_thumbnail,
+            augment,
+            find_closest_aspect_ratio_fn=self.find_closest_aspect_ratio_fn,
+        )
         num_tiles = [len(imgs)]
 
         conversation = [
             {"role": "system", "content": "Answer the questions."},
-            {"role": "user", "content": cur_prompt},
+            {"role": "user", "content": self._content_with_image_slot(cur_prompt)},
             {"role": "assistant", "content": str(cur_answer)},
         ]
 
         input_ids, target = self.tokenizer.tokenize_conversation(conversation, True, False)
 
         if self.is_packing_enabled:
-            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles)
+            input_ids, target = self._truncate_for_packing(input_ids, target, num_tiles, imgs)
 
         return ImageTaskSample(
             __key__=sample.__key__,
@@ -697,7 +960,7 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             num_tiles=num_tiles,
             tokens=torch.tensor(input_ids),
             labels=torch.tensor(target),
-            total_len=self._get_total_seq_length(input_ids, num_tiles),
+            total_len=self._get_total_seq_length(input_ids, num_tiles, imgs),
         )
 
     def encode_pdf_prompt(self, sample: OCRSample) -> ImageTaskSample:
@@ -788,18 +1051,22 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
 
         return sample, cur_prompt, cur_answer
 
-    def batch(self, samples: List[Union[ImageTaskSample, ImageTaskSamplePacked]]) -> ImageTaskBatchPacked:
+    def batch(
+        self, samples: List[Union[ImageTaskSample, ImageTaskSamplePacked]]
+    ) -> ImageTaskBatchPacked:
         # Stack images to [num_tiles, c, h, w]. If there are no images (text-only), then use a dummy image.
         imgs = [img for s in samples for img in s.imgs]
-        if len(imgs) > 0:
-            imgs = torch.stack(imgs)
-        else:
-            imgs = torch.tensor([[0]], dtype=torch.float32)
+
+        if len(imgs) > 0 and self.args.dynamic_resolution:
+            assert "radio" in self.args.vision_model_type or self.args.vision_model_type in [
+                "clip",
+                "siglip",
+            ], "Dynamic resolution currently only works with radio or clip/siglip"
 
         # If the user hasn't defined a target dataloader sequence length, then use the max along the sample lengths.
         max_seq_len = self.dataloader_seq_length
         if not max_seq_len:
-           max_seq_len = max(len(s.tokens) for s in samples)
+            max_seq_len = max(len(s.tokens) for s in samples)
 
         tokens = torch.full((len(samples), max_seq_len), self.tokenizer.pad, dtype=torch.int64)
         # +1 to accommodate shift to left by one later.
@@ -808,45 +1075,109 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         for i, s in enumerate(samples):
             # If the sample/target length exceeds the target sequence length, then truncate.
             text_len = min(max_seq_len, len(s.tokens))
-            target_len = min(max_seq_len+1, len(s.labels))
+            target_len = min(max_seq_len + 1, len(s.labels))
 
             tokens[i, :text_len] = s.tokens[:text_len]
             labels[i, :target_len] = s.labels[:target_len]
 
         num_tiles = torch.tensor([n for s in samples for n in s.num_tiles], dtype=torch.int32)
+
+        total_seq_len = self._get_total_seq_length(tokens[0], num_tiles, imgs)
+
         if len(num_tiles) == 0:
             num_tiles = torch.tensor([[0]], dtype=torch.int32)
 
+        # Pad image packed seq length to be % 16 if using fp8 and dynamic resolution
+        has_fp8 = self.args.fp8 is not None
+        has_pad_img = torch.tensor(False)
+        # TODO: Context parallel currently requires padding per CP rank so we do it later if needed.
+        no_cp = self.args.context_parallel_size == 1
+
+        if has_fp8 and self.args.dynamic_resolution and no_cp:
+            img_seq_len = 0
+            for img in imgs:
+                img_seq_len += (img.shape[1] // self.args.patch_dim) * (
+                    img.shape[2] // self.args.patch_dim
+                )
+            padding_needed = get_padding(
+                img_seq_len,
+                self.args.context_parallel_size,
+                self.args.tensor_model_parallel_size,
+                self.args.sequence_parallel,
+                self.args.tp_comm_overlap,
+                self.args.decoder_seq_length,
+                fp8_enabled=has_fp8,
+            )
+            if padding_needed > 0:
+                pad_img = torch.zeros(
+                    [3, self.args.patch_dim, padding_needed * self.args.patch_dim]
+                )
+                imgs.append(pad_img)
+                has_pad_img = torch.tensor(True)
+
+        imgs, imgs_sizes, vision_cu_lengths, vision_max_lengths = process_images(
+            imgs, self.args.patch_dim, self.args.dynamic_resolution, batch_mode=True
+        )
+
+        # Set default values if no vision metadata was returned (static resolution case)
+        if vision_cu_lengths is None:
+            vision_cu_lengths = torch.tensor([[0]], dtype=torch.int32)
+        if vision_max_lengths is None:
+            vision_max_lengths = torch.tensor([[0]], dtype=torch.int32)
+
         # Cumulative sample lengths are needed for packing, otherwise use dummy values.
         cu_lengths = torch.tensor([[0]], dtype=torch.int32)
+        cu_lengths_padded = torch.tensor([[0]], dtype=torch.int32)
         max_lengths = torch.tensor([[0]], dtype=torch.int32)
 
         is_packed = isinstance(samples[0], ImageTaskSamplePacked)
-
         if is_packed:
             cu_lengths = torch.stack([s.cu_lengths for s in samples])
+            cu_lengths_padded = torch.stack([s.cu_lengths_padded for s in samples])
             max_lengths = torch.tensor([s.max_length for s in samples], dtype=torch.int32)
 
-        # Pad entire sequence to be a multiple of 32 or 16 if using fp8.
-        has_fp8 = self.args.fp8
+            if self.dataloader_seq_length is not None:
+                for i in range(len(samples)):
+                    cu_lengths[i][-1] = self.dataloader_seq_length
+                    cu_lengths_padded[i][-1] = self.dataloader_seq_length
+                    new_max_length = cu_lengths_padded[i][-1] - cu_lengths[i][-2]
+                    max_lengths[i] = torch.max(max_lengths[i], new_max_length)
+
+        # Pad entire sequence to be a multiple of 16 if using fp8
         if has_fp8:
-            total_seq_len = self._get_total_seq_length(tokens[0], num_tiles)
             padding_needed = get_padding(
                 total_seq_len,
                 self.args.context_parallel_size,
                 self.args.tensor_model_parallel_size,
                 self.args.sequence_parallel,
+                self.args.tp_comm_overlap,
+                self.args.decoder_seq_length,
                 fp8_enabled=has_fp8,
-                fp8_recipe=self.args.fp8_recipe,
             )
             if padding_needed > 0:
-                tokens = torch.cat([tokens, torch.full((tokens.shape[0], padding_needed), self.tokenizer.pad, dtype=torch.int64)], dim=1)
-                labels = torch.cat([labels, torch.full((labels.shape[0], padding_needed), IGNORE_INDEX, dtype=torch.int64)], dim=1)
+                tokens = torch.cat(
+                    [
+                        tokens,
+                        torch.full(
+                            (tokens.shape[0], padding_needed), self.tokenizer.pad, dtype=torch.int64
+                        ),
+                    ],
+                    dim=1,
+                )
+                labels = torch.cat(
+                    [
+                        labels,
+                        torch.full(
+                            (labels.shape[0], padding_needed), IGNORE_INDEX, dtype=torch.int64
+                        ),
+                    ],
+                    dim=1,
+                )
                 if is_packed:
                     cu_lengths[0][-1] += padding_needed
-                    new_max_length = cu_lengths[0][-1] - cu_lengths[0][-2]
+                    cu_lengths_padded[0][-1] += padding_needed
+                    new_max_length = cu_lengths_padded[0][-1] - cu_lengths[0][-2]
                     max_lengths = torch.max(max_lengths, new_max_length)
-
 
         return ImageTaskBatchPacked(
             __key__=[s.__key__ for s in samples],
@@ -858,7 +1189,12 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             imgs=imgs,
             num_tiles=num_tiles,
             cu_lengths=cu_lengths,
+            cu_lengths_padded=cu_lengths_padded,
             max_lengths=max_lengths,
+            imgs_sizes=imgs_sizes,
+            vision_cu_lengths=vision_cu_lengths,
+            vision_max_lengths=vision_max_lengths,
+            has_pad_img=has_pad_img,
         )
 
     def encode_batch(self, batch: ImageTaskBatchPacked) -> dict:
@@ -901,6 +1237,7 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
         current_length = 0
         max_length = 0
         cu_lengths = [0]
+        cu_lengths_padded = [0]
 
         # Process each sample and build lists that we will concatenate to create the packed sample.
         for _, sample in enumerate(samples):
@@ -912,7 +1249,9 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             # If adding this sample exceeds the max length, stop.
             # This should not happen. The select_samples_to_pack method should have already ensured that the samples fit.
             if current_length + sample_len > packing_seq_len:
-                raise ValueError(f"Packed sample exceeds the maximum sequence length of {packing_seq_len}: {samples}")
+                raise ValueError(
+                    f"Packed sample exceeds the maximum sequence length of {packing_seq_len}: {samples}"
+                )
 
             # Add the sample's tokens and labels
             packed_tokens.append(sample.tokens)
@@ -923,6 +1262,7 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
 
             current_length += sample_len
             cu_lengths.append(current_length)
+            cu_lengths_padded.append(current_length)
 
         # Concatenate packed tokens and labels.
         packed_tokens = torch.cat(packed_tokens, dim=0)
@@ -937,30 +1277,7 @@ class TaskEncoder(DefaultTaskEncoder[OCRSample, OCRSample, ImageTaskBatchPacked,
             labels=packed_labels,
             imgs=packed_imgs,
             cu_lengths=torch.tensor(cu_lengths, dtype=torch.int32),
+            cu_lengths_padded=torch.tensor(cu_lengths_padded, dtype=torch.int32),
             max_length=max_length,
             num_tiles=[n for s in samples for n in s.num_tiles],
         )
-
-
-def print_error_handler(exc: Exception, key: Optional[str]):
-    print(
-        f"The following exception occurred in the dataloader for sample {key} and is skipped",
-        file=sys.stderr,
-    )
-    traceback.print_exc()
-
-
-def format_multichoice_question(question, multichoice_options):
-    """Format multi-choice question."""
-    options_text = ["{}. {}\n".format(chr(ord('A') + i), option) for i, option in
-                    zip(range(len(multichoice_options)), multichoice_options)]
-    options_text = "".join(options_text)
-
-    options_text = f"{options_text}Answer with the option's letter from the given choices directly."
-
-    return "{}\n{}".format(question, options_text)
-
-
-def format_multichoice_answer(idx):
-    """Format multi-choice answer."""
-    return chr(ord('A') + idx)

--- a/examples/multimodal/energon_util.py
+++ b/examples/multimodal/energon_util.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
-import torch
+import warnings
 from dataclasses import dataclass
 from typing import Any, List
 
+import torch
+
 from megatron.energon import Sample
+from megatron.energon.epathlib.epath import EPath
+from megatron.energon.flavors.webdataset import DefaultDecoderWebdatasetFactory
 
 
 @dataclass
@@ -15,6 +19,23 @@ class SampleListSample(Sample):
 
     #: The images of the sequence
     samples: List[Any]
+
+
+class SampleListWebdataset(DefaultDecoderWebdatasetFactory[SampleListSample]):
+    __sample_type__ = SampleListSample
+
+    def __init__(self, path: EPath, **kwargs):
+        warnings.warn(
+            f"{type(self)} is deprecated, use the default instead and set the sample_type:\n"
+            f"To convert, update your {path}/.nv-meta/dataset.yaml to:\n"
+            f"# remove top-level __module__ and __class__\n"
+            f"sample_type:\n"
+            f"  __module__: megatron.energon\n"
+            f"  __class__: {self.__sample_type__.__name__}\n"
+            f"# Keep the remaining content",
+            DeprecationWarning,
+        )
+        super().__init__(path, **kwargs)
 
 
 @dataclass

--- a/examples/multimodal/image_processing.py
+++ b/examples/multimodal/image_processing.py
@@ -1,8 +1,13 @@
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved. Except portions as noted which are Copyright (c) 2023 OpenGVLab and licensed under the MIT license found in LICENSE.
+import math
+
+import torch
+from einops import rearrange
 from torchvision import transforms as T
 from torchvision.transforms import Compose
 from torchvision.transforms.functional import InterpolationMode
 
+from megatron.core.models.multimodal.utils import patchify_image
 
 IMAGENET_PIXEL_MEAN = [0.485, 0.456, 0.406]
 IMAGENET_PIXEL_STD = [0.229, 0.224, 0.225]
@@ -19,6 +24,7 @@ pixel_statistics = {
     "siglip": (SIGLIP_PIXEL_MEAN, SIGLIP_PIXEL_STD),
     "internvit": (IMAGENET_PIXEL_MEAN, IMAGENET_PIXEL_STD),
     "radio": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
+    "radio-so400m": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
     "radio-g": (RADIO_G_PIXEL_MEAN, RADIO_G_PIXEL_STD),
     "cradio-g": (CLIP_PIXEL_MEAN, CLIP_PIXEL_STD),
     "internvit300M": (IMAGENET_PIXEL_MEAN, IMAGENET_PIXEL_STD),
@@ -53,30 +59,292 @@ def find_closest_area_weighted_aspect_ratio(aspect_ratio, target_ratios, width, 
     area = width * height
     for ratio in target_ratios:
         target_aspect_ratio = ratio[0] / ratio[1]
-        factor_based_on_area_n_ratio = (
-            min((ratio[0]*ratio[1]*image_size*image_size)/ area, 0.6) *
-            min(target_aspect_ratio/aspect_ratio, aspect_ratio/target_aspect_ratio))
+        factor_based_on_area_n_ratio = min(
+            (ratio[0] * ratio[1] * image_size * image_size) / area, 0.6
+        ) * min(target_aspect_ratio / aspect_ratio, aspect_ratio / target_aspect_ratio)
         if factor_based_on_area_n_ratio > best_factor:
             best_factor = factor_based_on_area_n_ratio
             best_ratio = ratio
     return best_ratio
 
 
+def process_images(sample_imgs, patch_dim, dynamic_resolution, batch_mode=False):
+    """Process a batch of images for multimodal training or evaluation.
+
+    This function handles image preprocessing with support for both static and dynamic
+    resolution processing. For dynamic resolution, it rearranges images into patches
+    and computes cumulative sequence lengths for efficient batching.
+
+    Args:
+        sample_imgs (List[torch.Tensor]): List of image tensors with shape (C, H, W).
+        patch_dim (int): Dimension of each patch (e.g., 14 for 14x14 patches).
+        dynamic_resolution (bool): Whether to use dynamic resolution processing.
+            If True, images are rearranged into patches with variable sequence lengths.
+            If False, images are simply stacked into a batch tensor.
+        batch_mode (bool, optional): Whether this is being called from training batch processing.
+            If True, wraps tensors in additional list dimension for consistency with batch format.
+            If False, returns tensors directly as used in evaluation. Defaults to False.
+
+    Returns:
+        tuple: A 4-tuple containing:
+            - images (torch.Tensor): Processed image tensor.
+                For dynamic resolution: shape (1, total_patches, patch_features) if batch_mode=False,
+                                       or shape (1, total_patches, patch_features) if batch_mode=True
+                For static resolution: shape (batch_size, C, H, W)
+            - imgs_sizes (torch.Tensor): Image sizes tensor with shape (N, 2)
+                containing [height, width] for each image, or [[0,0]] if no images.
+            - vision_cu_lengths (torch.Tensor or None): Cumulative sequence lengths
+                for dynamic resolution. Shape (batch_size + 1,) for evaluation mode,
+                or shape (1, batch_size + 1) for batch mode. None for static resolution.
+            - vision_max_lengths (torch.Tensor or None): Maximum sequence length
+                among all images for dynamic resolution. Scalar tensor for evaluation mode,
+                or shape (1,) for batch mode. None for static resolution.
+
+    Note:
+        This function is designed for processing one microbatch at a time for dynamic resolution.
+    """
+    vision_cu_lengths = None
+    vision_max_lengths = None
+
+    if len(sample_imgs) > 0:
+        imgs_sizes = torch.tensor(
+            [[img.shape[1], img.shape[2]] for img in sample_imgs], dtype=torch.int32
+        )
+        if dynamic_resolution:
+            # Patchify: (3,H,W) -> (L,3*patch_dim*patch_dim)
+            imgs = [patchify_image(img, patch_dim) for img in sample_imgs]
+
+            current_length = 0
+            max_length = 0
+            vision_cu_lengths = [0]
+            for img in imgs:
+                if max_length < img.shape[0]:
+                    max_length = img.shape[0]
+                current_length += img.shape[0]
+                vision_cu_lengths.append(current_length)
+
+            vision_cu_lengths = torch.tensor(vision_cu_lengths, dtype=torch.int32)
+            vision_max_lengths = torch.tensor(max_length, dtype=torch.int32)
+
+            # For batch mode, wrap in additional dimension for consistency
+            if batch_mode:
+                vision_cu_lengths = vision_cu_lengths.unsqueeze(0)  # Shape: (1, batch_size + 1)
+                vision_max_lengths = vision_max_lengths.unsqueeze(0)  # Shape: (1,)
+
+            imgs = torch.cat(imgs, dim=0)
+            images = imgs.unsqueeze(0)
+        else:
+            images = torch.stack(sample_imgs)
+    else:
+        imgs_sizes = torch.tensor([[0, 0]], dtype=torch.int32)
+        if len(sample_imgs) == 0 and batch_mode:
+            # For batch mode when no images, use appropriate dummy tensor
+            images = torch.tensor([[0]], dtype=torch.float32)
+        else:
+            images = torch.stack(sample_imgs)
+
+    return images, imgs_sizes, vision_cu_lengths, vision_max_lengths
+
+
 class ImageTransform:
     """Image transformation."""
 
-    def __init__(self, input_size, vision_model_type):
+    def __init__(
+        self,
+        input_size,
+        vision_model_type,
+        *,
+        dynamic_resolution=False,
+        res_step=16,
+        min_num_patches=1,
+        max_num_patches=128,
+        pixel_shuffle=False,
+        min_side=None,
+        match_tiling_dynamic_resolution=False,
+        masked_tiling_dynamic_resolution=False,
+        thumbnail_area_threshold=0.8,
+    ):
         self._transform = _build_transform(input_size, vision_model_type)
         self._vision_model_type = vision_model_type
+        self._dynamic_resolution = dynamic_resolution
+        self._res_step = res_step
+        self._min_num_patches = min_num_patches
+        self._max_num_patches = max_num_patches
+        self._pixel_shuffle = pixel_shuffle
+        self._min_side = min_side
+        self._match_tiling_dynamic_resolution = match_tiling_dynamic_resolution
+        self._masked_tiling_dynamic_resolution = masked_tiling_dynamic_resolution
+        self._thumbnail_area_threshold = thumbnail_area_threshold
 
-    def __call__(self, img, img_h, img_w, use_tiling=False, max_num_tiles=1, use_thumbnail=False, augment=False, find_closest_aspect_ratio_fn=find_closest_aspect_ratio):
+    def __call__(
+        self,
+        img,
+        img_h,
+        img_w,
+        use_tiling=False,
+        max_num_tiles=1,
+        use_thumbnail=False,
+        augment=False,
+        find_closest_aspect_ratio_fn=find_closest_aspect_ratio,
+        is_video=False,
+    ):
         assert not augment, "Image augmentation not implemented."
         if use_tiling:
             assert img_h == img_w, "dynamic tiling expects equal tile height and width"
             imgs = dynamic_preprocess(
-                img, min_num=1, max_num=max_num_tiles, image_size=img_h, use_thumbnail=use_thumbnail,
-                find_closest_aspect_ratio_fn=find_closest_aspect_ratio_fn)
+                img,
+                min_num=1,
+                max_num=max_num_tiles,
+                image_size=img_h,
+                use_thumbnail=use_thumbnail,
+                find_closest_aspect_ratio_fn=find_closest_aspect_ratio_fn,
+            )
             imgs = [self._transform(img) for img in imgs]
+        elif self._masked_tiling_dynamic_resolution:
+            assert (
+                img_h == img_w
+            ), "masked tiling dynamic resolution expects equal tile height and width"
+            assert (
+                "radio" in self._vision_model_type
+            ), "Masked tiling dynamic resolution is only supported for radio models"
+
+            # Use tiling logic to determine tile grid (nx, ny)
+            orig_width, orig_height = img.size
+            aspect_ratio = orig_width / orig_height
+
+            target_ratios = set(
+                (i, j)
+                for n in range(1, max_num_tiles + 1)
+                for i in range(1, n + 1)
+                for j in range(1, n + 1)
+                if i * j <= max_num_tiles and i * j >= 1
+            )
+            target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+            tiling = find_closest_aspect_ratio_fn(
+                aspect_ratio, target_ratios, orig_width, orig_height, img_h
+            )
+
+            # Resize and split into tiles of size (img_h x img_h)
+            target_width = img_h * tiling[0]
+            target_height = img_w * tiling[1]
+            blocks = tiling[0] * tiling[1]
+
+            resized_img = img.resize((target_width, target_height))
+            processed_images = []
+            for i in range(blocks):
+                box = (
+                    (i % (target_width // img_h)) * img_h,
+                    (i // (target_width // img_h)) * img_h,
+                    ((i % (target_width // img_h)) + 1) * img_h,
+                    ((i // (target_width // img_h)) + 1) * img_h,
+                )
+                tile_img = resized_img.crop(box)
+                processed_images.append(tile_img)
+            assert len(processed_images) == blocks
+
+            # Optional thumbnail
+            if use_thumbnail and blocks != 1:
+                thumbnail_img = img.resize((img_h, img_h))
+                processed_images.append(thumbnail_img)
+
+            pixel_mean, pixel_std = pixel_statistics[self._vision_model_type]
+            transform = T.Compose(
+                [
+                    T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+                    T.ToTensor(),
+                    T.Normalize(mean=pixel_mean, std=pixel_std),
+                ]
+            )
+            imgs = [transform(im) for im in processed_images]
+        elif self._match_tiling_dynamic_resolution:
+            assert (
+                img_h == img_w
+            ), "match tiling dynamic resolution expects equal tile height and width"
+            assert (
+                "radio" in self._vision_model_type
+            ), "Match tiling dynamic resolution is only supported for radio models"
+
+            # Use tiling logic to determine optimal dimensions
+            orig_width, orig_height = img.size
+            aspect_ratio = orig_width / orig_height
+
+            # Calculate target ratios (same logic as tiling)
+            target_ratios = set(
+                (i, j)
+                for n in range(1, max_num_tiles + 1)
+                for i in range(1, n + 1)
+                for j in range(1, n + 1)
+                if i * j <= max_num_tiles and i * j >= 1
+            )
+            target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+            # Find the closest aspect ratio to the target
+            target_aspect_ratio = find_closest_aspect_ratio_fn(
+                aspect_ratio, target_ratios, orig_width, orig_height, img_h
+            )
+
+            # Calculate the target width and height using tiling logic
+            target_width = img_h * target_aspect_ratio[0]
+            target_height = img_w * target_aspect_ratio[1]
+
+            # Resize image to target dimensions (same as tiling, but don't split)
+            resized_img = img.resize((target_width, target_height))
+
+            # Process as single dynamic resolution image
+            pixel_mean, pixel_std = pixel_statistics[self._vision_model_type]
+            transform = T.Compose(
+                [
+                    T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+                    T.ToTensor(),
+                    T.Normalize(mean=pixel_mean, std=pixel_std),
+                ]
+            )
+            processed_images = [resized_img]
+
+            # Add thumbnail if use_thumbnail=True and there's more than 1 tile
+            blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+            if use_thumbnail and blocks != 1:
+                thumbnail_img = img.resize((img_h, img_h))
+                processed_images.append(thumbnail_img)
+
+            imgs = [transform(img) for img in processed_images]
+        elif self._dynamic_resolution:
+            pixel_mean, pixel_std = pixel_statistics[self._vision_model_type]
+            transform = T.Compose(
+                [
+                    T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+                    T.ToTensor(),
+                    T.Normalize(mean=pixel_mean, std=pixel_std),
+                ]
+            )
+            processed_img = dynamic_res_preprocess(
+                img,
+                min_patches=self._min_num_patches,
+                max_patches=self._max_num_patches,
+                res_step=self._res_step,
+                pixel_shuffle=self._pixel_shuffle,
+                min_side=self._min_side,
+                is_video=is_video,
+            )
+            processed_images = [processed_img]
+
+            # Add thumbnail if enabled and image area is below threshold
+            if use_thumbnail:
+                # Calculate areas
+                processed_width, processed_height = processed_img.size
+                resized_area = processed_width * processed_height
+                thumbnail_area = img_h * img_h  # img_h should be square thumbnail size
+                area_ratio = resized_area / thumbnail_area
+
+                # Only add thumbnail if resized image area is less than threshold % of thumbnail area
+                if area_ratio < self._thumbnail_area_threshold:
+                    thumbnail_img = img.resize(
+                        (img_h, img_h)
+                    )  # Use square thumbnail with img_h size
+                    processed_images.append(thumbnail_img)
+
+            imgs = [transform(img) for img in processed_images]
         else:
             imgs = [self._transform(img)]
 
@@ -86,20 +354,30 @@ class ImageTransform:
 # From https://github.com/OpenGVLab/InternVL/blob/c62fa4f7c850165d7386bdc48ac6bc5a6fab0864/internvl_chat/internvl/train/dataset.py#L702
 # Copyright (c) 2023 OpenGVLab.
 def dynamic_preprocess(
-    image, min_num=1, max_num=6, image_size=448, use_thumbnail=False,
-    find_closest_aspect_ratio_fn=find_closest_aspect_ratio):
+    image,
+    min_num=1,
+    max_num=6,
+    image_size=448,
+    use_thumbnail=False,
+    find_closest_aspect_ratio_fn=find_closest_aspect_ratio,
+):
     orig_width, orig_height = image.size
     aspect_ratio = orig_width / orig_height
 
     # calculate the existing image aspect ratio
     target_ratios = set(
-        (i, j) for n in range(min_num, max_num + 1) for i in range(1, n + 1) for j in range(1, n + 1) if
-        i * j <= max_num and i * j >= min_num)
+        (i, j)
+        for n in range(min_num, max_num + 1)
+        for i in range(1, n + 1)
+        for j in range(1, n + 1)
+        if i * j <= max_num and i * j >= min_num
+    )
     target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
 
     # find the closest aspect ratio to the target
     target_aspect_ratio = find_closest_aspect_ratio_fn(
-        aspect_ratio, target_ratios, orig_width, orig_height, image_size)
+        aspect_ratio, target_ratios, orig_width, orig_height, image_size
+    )
 
     # calculate the target width and height
     target_width = image_size * target_aspect_ratio[0]
@@ -114,7 +392,7 @@ def dynamic_preprocess(
             (i % (target_width // image_size)) * image_size,
             (i // (target_width // image_size)) * image_size,
             ((i % (target_width // image_size)) + 1) * image_size,
-            ((i // (target_width // image_size)) + 1) * image_size
+            ((i // (target_width // image_size)) + 1) * image_size,
         )
         # split the image
         split_img = resized_img.crop(box)
@@ -126,27 +404,170 @@ def dynamic_preprocess(
     return processed_images
 
 
+def dynamic_res_preprocess(
+    image,
+    min_patches=1,
+    max_patches=128,
+    res_step=16,
+    factor_max=1.0,
+    pixel_shuffle=False,
+    min_side=None,
+    is_video=False,
+):
+    """Preprocess an image with dynamic resolution for vision transformers.
+
+    This function resizes an image to optimize the number of patches while respecting
+    constraints on minimum/maximum patches, minimum side length, and compatibility
+    with pixel shuffle operations.
+
+    The algorithm works by:
+    1. Computing the initial patch grid size based on the image dimensions and res_step
+    2. Scaling the patch grid to fit within the max_patches constraint
+    3. Ensuring the result has at least min_patches
+    4. Optionally enforcing a minimum side length constraint
+    5. Rounding patch dimensions to even numbers for pixel-shuffle compatibility
+    6. Resizing the image to the computed target dimensions
+
+    Args:
+        image (PIL.Image): Input image to preprocess.
+        min_patches (int, optional): Minimum number of patches required. Defaults to 1.
+        max_patches (int, optional): Maximum number of patches allowed. Defaults to 128.
+        res_step (int, optional): Resolution step size (patch dimension). Defaults to 16.
+        factor_max (float, optional): Maximum scaling factor to apply. Defaults to 1.0.
+        pixel_shuffle (bool, optional): Whether to ensure compatibility with pixel shuffle
+            operations by rounding to even patch dimensions. Defaults to False.
+        min_side (int, optional): Minimum side length in pixels. If specified, ensures
+            at least one side meets this constraint. Defaults to None.
+        is_video (bool, optional): Whether this is a video frame. When True and video-specific
+            pooling args are provided, uses those for divisibility. Defaults to False.
+
+    Returns:
+        PIL.Image: Resized image with dimensions optimized for patch-based processing.
+            The output dimensions will be (target_patch_width * res_step, target_patch_height * res_step).
+
+    Note:
+        The function preserves aspect ratio as much as possible while satisfying all constraints.
+        When constraints conflict (e.g., min_side vs max_patches), the function prioritizes
+        staying within max_patches while maximizing the image size.
+
+    Example:
+        >>> from PIL import Image
+        >>> img = Image.open("example.jpg")  # 800x600 image
+        >>> resized_img = dynamic_res_preprocess(img, min_patches=4, max_patches=64, res_step=14)
+        >>> # Returns image resized to maintain aspect ratio with 4-64 patches of size 14x14
+    """
+    orig_width, orig_height = image.size
+
+    closest_patch_height = round(orig_height / res_step + 0.5)
+    closest_patch_width = round(orig_width / res_step + 0.5)
+    patches = closest_patch_height * closest_patch_width
+
+    factor = min(math.sqrt(max_patches / patches), factor_max)
+    target_patch_height = math.floor(factor * closest_patch_height)
+    target_patch_width = math.floor(factor * closest_patch_width)
+
+    if target_patch_height * target_patch_width < min_patches:
+        up_factor = math.sqrt(min_patches / (target_patch_height * target_patch_width))
+        target_patch_height = math.ceil(up_factor * target_patch_height)
+        target_patch_width = math.ceil(up_factor * target_patch_width)
+
+    if min_side is not None and min(target_patch_width, target_patch_height) * res_step < min_side:
+        if target_patch_width <= target_patch_height:
+            up_factor = min_side / (target_patch_width * res_step)
+            new_patch_height = math.ceil(up_factor * target_patch_height)
+            new_patch_width = math.ceil(up_factor * target_patch_width)
+
+            if new_patch_height * new_patch_width > max_patches:
+                # If only one side can be min_side, make as big as possible at native aspect ratio while staying below max_patches
+                if max(max_patches // new_patch_width, 1) * res_step < min_side:
+                    up_factor = math.sqrt(max_patches / (target_patch_height * target_patch_width))
+                    target_patch_height = math.floor(up_factor * target_patch_height)
+                    target_patch_width = math.floor(up_factor * target_patch_width)
+                target_patch_width = new_patch_width
+                target_patch_height = max(max_patches // new_patch_width, 1)
+            else:
+                target_patch_height = new_patch_height
+                target_patch_width = new_patch_width
+        else:
+            up_factor = min_side / (target_patch_height * res_step)
+            new_patch_height = math.ceil(up_factor * target_patch_height)
+            new_patch_width = math.ceil(up_factor * target_patch_width)
+
+            if new_patch_height * new_patch_width > max_patches:
+                # If only one side can be min_side, make as big as possible at native aspect ratio while staying below max_patches
+                if max(max_patches // new_patch_height, 1) * res_step < min_side:
+                    up_factor = math.sqrt(max_patches / (target_patch_height * target_patch_width))
+                    target_patch_height = math.floor(up_factor * target_patch_height)
+                    target_patch_width = math.floor(up_factor * target_patch_width)
+                else:
+                    target_patch_height = new_patch_height
+                    target_patch_width = max(max_patches // new_patch_height, 1)
+            else:
+                target_patch_height = new_patch_height
+                target_patch_width = new_patch_width
+
+    # Pixel shuffle groups 2x2 patches, so both grid dimensions must be even.
+    if pixel_shuffle:
+        required_divisor = 2
+
+        rem_h = target_patch_height % required_divisor
+        if rem_h != 0:
+            inc_h = required_divisor - rem_h
+            if (target_patch_height + inc_h) * target_patch_width <= max_patches:
+                target_patch_height += inc_h
+            else:
+                target_patch_height = max(1, target_patch_height - rem_h)
+
+        rem_w = target_patch_width % required_divisor
+        if rem_w != 0:
+            inc_w = required_divisor - rem_w
+            if target_patch_height * (target_patch_width + inc_w) <= max_patches:
+                target_patch_width += inc_w
+            else:
+                target_patch_width = max(1, target_patch_width - rem_w)
+    assert target_patch_height * target_patch_width <= max_patches
+
+    # TEMP: hacky way to process video same as in training
+    if is_video:
+        # max_patches = 1024
+        # min_patches = 512
+        target_patch_width = 32
+        target_patch_height = 32
+
+    # resize the image
+    resized_img = image.resize((target_patch_width * res_step, target_patch_height * res_step))
+
+    return resized_img
+
+
 # Based on https://github.com/openai/CLIP/blob/dcba3cb2e2827b402d2701e7e1c7d9fed8a20ef1/clip/clip.py#L79
 # and https://github.com/OpenGVLab/InternVL/blob/aa521e6eb1df4cf153aa4118fcf13e673c055d46/internvl_chat/internvl/train/dataset.py#L276
 def _build_transform(input_size, vision_model_type):
-    if vision_model_type in ("siglip", "internvit", "internvit300M", "radio", "radio-g", "cradio-g"):
+    if (
+        vision_model_type in ("siglip", "internvit", "internvit300M")
+        or "radio" in vision_model_type
+    ):
         pixel_mean, pixel_std = pixel_statistics[vision_model_type]
 
-        transform = T.Compose([
-            T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
-            T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
-            T.ToTensor(),
-            T.Normalize(mean=pixel_mean, std=pixel_std)
-        ])
+        transform = T.Compose(
+            [
+                T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+                T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+                T.ToTensor(),
+                T.Normalize(mean=pixel_mean, std=pixel_std),
+            ]
+        )
     elif vision_model_type == "clip":
         pixel_mean, pixel_std = pixel_statistics[vision_model_type]
 
-        transform = Compose([
-            T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
-            T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
-            T.ToTensor(),
-            T.Normalize(mean=pixel_mean, std=pixel_std),
-        ])
+        transform = Compose(
+            [
+                T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+                T.Lambda(lambda img: img.convert('RGB') if img.mode != 'RGB' else img),
+                T.ToTensor(),
+                T.Normalize(mean=pixel_mean, std=pixel_std),
+            ]
+        )
     elif vision_model_type.startswith("hf://"):
         from megatron.core.models.huggingface.module import get_hf_model_type
 
@@ -160,9 +581,14 @@ def _build_transform(input_size, vision_model_type):
                 x = x.convert("RGB") if x.mode != "RGB" else x
                 x = processor(x, return_tensors="pt")
                 return x["pixel_values"][0]
+
         else:
-            raise NotImplementedError(f"image processing not defined for huggingface model {vision_model_type}")
+            raise NotImplementedError(
+                f"image processing not defined for huggingface model {vision_model_type}"
+            )
     else:
-        raise NotImplementedError(f"image processing not defined for vision model {vision_model_type}")
+        raise NotImplementedError(
+            f"image processing not defined for vision model {vision_model_type}"
+        )
 
     return transform

--- a/examples/multimodal/iter_data.py
+++ b/examples/multimodal/iter_data.py
@@ -1,0 +1,118 @@
+import faulthandler
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+import tqdm
+from data_loading.task_encoder import MultiModalTaskEncoder
+from multimodal_args import add_multimodal_extra_args
+
+from megatron.core import parallel_state
+from megatron.energon import FileStoreCachePool, WorkerConfig, get_savable_loader, get_train_dataset
+from megatron.training import get_args, get_tokenizer
+from megatron.training.initialize import initialize_megatron
+
+
+def main():
+    # Initalize and get arguments, timers, and Tensorboard writer.
+    faulthandler.enable()
+    print(f"PID: {os.getpid()}")
+
+    torch.distributed.init_process_group(backend='gloo')
+
+    initialize_megatron(
+        args_defaults={'tokenizer_type': 'GPT2BPETokenizer'},
+        extra_args_provider=add_multimodal_extra_args,
+        allow_no_cuda=True,
+        skip_mpu_initialization=True,
+    )
+
+    # This requires not to skip mpu initialization.
+    # rank = parallel_state.get_data_parallel_rank()
+    # world_size = parallel_state.get_data_parallel_world_size()
+    # try:
+    #     data_parallel_group = parallel_state.get_data_parallel_group()
+    # except Exception as e:
+    #     print(f"Error getting data parallel group: {e}")
+    #     data_parallel_group = None
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    data_parallel_group = torch.distributed.group.WORLD
+    # rank = 0
+    # world_size = 1
+    # data_parallel_group = None
+
+    args = get_args()
+
+    dname = args.data_path[0] if type(args.data_path) is list else args.data_path
+
+    worker_config = WorkerConfig(
+        rank=rank,
+        world_size=world_size,
+        num_workers=args.num_workers,
+        data_parallel_group=data_parallel_group,
+        # worker_debug_path=str(Path('tmpdata/energon-dbg-{worker_id:02}-{pid}.jsonl').absolute()),
+        # worker_log_level=2,
+    )
+
+    print(f"worker_config: {worker_config}")
+
+    train_dataset = get_train_dataset(
+        dname,
+        batch_size=1,
+        task_encoder=MultiModalTaskEncoder(),
+        worker_config=worker_config,
+        packing_buffer_size=args.packing_buffer_size,
+        shuffle_buffer_size=None,
+        max_samples_per_sequence=None,
+        repeat=True,
+    )
+    train_dataloader = get_savable_loader(
+        train_dataset,
+        gc_collect_every_n_steps=100000,
+        cache_pool=FileStoreCachePool(num_workers=8, max_cache_size_gbytes=8, method="raw"),
+        watchdog_timeout_seconds=120,
+    )
+
+    max_iter = 200
+
+    times = np.zeros(max_iter, dtype=np.float32)
+
+    total_samples = 0
+
+    # gc.freeze()
+    step = -1
+    start = time.time()
+    try:
+        with tqdm.tqdm(total=len(train_dataloader), position=rank) as pbar:
+            # Iterate over the train dataloader
+            for step, batch in enumerate(train_dataloader):
+                times[step] = time.time() - start
+                if step == times.shape[0] - 1:
+                    break
+                pbar.update(batch['samples_seen'].item())
+                total_samples += batch['samples_seen'].item()
+
+                # tokenizer = get_tokenizer()
+                # print("-" * 20)
+                # print(f"Sample {batch['__key__']} Images {batch['num_tiles']}:")
+                # print(tokenizer.detokenize(batch['tokens'][0]))
+                # print("-" * 20)
+                print(f"Step {step} {batch['__key__']}")
+
+                start = time.time()
+                # gc.collect()
+                if total_samples >= len(train_dataloader):
+                    break
+    finally:
+        if step > 2:
+            print("sec/iter so far:", times[: step - 1].mean())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/data/test_explicit_assistant_loss.py
+++ b/tests/unit_tests/data/test_explicit_assistant_loss.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import copy
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from examples.multimodal.data_loading.conversation_base import conversation_convert_message
+from examples.multimodal.data_loading.conversation_sample import ConversationSample, Message
+from examples.multimodal.data_loading.cookers import conversation as conversation_cooker
+from examples.multimodal.data_loading.cookers.conversation import (
+    EXPLICIT_ASSISTANT_LOSS_COOK,
+    EXPLICIT_ASSISTANT_LOSS_FIELD,
+    EXPLICIT_ASSISTANT_LOSS_MODE,
+    _validate_explicit_assistant_loss_contract,
+    _validate_loss_mask_subflavors,
+    _validate_openai_messages_have_no_explicit_loss,
+    _validate_standard_jsonl_has_no_explicit_loss,
+)
+from examples.multimodal.data_loading.task_encoder import MultiModalTaskEncoder
+from megatron.core.models.multimodal.llava_model import IGNORE_INDEX
+
+
+def _valid_data() -> dict:
+    return {
+        "conversations": [
+            {"from": "system", "value": "system"},
+            {"from": "human", "value": "task"},
+            {"from": "gpt", "value": "history", "loss": False},
+            {"from": "human", "value": "observation"},
+            {"from": "gpt", "value": "action one", "loss": True},
+            {"from": "human", "value": "observation"},
+            {"from": "assistant", "value": "action two", "loss": True},
+        ]
+    }
+
+
+def _valid_subflavors() -> dict:
+    return {
+        "cook": EXPLICIT_ASSISTANT_LOSS_COOK,
+        "loss_mask_mode": EXPLICIT_ASSISTANT_LOSS_MODE,
+        "assistant_loss_mask_field": EXPLICIT_ASSISTANT_LOSS_FIELD,
+    }
+
+
+def test_explicit_assistant_loss_contract_accepts_multiple_targets() -> None:
+    _validate_explicit_assistant_loss_contract(_valid_data(), _valid_subflavors())
+
+
+def test_explicit_assistant_loss_contract_accepts_single_target() -> None:
+    data = _valid_data()
+    data["conversations"][4]["loss"] = False
+    _validate_explicit_assistant_loss_contract(data, _valid_subflavors())
+
+
+def test_loss_mask_subflavors_accept_legacy_and_explicit_contracts() -> None:
+    assert not _validate_loss_mask_subflavors({"cook": "general_conversations_jsonl"})
+    assert _validate_loss_mask_subflavors(_valid_subflavors())
+
+
+def test_loss_mask_subflavors_reject_unknown_mode() -> None:
+    subflavors = {
+        "cook": "general_conversations_jsonl",
+        "loss_mask_mode": "explicit_assistant_turns_v1",
+    }
+    with pytest.raises(ValueError, match="unsupported loss_mask_mode"):
+        _validate_loss_mask_subflavors(subflavors)
+
+
+@pytest.mark.parametrize("assistant_loss_mask_field", [EXPLICIT_ASSISTANT_LOSS_FIELD, None])
+def test_loss_mask_subflavors_reject_stray_field(assistant_loss_mask_field: object) -> None:
+    subflavors = {
+        "cook": "general_conversations_jsonl",
+        "assistant_loss_mask_field": assistant_loss_mask_field,
+    }
+    with pytest.raises(ValueError, match="assistant_loss_mask_field requires loss_mask_mode"):
+        _validate_loss_mask_subflavors(subflavors)
+
+
+@pytest.mark.parametrize(
+    "cook",
+    [
+        "general_conversations_jsonl",
+        "openai_messages_jsonl",
+        "openai_messages_offline_packed_jsonl",
+    ],
+)
+def test_loss_mask_subflavors_reject_explicit_mode_with_wrong_cooker(cook: str) -> None:
+    subflavors = _valid_subflavors()
+    subflavors["cook"] = cook
+    with pytest.raises(ValueError, match="requires cook"):
+        _validate_loss_mask_subflavors(subflavors)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("loss_mask_mode", "last_assistant_turn"),
+        ("assistant_loss_mask_field", "loss"),
+        ("train_only_on_last_assistant_turn", True),
+        ("skip_chat_template", True),
+        ("tool_response_as_turn_boundary", True),
+        ("offline_packed_messages", True),
+    ],
+)
+def test_explicit_assistant_loss_contract_rejects_bad_subflavors(field: str, value: object) -> None:
+    subflavors = _valid_subflavors()
+    subflavors[field] = value
+    with pytest.raises(ValueError):
+        _validate_explicit_assistant_loss_contract(_valid_data(), subflavors)
+
+
+@pytest.mark.parametrize(
+    "incompatible_option",
+    [
+        "train_only_on_last_assistant_turn",
+        "skip_chat_template",
+        "tool_response_as_turn_boundary",
+        "offline_packed_messages",
+    ],
+)
+def test_loss_mask_subflavors_reject_incompatible_options(incompatible_option: str) -> None:
+    subflavors = _valid_subflavors()
+    subflavors[incompatible_option] = True
+    with pytest.raises(ValueError, match=f"incompatible with {incompatible_option}"):
+        _validate_loss_mask_subflavors(subflavors)
+
+
+@pytest.mark.parametrize("invalid_loss", [None, 0, 1, "true"])
+def test_explicit_assistant_loss_contract_requires_boolean_assistant_loss(
+    invalid_loss: object,
+) -> None:
+    data = _valid_data()
+    data["conversations"][2]["loss"] = invalid_loss
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _validate_explicit_assistant_loss_contract(data, _valid_subflavors())
+
+
+def test_explicit_assistant_loss_contract_requires_every_assistant_flag() -> None:
+    data = _valid_data()
+    del data["conversations"][2]["loss"]
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _validate_explicit_assistant_loss_contract(data, _valid_subflavors())
+
+
+def test_explicit_assistant_loss_contract_rejects_non_assistant_flag() -> None:
+    data = _valid_data()
+    data["conversations"][1]["loss"] = False
+    with pytest.raises(ValueError, match="only valid on assistant"):
+        _validate_explicit_assistant_loss_contract(data, _valid_subflavors())
+
+
+def test_explicit_assistant_loss_contract_requires_trainable_turn() -> None:
+    data = _valid_data()
+    for message in data["conversations"]:
+        if "loss" in message:
+            message["loss"] = False
+    with pytest.raises(ValueError, match="at least one loss=true"):
+        _validate_explicit_assistant_loss_contract(data, _valid_subflavors())
+
+
+def test_explicit_assistant_loss_contract_rejects_unknown_sender() -> None:
+    data = _valid_data()
+    data["conversations"][1]["from"] = "computer"
+    with pytest.raises(ValueError, match="unsupported sender"):
+        _validate_explicit_assistant_loss_contract(data, _valid_subflavors())
+
+
+def test_standard_jsonl_rejects_explicit_loss() -> None:
+    with pytest.raises(ValueError, match="requires cook"):
+        _validate_standard_jsonl_has_no_explicit_loss(_valid_data())
+
+    data = copy.deepcopy(_valid_data())
+    for message in data["conversations"]:
+        message.pop("loss", None)
+    _validate_standard_jsonl_has_no_explicit_loss(data)
+
+
+def test_general_conversations_jsonl_forwards_named_media_sources(monkeypatch) -> None:
+    captured_kwargs = {}
+    expected_result = object()
+
+    def record_post_processing(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return expected_result
+
+    monkeypatch.setattr(conversation_cooker, "conversation_post_processing", record_post_processing)
+    babyvision_synth = object()
+    babyvision_style_questions = object()
+
+    result = conversation_cooker._cook_general_conversations_jsonl(
+        {"json": {"conversations": []}},
+        cache=object(),
+        primary=object(),
+        explicit_assistant_loss=False,
+        babyvision_synth=babyvision_synth,
+        babyvision_style_questions=babyvision_style_questions,
+    )
+
+    assert result is expected_result
+    assert captured_kwargs["babyvision_synth"] is babyvision_synth
+    assert captured_kwargs["babyvision_style_questions"] is babyvision_style_questions
+    assert "media_sources" not in captured_kwargs
+
+
+def test_openai_messages_reject_explicit_loss() -> None:
+    messages = [{"role": "assistant", "content": "answer", "loss": False}]
+    with pytest.raises(ValueError, match=r"messages\[0\]\.loss is unsupported"):
+        _validate_openai_messages_have_no_explicit_loss(messages)
+
+    _validate_openai_messages_have_no_explicit_loss([{"role": "assistant", "content": "answer"}])
+
+
+@pytest.mark.parametrize("loss", [False, True])
+def test_message_loss_round_trips_without_entering_fragments(loss: bool) -> None:
+    message = conversation_convert_message(
+        {"conversations": []},
+        {"from": "gpt", "value": "answer"},
+        defaultdict(int),
+        check_if_media_file_exist=False,
+        loss=loss,
+    )
+    assert message == Message(sender="assistant", fragments=["answer"], loss=loss)
+
+    serialized = ConversationSample.to_json(SimpleNamespace(conversation=[message]))
+    assert serialized == {
+        "conversation": [{"sender": "assistant", "fragments": ["answer"], "loss": loss}]
+    }
+    round_tripped = ConversationSample.from_json(serialized, __key__="sample", __restore_key__=())
+    assert round_tripped.conversation == [message]
+
+    legacy_serialized = ConversationSample.to_json(
+        SimpleNamespace(conversation=[Message(sender="assistant", fragments=["legacy"])])
+    )
+    assert legacy_serialized == {"conversation": [{"sender": "assistant", "fragments": ["legacy"]}]}
+
+
+def test_offline_packed_conversations_reject_explicit_loss() -> None:
+    sample = SimpleNamespace(
+        __key__="offline",
+        conversation=[Message(sender="assistant", fragments=["answer"], loss=True)],
+    )
+    with pytest.raises(ValueError, match="does not support explicit assistant loss"):
+        MultiModalTaskEncoder._split_offline_packed_conversations(object(), sample)
+
+
+def test_explicit_loss_span_validation_allows_partial_final_span() -> None:
+    full = torch.tensor([IGNORE_INDEX, 1, 2, IGNORE_INDEX, 3, 4])
+    partial_final = full[:-1]
+
+    MultiModalTaskEncoder._validate_explicit_loss_target_spans(
+        full, expected_span_count=2, sample_key="full", phase="truncation"
+    )
+    MultiModalTaskEncoder._validate_explicit_loss_target_spans(
+        partial_final, expected_span_count=2, sample_key="partial", phase="truncation"
+    )
+
+
+def test_explicit_loss_span_validation_rejects_removed_target() -> None:
+    removed_final = torch.tensor([IGNORE_INDEX, 1, 2, IGNORE_INDEX])
+    with pytest.raises(ValueError, match="expected 2, found 1"):
+        MultiModalTaskEncoder._validate_explicit_loss_target_spans(
+            removed_final, expected_span_count=2, sample_key="removed", phase="truncation"
+        )

--- a/tests/unit_tests/data/test_multimodal_dataloader_provider.py
+++ b/tests/unit_tests/data/test_multimodal_dataloader_provider.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+MULTIMODAL_EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "multimodal"
+sys.path.insert(0, str(MULTIMODAL_EXAMPLE_DIR))
+
+import dataloader_provider  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "cp_rank", "deduplicate", "expected"),
+    [
+        (0, 0, False, True),
+        (0, 1, False, True),
+        (0, 0, True, True),
+        (0, 1, True, False),
+        (1, 0, True, False),
+    ],
+)
+def test_dataloader_rank_cp_deduplication(monkeypatch, tp_rank, cp_rank, deduplicate, expected):
+    monkeypatch.setattr(dataloader_provider, "get_tensor_model_parallel_rank", lambda: tp_rank)
+    monkeypatch.setattr(dataloader_provider, "get_context_parallel_rank", lambda: cp_rank)
+    monkeypatch.setattr(dataloader_provider, "get_pipeline_model_parallel_world_size", lambda: 1)
+
+    assert (
+        dataloader_provider.is_dataloader_rank(
+            encoder_pipeline_model_parallel_size=0, deduplicate_across_context_parallel=deduplicate
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_workers", "configured_prefetch_factor", "expected_prefetch_factor"),
+    [(0, 4, None), (1, 4, 4), (1, None, 8)],
+)
+def test_new_dataloader_prefetch_factor(
+    monkeypatch, num_workers, configured_prefetch_factor, expected_prefetch_factor
+):
+    values = {
+        "dataloader_seed": 0,
+        "encoder_pipeline_model_parallel_size": 0,
+        "load": None,
+        "num_workers": num_workers,
+        "packing_buffer_size": 10000,
+    }
+    if configured_prefetch_factor is not None:
+        values["dataloader_prefetch_factor"] = configured_prefetch_factor
+    args = SimpleNamespace(**values)
+    loader_kwargs = {}
+
+    monkeypatch.setattr(dataloader_provider, "get_args", lambda: args)
+    monkeypatch.setattr(dataloader_provider, "is_dataloader_rank", lambda _, **kwargs: True)
+    monkeypatch.setattr(dataloader_provider.parallel_state, "get_data_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        dataloader_provider.parallel_state, "get_data_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(
+        dataloader_provider.parallel_state, "get_data_parallel_group", lambda: object()
+    )
+    monkeypatch.setattr(dataloader_provider, "WorkerConfig", lambda **kwargs: kwargs)
+    monkeypatch.setattr(
+        dataloader_provider,
+        "datasets_provider",
+        lambda task_encoder, worker_config: ("train-dataset", None, None),
+    )
+    monkeypatch.setattr(dataloader_provider, "use_new_dataloader_path", lambda: True)
+    monkeypatch.setattr(dataloader_provider, "FileStoreCachePool", lambda **kwargs: kwargs)
+
+    def fake_get_savable_loader(dataset, **kwargs):
+        loader_kwargs.update(kwargs)
+        return [dataset]
+
+    monkeypatch.setattr(dataloader_provider, "get_savable_loader", fake_get_savable_loader)
+
+    train_loader, valid_loader, test_loader = (
+        dataloader_provider.train_valid_test_dataloaders_provider(
+            train_val_test_num_samples=None, task_encoder=object()
+        )
+    )
+
+    assert train_loader._dataloader == ["train-dataset"]
+    assert valid_loader is None
+    assert test_loader._dataloader is None
+    if expected_prefetch_factor is None:
+        assert "prefetch_factor" not in loader_kwargs
+    else:
+        assert loader_kwargs["prefetch_factor"] == expected_prefetch_factor
+
+
+def test_new_dataloader_rejects_non_positive_prefetch_factor(monkeypatch):
+    monkeypatch.setattr(
+        dataloader_provider, "get_args", lambda: SimpleNamespace(dataloader_prefetch_factor=0)
+    )
+
+    with pytest.raises(ValueError, match="must be positive"):
+        dataloader_provider.train_valid_test_dataloaders_provider(
+            train_val_test_num_samples=None, task_encoder=object()
+        )

--- a/tests/unit_tests/data/test_multimodal_dataloader_resume.py
+++ b/tests/unit_tests/data/test_multimodal_dataloader_resume.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+_HELPER_PATH = Path(__file__).parents[3] / "examples" / "multimodal" / "dataloader_resume.py"
+_SPEC = importlib.util.spec_from_file_location("dataloader_resume", _HELPER_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+
+dataloader_resume = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(dataloader_resume)
+
+
+def _args(**overrides) -> SimpleNamespace:
+    values = {
+        "iteration": 0,
+        "finetune": False,
+        "pretrained_checkpoint": None,
+        "strict_dataloader_state_load": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_initial_finetune_load_tolerates_missing_dataloader_state():
+    assert dataloader_resume.is_initial_checkpoint_load_without_dataloader_state(
+        _args(finetune=True)
+    )
+
+
+def test_initial_pretrained_load_tolerates_missing_dataloader_state():
+    assert dataloader_resume.is_initial_checkpoint_load_without_dataloader_state(
+        _args(pretrained_checkpoint="/checkpoints/initial")
+    )
+
+
+def test_nonzero_resume_is_not_an_initial_load():
+    assert not dataloader_resume.is_initial_checkpoint_load_without_dataloader_state(
+        _args(iteration=250, finetune=True, pretrained_checkpoint="/checkpoints/initial")
+    )
+
+
+def test_dataloader_state_load_is_tolerant_by_default():
+    assert not dataloader_resume.should_strictly_load_dataloader_state(_args())
+
+
+def test_dataloader_state_load_can_be_strict():
+    assert dataloader_resume.should_strictly_load_dataloader_state(
+        _args(strict_dataloader_state_load=True)
+    )

--- a/tests/unit_tests/data/test_multimodal_knapsacks.py
+++ b/tests/unit_tests/data/test_multimodal_knapsacks.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from dataclasses import dataclass
+
+import pytest
+
+from examples.multimodal.data_loading.knapsacks import streaming_prompt_dedup_first_fit_knapsack
+
+
+@dataclass
+class Sample:
+    size: int
+    prompt_hash: str
+
+
+def test_streaming_knapsack_avoids_duplicate_prompts():
+    samples = [Sample(6, "a"), Sample(4, "a"), Sample(6, "b"), Sample(4, "c")]
+
+    packs = streaming_prompt_dedup_first_fit_knapsack(
+        [sample.size for sample in samples], samples, max_capacity=10, tolerance=0
+    )
+
+    assert sorted(sum(sample.size for sample in pack) for pack in packs) == [10, 10]
+    assert all(len({sample.prompt_hash for sample in pack}) == len(pack) for pack in packs)
+
+
+def test_streaming_knapsack_rejects_oversized_samples():
+    sample = Sample(11, "a")
+
+    with pytest.raises(ValueError, match="exceeds max_capacity"):
+        streaming_prompt_dedup_first_fit_knapsack([sample.size], [sample], max_capacity=10)

--- a/tests/unit_tests/data/test_multimodal_task_encoder.py
+++ b/tests/unit_tests/data/test_multimodal_task_encoder.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import importlib
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from examples.multimodal.data_loading import task_encoder
+from examples.multimodal.data_loading.task_encoder import (
+    MultiModalTaskEncoder,
+    _normalize_thinking_trace,
+)
+
+
+def _encoder(thread_count=8):
+    encoder = object.__new__(MultiModalTaskEncoder)
+    encoder.args = SimpleNamespace(video_decode_thread_count=thread_count)
+    return encoder
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("<think>reasoning</think>answer", "<think>\nreasoning</think>answer"),
+        (
+            "<think>\n  multi-line\nreasoning  \n</think>\n\nanswer",
+            "<think>\nmulti-line\nreasoning</think>answer",
+        ),
+        ("<think>  </think>\nanswer", "<think></think>answer"),
+    ],
+)
+def test_normalize_thinking_trace_ultra(content, expected):
+    assert _normalize_thinking_trace(content, thinking_trace_format="ultra") == expected
+
+
+def test_normalize_thinking_trace_uses_nemotron6_separator():
+    assert (
+        _normalize_thinking_trace(
+            "<think>reasoning</think>answer", thinking_trace_format="normalized"
+        )
+        == "<think>\nreasoning\n</think>\nanswer"
+    )
+
+
+class _FakeVideoStream:
+    def __init__(self):
+        self.codec_context = SimpleNamespace(thread_count=None, thread_type=None)
+        self.type = "video"
+
+
+class _FakeContainer:
+    def __init__(self):
+        self.closed = False
+        self.video_stream = _FakeVideoStream()
+        self.streams = [self.video_stream]
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+def _decoder_module():
+    return importlib.import_module(task_encoder.AVDecoder.__module__)
+
+
+def _fake_decoder(decoder_module, frames):
+    class FakeEnergonDecoder:
+        def get_clips(self, **kwargs):
+            with decoder_module.av_open(io.BytesIO(b"video")):
+                pass
+            return SimpleNamespace(video_clips=[[frame] for frame in frames])
+
+    return FakeEnergonDecoder()
+
+
+def test_video_decode_configures_threads_and_restores_hook(monkeypatch):
+    container = _FakeContainer()
+    decoder_module = _decoder_module()
+
+    def original_av_open(*args, **kwargs):
+        return container
+
+    monkeypatch.setattr(decoder_module, "av_open", original_av_open, raising=False)
+    monkeypatch.setattr(task_encoder, "tensor_to_pil", lambda image: image)
+
+    images = _encoder()._decode_video_frames_with_energon(
+        _fake_decoder(decoder_module, ["frame-0", "frame-1"]), [1.5, 0.25], thread_count=8
+    )
+
+    assert images == ["frame-0", "frame-1"]
+    assert container.video_stream.codec_context.thread_count == 8
+    assert container.video_stream.codec_context.thread_type == "FRAME"
+    assert decoder_module.av_open is original_av_open
+    assert container.closed
+
+
+def test_video_decode_disabled_preserves_original_open(monkeypatch):
+    container = _FakeContainer()
+    decoder_module = _decoder_module()
+
+    def original_av_open(*args, **kwargs):
+        return container
+
+    monkeypatch.setattr(decoder_module, "av_open", original_av_open, raising=False)
+    monkeypatch.setattr(task_encoder, "tensor_to_pil", lambda image: image)
+
+    images = _encoder(thread_count=0)._decode_video_frames(
+        _fake_decoder(decoder_module, ["frame"]), [0.0]
+    )
+
+    assert images == ["frame"]
+    assert container.video_stream.codec_context.thread_count is None
+    assert container.video_stream.codec_context.thread_type is None
+
+
+def test_video_decode_restores_hook_when_decode_raises(monkeypatch):
+    decoder_module = _decoder_module()
+
+    def original_av_open(*args, **kwargs):
+        return _FakeContainer()
+
+    class FailingDecoder:
+        def get_clips(self, **kwargs):
+            with decoder_module.av_open(io.BytesIO(b"video")):
+                raise RuntimeError("decode failed")
+
+    monkeypatch.setattr(decoder_module, "av_open", original_av_open, raising=False)
+
+    with pytest.raises(RuntimeError, match="decode failed"):
+        _encoder()._decode_video_frames_with_energon(FailingDecoder(), [0.0], thread_count=8)
+
+    assert decoder_module.av_open is original_av_open
+
+
+def test_video_decode_rejects_negative_thread_count():
+    decoder = SimpleNamespace(
+        get_clips=lambda **kwargs: pytest.fail("invalid config must fail before decode")
+    )
+    with pytest.raises(ValueError, match="must be non-negative"):
+        _encoder(thread_count=-1)._decode_video_frames(decoder, [0.0])
+
+
+@pytest.mark.parametrize("container_type", [tuple, list])
+def test_load_media_unwraps_grouped_video_results(monkeypatch, container_type):
+    class FakeAVDecoder:
+        suppress_warnings = False
+
+    decoder = FakeAVDecoder()
+
+    class FakeLazy:
+        def get(self, sample):
+            return container_type([decoder, "ignored metadata"])
+
+    lazy_media = FakeLazy()
+    frames = [
+        SimpleNamespace(media=SimpleNamespace(value=lazy_media, timestamp=0.0)),
+        SimpleNamespace(media=SimpleNamespace(value=lazy_media, timestamp=1.0)),
+    ]
+    encoder = _encoder()
+    monkeypatch.setattr(task_encoder, "AVDecoder", FakeAVDecoder)
+    monkeypatch.setattr(
+        encoder,
+        "_decode_video_frames",
+        lambda resolved_decoder, timestamps: [f"frame-{timestamp}" for timestamp in timestamps],
+    )
+
+    encoder._load_media(SimpleNamespace(images=frames))
+
+    assert [frame.media.value for frame in frames] == ["frame-0.0", "frame-1.0"]
+    assert decoder.suppress_warnings
+
+
+@pytest.mark.parametrize("container_type", [tuple, list])
+def test_load_media_unwraps_single_image_results(container_type):
+    resolved_image = object()
+    lazy_media = SimpleNamespace(
+        get=lambda sample: container_type([resolved_image, "ignored metadata"])
+    )
+    image = SimpleNamespace(media=SimpleNamespace(value=lazy_media))
+
+    _encoder()._load_media(SimpleNamespace(images=[image]))
+
+    assert image.media.value is resolved_image


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

## What does this PR do?

Add the Energon multimodal SFT data pipeline: conversation preprocessing and cookers, dynamic-resolution image/video preprocessing, sample packing, and resumable dataloaders. Preserve four atomic implementation commits with focused data tests.

This is part of a review-split multimodal SFT series. Production run scripts, data YAMLs, checkpoint conversion tooling, and separate CI compatibility fixes are outside this series.

## Dependencies and review scope

Targets `main`.

Functional prerequisites: #7248 (multimodal tokenizer formats) and #7249 (vision token utilities). Merge those before this PR. Full CI is deferred until these prerequisites are available; do not interpret this draft as independently ready.

## Validation

- Replayed onto public `main` at `46fb90ca942a2950c58c5654b3e56877e88a3e35`, preserving atomic signed and signed-off commits.
- The original combined feature stack had multi-node Super SFT validation before this migration; that is not an isolated-PR or rebased-head test result.
- GitHub CI is pending. No GPU tests have been rerun locally for these rebased heads.
- Local Black, isort, pylint, and Ruff checks passed for paths covered by the repository autoformat script (`megatron/core` and `tests`). Mypy is unavailable locally. Changed Python files pass syntax parsing; no CI configuration changes are included.

Kept as a draft pending CI and dependency integration.
