### PR TITLE
Add measured determinism coverage from kernel replay evidence

### DIFF
--- a/docs/developer/determinism/coverage.md
+++ b/docs/developer/determinism/coverage.md
@@ -1,0 +1,93 @@
+---
+orphan: true
+---
+
+# Measured determinism coverage
+
+Kernel registration says where tests belong. Measured coverage says which
+declared cases actually completed a replay protocol on a particular revision,
+software stack, GPU, and rank count.
+
+The initial producer annotates local fused-activation tests. The distributed
+cross-entropy test is not annotated: its process-group contract needs a separate
+adapter before its evidence can be reused by a recipe. Other kernel families
+remain visible in `inventory_without_declared_cases`; they are not included in
+the case percentage. This is incremental onboarding, not whole-model coverage.
+
+## Adding a case
+
+Mark a positive replay test with an operation ID from `kernels/manifest.py` and
+an implementation identifier that distinguishes backend and numerical variants:
+
+```python
+@pytest.mark.determinism_case(
+    op_id="fused_bias_swiglu", implementation="torch.compile:bias_swiglu"
+)
+def test_swiglu_replay():
+    # Construct representative inputs, then call the existing replay helper.
+    assert_replays_bit_exact(fn, inputs, replays=3, backward=True)
+```
+
+Parametrized tests declare separate cases. The harness records tensor shapes,
+strides, dtypes, gradient requirements, deterministic-algorithm mode, and the
+actual comparison protocol. Autocast, TF32, and cuDNN dispatch settings are
+recorded at each call, and the run context includes GPU driver versions.
+A test-file mapping or a marker alone cannot pass.
+Do not annotate artificial negative controls as production operations.
+
+The current protocol compares outputs and gradients within one process. It does
+not certify fresh-process dispatch, checkpoint restart, arbitrary shapes,
+unobserved internal kernels, or complete mutable training state. Correctness
+against an independent reference is a separate check.
+
+## Running and reporting
+
+The dedicated H100 kernel recipe enables collection and writes reports beside
+the uploaded logs, including on test failure. For a local GPU run, use a fresh
+output directory for each launch:
+
+```bash
+export DETERMINISM_EVIDENCE_RUN_ID=my-run
+export CUDA_DEVICE_MAX_CONNECTIONS=1 NCCL_ALGO=Ring
+export CUBLAS_WORKSPACE_CONFIG=:4096:8 NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+export MAMBA_DETERMINISTIC=1 CAUSAL_CONV1D_DETERMINISTIC=1
+uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest \
+  -p tools.determinism.pytest_plugin \
+  --determinism-evidence-dir /tmp/my-run/shards \
+  tests/unit_tests/determinism/kernels/test_fused_activations.py
+python -m tools.determinism.coverage /tmp/my-run/shards \
+  --revision "$(git rev-parse HEAD)" --output /tmp/my-run/coverage.json
+```
+
+The report also writes `coverage.md`. Collection persists each rank's declared
+cases before execution and updates observations as comparisons finish. Reusing
+a directory with duplicate rank shards is rejected rather than silently picking
+the best retry.
+
+| Status | Meaning |
+| --- | --- |
+| `verified_deterministic` | Nonempty replay evidence passed, all required ranks completed, and source provenance is current and clean |
+| `verified_nondeterministic` | An explicit identical-input replay mismatch was observed |
+| `not_verified` | Missing replay/rank, skipped or failed setup/teardown, interrupted session, or stale/dirty source |
+
+Expected failures are classified using the typed replay observation. An xfail
+caused by a missing dependency is unverified. A numerical mismatch remains
+nondeterministic even if pytest expected it. An XPASS is eligible only when the
+underlying replay actually completed.
+
+For the declared selected cases, deterministic coverage is `D / (D + N + U)`;
+verification coverage is `(D + N) / (D + N + U)`. An empty denominator produces
+null percentages. Always publish the selected case list and the unannotated
+inventory alongside these metrics; narrowing test selection changes the scope.
+
+The JSON schema is versioned. Consumers must match source and environment
+context before reusing observations. The `implementation` identifier is an
+author-maintained dispatch contract, not automatic introspection into TE or
+compiled kernels.
+
+CPU contract tests can run without importing the GPU test conftest:
+
+```bash
+PYTHONPATH=. python -m pytest --confcutdir=tests/unit_tests/determinism_reporting \
+  tests/unit_tests/determinism_reporting/test_coverage_evidence.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,7 @@ addopts = "--durations=15 -s -rA"
 testpaths = ["tests"]
 python_files = "test_*.py"
 markers = [
+    "determinism_case(op_id, implementation): measured kernel replay case",
     "internal: mark a test as a test to private/internal functions.",
     "flaky: mark flaky tests for LTS environment",
     "flaky_in_dev: mark flaky tests for DEV environment",

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -51,6 +51,14 @@ spec:
         TEST_PATH="/opt/megatron-lm-legacy/"
     fi
 
+    # Only the dedicated kernel bucket collects numerical evidence. Keep the
+    # report beside uploaded logs, including when pytest fails.
+    if [[ "$TAG" == "latest" && "$BUCKET" == "tests/unit_tests/determinism/kernels/**/*.py" ]]; then
+        export DETERMINISM_EVIDENCE_RUN_ID="{environment}-{platforms}-{tag}"
+        export PYTEST_ADDOPTS="${{PYTEST_ADDOPTS:-}} -p tools.determinism.pytest_plugin --determinism-evidence-dir={assets_dir}/logs/determinism-shards"
+        trap 'status=$?; cd "$TEST_PATH"; python -m tools.determinism.coverage "{assets_dir}/logs/determinism-shards" --output "{assets_dir}/logs/determinism-coverage.json" --revision "$(git rev-parse HEAD)" || status=1; exit "$status"' EXIT
+    fi
+
     bash $TEST_PATH/tests/unit_tests/run_ci_test.sh \
       --tag $TAG \
       --environment $ENVIRONMENT \

--- a/tests/unit_tests/determinism/kernels/harness.py
+++ b/tests/unit_tests/determinism/kernels/harness.py
@@ -19,6 +19,8 @@ Sizing matters more than replay count: a reduction with two contending blocks ca
 from __future__ import annotations
 
 import contextlib
+import functools
+import inspect
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import torch
@@ -30,10 +32,63 @@ from tests.unit_tests.determinism.utils import (
     restore_rng_state,
     zero_grads,
 )
+from tools.determinism.coverage import (
+    ReplayMismatch,
+    is_recording,
+    observe_replay,
+    runtime_signature,
+)
 
 # Shapes that make many CTAs contend on shared outputs. A token count of a few thousand
 # with a hidden size of ~1-4k puts dozens of blocks on every reduction.
 CONTENTION_TOKENS = 4096
+
+
+def _input_signature(value):
+    if isinstance(value, torch.Tensor):
+        return {
+            "shape": list(value.shape),
+            "stride": list(value.stride()),
+            "dtype": str(value.dtype),
+            "requires_grad": value.requires_grad,
+        }
+    if isinstance(value, dict):
+        return {str(key): _input_signature(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_input_signature(item) for item in value]
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    return {"type": type(value).__qualname__}
+
+
+def _recorded_replay(replay):
+    """Observe the existing protocol only inside explicitly annotated pytest cases."""
+
+    @functools.wraps(replay)
+    def wrapped(*args, **kwargs):
+        if not is_recording():
+            return replay(*args, **kwargs)
+        bound = inspect.signature(replay).bind(*args, **kwargs)
+        bound.apply_defaults()
+        options = bound.arguments
+        signature = {
+            "inputs": _input_signature(options["inputs"]),
+            "phase": "forward_backward" if options["backward"] else "forward",
+            "deterministic_algorithms": torch.are_deterministic_algorithms_enabled(),
+            "runtime": runtime_signature(torch),
+        }
+        protocol = {key: options[key] for key in ("replays", "contention", "restore_rng")}
+        protocol.update(
+            scope="same_process_outputs_and_gradients",
+            what=options["what"],
+            warn_only=torch.is_deterministic_algorithms_warn_only_enabled(),
+        )
+        with observe_replay(signature, protocol) as observation:
+            result = replay(*args, **kwargs)
+            observation.update(compared_outputs=len(result[0]), compared_gradients=len(result[1]))
+            return result
+
+    return wrapped
 
 
 def _clone_preserving_layout(t: torch.Tensor) -> torch.Tensor:
@@ -164,6 +219,7 @@ def run_once(
     return {k: v.detach().clone() for k, v in outputs.items()}, grads
 
 
+@_recorded_replay
 def assert_replays_bit_exact(
     fn: Callable[..., Any],
     inputs: Any,
@@ -218,7 +274,7 @@ def assert_replays_bit_exact(
 def _assert_replay_matches(i, ref_out, ref_grad, out, grad, what) -> None:
     """Raise if replay ``i`` differs from the reference in any output or gradient tensor."""
     if out.keys() != ref_out.keys() or grad.keys() != ref_grad.keys():
-        raise AssertionError(
+        raise ReplayMismatch(
             f"{what}: replay {i} returned different tensors "
             f"({sorted(out)}/{sorted(grad)} vs {sorted(ref_out)}/{sorted(ref_grad)})"
         )
@@ -232,7 +288,7 @@ def _assert_replay_matches(i, ref_out, ref_grad, out, grad, what) -> None:
         if not bytes_equal(ref_grad[name], grad[name])
     ]
     if mismatches:
-        raise AssertionError(
+        raise ReplayMismatch(
             f"{what} is not bit-exact across replays (replay {i} vs 1):\n  "
             + "\n  ".join(mismatches)
         )
@@ -309,6 +365,7 @@ def _module_fwd_bwd(module, inputs, grad_output, backward):
     return {k: v.detach().clone() for k, v in outputs.items()}, grads
 
 
+@_recorded_replay
 def assert_module_replays_bit_exact(
     module: torch.nn.Module,
     inputs: Any,

--- a/tests/unit_tests/determinism/kernels/test_fused_activations.py
+++ b/tests/unit_tests/determinism/kernels/test_fused_activations.py
@@ -12,7 +12,6 @@ only non-elementwise math, so shapes are sized to make those reductions wide.
 
 import pytest
 import torch
-import torch.nn.functional as F
 
 from megatron.core import activations, parallel_state
 from megatron.core.fusions.fused_bias_dropout import (
@@ -30,6 +29,7 @@ from megatron.core.transformer.utils import erf_gelu, gelu_impl
 from tests.unit_tests.determinism.kernels.harness import (
     CONTENTION_TOKENS,
     assert_replays_bit_exact,
+    deterministic_algorithms,
     seeded,
 )
 from tests.unit_tests.test_utilities import Utils
@@ -39,6 +39,12 @@ pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a G
 TOKENS = CONTENTION_TOKENS
 FFN = 8192
 DTYPE = torch.bfloat16
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_mode():
+    with deterministic_algorithms(True):
+        yield
 
 
 def _act(shape, dtype=DTYPE, grad=True):
@@ -98,7 +104,36 @@ GATED_CASES = {
 }
 
 
-@pytest.mark.parametrize("case", sorted(GATED_CASES))
+GATED_OP_IDS = {
+    "bias_swiglu": "fused_bias_swiglu",
+    "swiglu_no_bias": "fused_bias_swiglu",
+    "clamped_swiglu": "fused_bias_swiglu",
+    "situ_glu": "fused_bias_swiglu",
+    "weighted_swiglu": "fused_bias_swiglu",
+    "weighted_clamped_swiglu": "fused_bias_swiglu",
+    "weighted_situ_glu": "fused_bias_swiglu",
+    "bias_geglu": "fused_bias_geglu",
+    "geglu_no_bias": "fused_bias_geglu",
+    "weighted_quick_geglu": "fused_bias_geglu",
+    "weighted_clamped_quick_geglu": "fused_bias_geglu",
+    "bias_gelu": "fused_bias_gelu",
+    "weighted_squared_relu": "fused_weighted_squared_relu",
+    "weighted_clamped_squared_relu": "fused_weighted_squared_relu",
+}
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            case,
+            marks=pytest.mark.determinism_case(
+                op_id=GATED_OP_IDS[case], implementation="torch.compile:" + case
+            ),
+        )
+        for case in sorted(GATED_CASES)
+    ],
+)
 def test_mlp_activation_fusions_replay_bit_exactly(case):
     seeded()
     fn, inputs = GATED_CASES[case]()
@@ -119,7 +154,18 @@ ACTIVATION_CASES = {
 }
 
 
-@pytest.mark.parametrize("case", sorted(ACTIVATION_CASES))
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            case,
+            marks=pytest.mark.determinism_case(
+                op_id="compiled_activations", implementation="torch.compile:" + case
+            ),
+        )
+        for case in sorted(ACTIVATION_CASES)
+    ],
+)
 def test_compiled_activations_replay_bit_exactly(case):
     seeded()
     x = _act((TOKENS, FFN)) * 5.0
@@ -127,6 +173,9 @@ def test_compiled_activations_replay_bit_exactly(case):
     assert_replays_bit_exact(ACTIVATION_CASES[case], (x,), replays=3, what=case)
 
 
+@pytest.mark.determinism_case(
+    op_id="compiled_activations", implementation="torch.compile:attention_output_gate"
+)
 def test_attention_output_gate_replays_bit_exactly():
     """``Attention._apply_output_gate`` is a compiled method; ``self`` is unused."""
     seeded()
@@ -140,6 +189,7 @@ def test_attention_output_gate_replays_bit_exactly():
     )
 
 
+@pytest.mark.determinism_case(op_id="compiled_activations", implementation="torch.compile:L2Norm")
 def test_l2norm_replays_bit_exactly():
     """QK L2 norm: compiled row reduction (``pow(2).mean(-1)``) over head_dim."""
     seeded()
@@ -152,6 +202,9 @@ def test_l2norm_replays_bit_exactly():
 
 
 @pytest.mark.parametrize("residual_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.determinism_case(
+    op_id="fused_bias_dropout_add", implementation="torch.compile:bias_dropout_add_train"
+)
 def test_bias_dropout_add_fused_train_replays_under_restored_rng(residual_dtype):
     """Dropout consumes the CUDA RNG: identical mask, output and grads when the RNG is restored."""
     seeded()
@@ -167,6 +220,9 @@ def test_bias_dropout_add_fused_train_replays_under_restored_rng(residual_dtype)
     )
 
 
+@pytest.mark.determinism_case(
+    op_id="fused_bias_dropout_add", implementation="torch.compile:bias_dropout_add_inference"
+)
 def test_bias_dropout_add_fused_inference_replays_bit_exactly():
     seeded()
     x = _act((2048, 4, 4096), grad=False)
@@ -216,6 +272,9 @@ class TestFusedCrossEntropy:
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32], ids=["bf16", "fp32"])
 @pytest.mark.parametrize("layout", ["contiguous", "transposed"])
+@pytest.mark.determinism_case(
+    op_id="dsv4_q_rms_norm", implementation="torch.compile:dsv4_q_rms_norm"
+)
 def test_dsv4_q_rms_norm_replays(dtype, layout):
     """``_q_rms_norm`` (weightless RMS norm, ``torch.compile``) on a [s, b, heads, dim] query.
 

--- a/tests/unit_tests/determinism_reporting/test_coverage_evidence.py
+++ b/tests/unit_tests/determinism_reporting/test_coverage_evidence.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""CPU-only contract tests; run with --confcutdir at this directory."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.determinism.coverage import (
+    DETERMINISTIC,
+    NONDETERMINISTIC,
+    UNVERIFIED,
+    ReplayMismatch,
+    aggregate,
+    collect_observations,
+    main,
+    observe_replay,
+)
+
+pytest_plugins = ["pytester"]
+
+
+def shard(rank=0, world_size=1, status=DETERMINISTIC):
+    return {
+        "schema_version": 1,
+        "run_id": "ci-run-123",
+        "rank": rank,
+        "complete": True,
+        "context": {"revision": "a" * 40, "dirty": False, "world_size": world_size},
+        "inventory": {"tested": {}, "missing": {"exempt_reason": "Dependency absent"}},
+        "cases": {
+            "test_op[bf16]": {
+                "declaration": {"op_id": "tested", "implementation": "torch:example"},
+                "test_complete": True,
+                "observations": [{"status": status, "signature": {}, "protocol": {}}],
+            }
+        },
+    }
+
+
+def test_complete_rank_coverage_and_inventory_debt():
+    report = aggregate([shard(0, 2), shard(1, 2)])
+    assert report["counts"] == {"total": 1, DETERMINISTIC: 1, NONDETERMINISTIC: 0, UNVERIFIED: 0}
+    assert report["deterministic_percent"] == 100
+    assert report["inventory_without_declared_cases"] == {
+        "missing": {"exempt_reason": "Dependency absent"}
+    }
+
+
+@pytest.mark.parametrize(
+    "failure", ["rank", "session", "test", "observation", "case", "dirty", "stale"]
+)
+def test_incomplete_or_stale_evidence_cannot_turn_green(failure):
+    rows = [shard(0, 2), shard(1, 2)]
+    revision = "a" * 40
+    if failure == "rank":
+        rows.pop()
+    elif failure == "session":
+        rows[1]["complete"] = False
+    elif failure == "test":
+        rows[1]["cases"]["test_op[bf16]"]["test_complete"] = False
+    elif failure == "observation":
+        rows[1]["cases"]["test_op[bf16]"]["observations"] = []
+    elif failure == "case":
+        rows[1]["cases"] = {}
+    elif failure == "dirty":
+        for row in rows:
+            row["context"]["dirty"] = True
+    elif failure == "stale":
+        revision = "b" * 40
+    assert aggregate(rows, revision)["cases"][0]["status"] == UNVERIFIED
+
+
+def test_observed_mismatch_survives_xfail_and_missing_peer():
+    row = shard(0, 2, NONDETERMINISTIC)
+    row["cases"]["test_op[bf16]"]["test_complete"] = False
+    assert aggregate([row])["cases"][0]["status"] == NONDETERMINISTIC
+
+
+@pytest.mark.parametrize("field,value", [("revision", "b" * 40), ("world_size", 8)])
+def test_mixed_context_is_rejected(field, value):
+    rows = [shard(0, 2), shard(1, 2)]
+    rows[1]["context"][field] = value
+    with pytest.raises(ValueError, match="Cannot combine"):
+        aggregate(rows)
+
+
+def test_duplicate_ranks_are_not_retries_or_additional_coverage():
+    with pytest.raises(ValueError, match="Duplicate"):
+        aggregate([shard(), shard()])
+
+
+def test_empty_selection_has_no_percentage():
+    row = shard()
+    row["cases"] = {}
+    assert aggregate([row])["deterministic_percent"] is None
+
+
+@pytest.mark.parametrize(
+    "error,status",
+    [
+        (ReplayMismatch("bytes differ"), NONDETERMINISTIC),
+        (RuntimeError("CUDA unavailable"), UNVERIFIED),
+        (AssertionError("wrong reference"), UNVERIFIED),
+    ],
+)
+def test_only_typed_replay_mismatch_is_nondeterministic(error, status):
+    observations = []
+    with collect_observations(observations.append), pytest.raises(type(error)):
+        with observe_replay({}, {"replays": 3}):
+            raise error
+    assert observations[0]["status"] == status
+
+
+def test_success_requires_nonvacuous_observation_and_observer_is_restored():
+    observations = []
+    with collect_observations(observations.append):
+        with observe_replay({}, {"replays": 3}):
+            pass
+        with observe_replay({}, {"replays": 3}) as observation:
+            observation["compared_outputs"] = 1
+    with observe_replay({}, {}):
+        pass
+    assert [item["status"] for item in observations] == [UNVERIFIED, DETERMINISTIC]
+
+
+def test_forward_backward_requires_gradient_comparisons():
+    observations = []
+    with collect_observations(observations.append):
+        with observe_replay({"phase": "forward_backward"}, {"replays": 3}) as observation:
+            observation["compared_outputs"] = 1
+        with observe_replay({"phase": "forward_backward"}, {"replays": 3}) as observation:
+            observation.update(compared_outputs=1, compared_gradients=1)
+    assert [item["status"] for item in observations] == [UNVERIFIED, DETERMINISTIC]
+
+
+def test_cli_writes_matching_json_and_markdown(tmp_path):
+    (tmp_path / "rank-0.json").write_text(json.dumps(shard()))
+    target = tmp_path / "report.json"
+    assert main([str(tmp_path), "--output", str(target)]) == 0
+    assert json.loads(target.read_text())["deterministic_percent"] == 100
+    assert "Verification coverage: 100.0%" in target.with_suffix(".md").read_text()
+
+
+def test_real_pytest_lifecycle_uses_replay_evidence(pytester, monkeypatch):
+    root = Path(__file__).resolve().parents[3]
+    monkeypatch.setenv("PYTHONPATH", str(root))
+    monkeypatch.setenv("RANK", "0")
+    pytester.makeini("[pytest]\n")
+    manifest = pytester.path / "tests/unit_tests/determinism/kernels/manifest.py"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        "from types import SimpleNamespace\nKERNELS = [SimpleNamespace(name='op', sources=(), exempt_reason='')]\n"
+    )
+    pytester.makeconftest("""
+from tools.determinism import pytest_plugin
+pytest_plugin._context = lambda root: {'revision': 'a' * 40, 'dirty': False, 'world_size': 1}
+""")
+    pytester.makepyfile("""
+import pytest
+from tools.determinism.coverage import observe_replay, ReplayMismatch
+pytestmark = pytest.mark.determinism_case(op_id='op', implementation='test:op')
+
+def test_good():
+    with observe_replay({}, {'replays': 3}) as obs:
+        obs['compared_outputs'] = 1
+
+@pytest.mark.xfail(reason='known numerical mismatch')
+def test_numerical_xfail():
+    with observe_replay({}, {'replays': 3}):
+        raise ReplayMismatch('different bytes')
+
+@pytest.mark.xfail(reason='missing dependency')
+def test_setup_xfail():
+    raise RuntimeError('missing dependency')
+
+def test_no_replay():
+    pass
+
+@pytest.fixture
+def teardown_failure():
+    yield
+    raise RuntimeError('teardown failed')
+
+def test_failed_teardown(teardown_failure):
+    with observe_replay({}, {'replays': 3}) as obs:
+        obs['compared_outputs'] = 1
+""")
+    output = pytester.path / "evidence"
+    result = pytester.runpytest_subprocess(
+        "-p", "tools.determinism.pytest_plugin", "--determinism-evidence-dir", str(output)
+    )
+    result.assert_outcomes(passed=3, xfailed=2, errors=1)
+    rows = [json.loads(path.read_text()) for path in output.glob("rank-*.json")]
+    report = aggregate(rows)
+    states = {case["case_id"].split("::")[-1]: case["status"] for case in report["cases"]}
+    assert states == {
+        "test_good": DETERMINISTIC,
+        "test_numerical_xfail": NONDETERMINISTIC,
+        "test_setup_xfail": UNVERIFIED,
+        "test_no_replay": UNVERIFIED,
+        "test_failed_teardown": UNVERIFIED,
+    }

--- a/tools/determinism/__init__.py
+++ b/tools/determinism/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tools for recording and inspecting scoped determinism evidence."""

--- a/tools/determinism/coverage.py
+++ b/tools/determinism/coverage.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Aggregate measured replay evidence without importing GPU dependencies.
+
+Only an explicit replay mismatch is evidence of nondeterminism. Pytest outcomes,
+source registration, and exemptions are not numerical observations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import contextvars
+import json
+from pathlib import Path
+from typing import Callable, Iterator
+
+SCHEMA_VERSION = 1
+DETERMINISTIC = "verified_deterministic"
+NONDETERMINISTIC = "verified_nondeterministic"
+UNVERIFIED = "not_verified"
+STATUSES = (DETERMINISTIC, NONDETERMINISTIC, UNVERIFIED)
+_OBSERVER: contextvars.ContextVar[Callable[[dict], None] | None] = contextvars.ContextVar(
+    "determinism_observer", default=None
+)
+
+
+class ReplayMismatch(AssertionError):
+    """Identical-input replay produced different tensors or tensor contents."""
+
+
+def is_recording() -> bool:
+    """Return whether a caller is collecting replay observations."""
+    return _OBSERVER.get() is not None
+
+
+def runtime_signature(torch) -> dict:
+    """Record dispatch-affecting settings at the call, after test setup."""
+    return {
+        "autocast": torch.is_autocast_enabled(),
+        "autocast_dtype": str(torch.get_autocast_dtype("cuda")),
+        "float32_matmul_precision": torch.get_float32_matmul_precision(),
+        "matmul_allow_tf32": torch.backends.cuda.matmul.allow_tf32,
+        "cudnn_allow_tf32": torch.backends.cudnn.allow_tf32,
+        "cudnn_deterministic": torch.backends.cudnn.deterministic,
+        "cudnn_benchmark": torch.backends.cudnn.benchmark,
+    }
+
+
+@contextlib.contextmanager
+def collect_observations(sink: Callable[[dict], None]) -> Iterator[None]:
+    """Route replay observations to a test-local sink."""
+    token = _OBSERVER.set(sink)
+    try:
+        yield
+    finally:
+        _OBSERVER.reset(token)
+
+
+@contextlib.contextmanager
+def observe_replay(signature: dict, protocol: dict) -> Iterator[dict]:
+    """Record completed comparisons; preserve the original exception on failure.
+
+    The caller fills ``compared_outputs`` and ``compared_gradients`` after replay.
+    An unrelated assertion, unsupported operation, or infrastructure error remains
+    unverified, even if pytest marks it as an expected failure.
+    """
+    observation: dict = {"signature": signature, "protocol": protocol, "status": UNVERIFIED}
+    try:
+        yield observation
+    except ReplayMismatch as error:
+        observation.update(status=NONDETERMINISTIC, reason=str(error))
+        raise
+    except BaseException as error:
+        observation["reason"] = f"{type(error).__name__}: {error}"
+        raise
+    else:
+        if (
+            observation.get("compared_outputs", 0) > 0
+            and protocol.get("replays", 0) >= 2
+            and (
+                signature.get("phase") != "forward_backward"
+                or observation.get("compared_gradients", 0) > 0
+            )
+        ):
+            observation["status"] = DETERMINISTIC
+        else:
+            observation["reason"] = "Replay count or output/gradient comparisons were insufficient"
+    finally:
+        observer = _OBSERVER.get()
+        if observer is not None:
+            observer(observation)
+
+
+def case_status(observations: list[dict], test_complete: bool) -> str:
+    """Classify a case from numerical observations and test completion."""
+    statuses = [item["status"] for item in observations]
+    if NONDETERMINISTIC in statuses:
+        return NONDETERMINISTIC
+    if test_complete and statuses and all(status == DETERMINISTIC for status in statuses):
+        return DETERMINISTIC
+    return UNVERIFIED
+
+
+def aggregate(shards: list[dict], expected_revision: str | None = None) -> dict:
+    """Require matching provenance and complete rank coverage before assigning D.
+
+    The denominator is the union of declared, selected test cases. Untagged kernel
+    families are reported separately, never silently represented by passing tests
+    from the same source file. Missing ranks, interrupted runs, and dirty source
+    trees cannot produce a verified-deterministic case.
+    """
+    if not shards:
+        raise ValueError("No evidence shards supplied")
+    first = shards[0]
+    context = first["context"]
+    world_size = context["world_size"]
+    if not isinstance(world_size, int) or world_size < 1:
+        raise ValueError("world_size must be a positive integer")
+    by_rank = {}
+    for shard in shards:
+        if shard.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError("Unsupported evidence schema")
+        if shard["context"] != context or shard["run_id"] != first["run_id"]:
+            raise ValueError("Cannot combine different runs, source revisions, or environments")
+        rank = shard["rank"]
+        if not isinstance(rank, int) or not 0 <= rank < world_size or rank in by_rank:
+            raise ValueError(f"Duplicate or invalid rank: {rank}")
+        by_rank[rank] = shard
+    case_ids = sorted({case_id for shard in shards for case_id in shard["cases"]})
+    cases = []
+    for case_id in case_ids:
+        present = [shard["cases"][case_id] for shard in shards if case_id in shard["cases"]]
+        declaration = present[0]["declaration"]
+        if any(case["declaration"] != declaration for case in present):
+            raise ValueError(f"Different declarations for {case_id}")
+        observations = [
+            {**observation, "rank": rank}
+            for rank, shard in sorted(by_rank.items())
+            for observation in shard["cases"].get(case_id, {}).get("observations", [])
+        ]
+        for observation in observations:
+            if observation["status"] not in STATUSES:
+                raise ValueError(f"Unknown observation status in {case_id}")
+        complete = all(
+            rank in by_rank
+            and by_rank[rank]["complete"]
+            and by_rank[rank]["cases"].get(case_id, {}).get("test_complete", False)
+            and by_rank[rank]["cases"][case_id].get("observations")
+            for rank in range(world_size)
+        )
+        stale = expected_revision is not None and context["revision"] != expected_revision
+        dirty = context.get("dirty", True)
+        status = case_status(observations, complete)
+        reasons = sorted({case.get("reason", "") for case in present} - {""})
+        if stale or dirty:
+            # A mismatch remains in the raw observations, but is not evidence
+            # about the requested clean revision.
+            status = UNVERIFIED
+            reasons.append("Source revision is stale or has uncommitted changes")
+        elif not complete and status != NONDETERMINISTIC:
+            reasons.append("Missing replay, failed test phase, incomplete session, or missing rank")
+        cases.append(
+            {
+                "case_id": case_id,
+                **declaration,
+                "status": status,
+                "reasons": reasons,
+                "observations": observations,
+            }
+        )
+    counts = {status: sum(case["status"] == status for case in cases) for status in STATUSES}
+    total = len(cases)
+    tagged = {case["op_id"] for case in cases}
+    inventory = first.get("inventory", {})
+    if any(shard.get("inventory", {}) != inventory for shard in shards):
+        raise ValueError("Kernel inventories differ")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "determinism_coverage",
+        "run_id": first["run_id"],
+        "context": context,
+        "ranks_present": sorted(by_rank),
+        "scope": "Declared selected replay cases; outputs and gradients, not full training state",
+        "counts": {"total": total, **counts},
+        "deterministic_percent": 100 * counts[DETERMINISTIC] / total if total else None,
+        "verified_percent": (
+            100 * (counts[DETERMINISTIC] + counts[NONDETERMINISTIC]) / total if total else None
+        ),
+        "inventory_without_declared_cases": {
+            name: detail for name, detail in inventory.items() if name not in tagged
+        },
+        "cases": cases,
+    }
+
+
+def markdown_report(report: dict) -> str:
+    """Render a compact report, including visible unannotated inventory debt."""
+    counts = report["counts"]
+    lines = [
+        "# Determinism coverage",
+        "",
+        report["scope"],
+        "",
+        f"Revision: `{report['context']['revision']}`. Ranks: {report['ranks_present']}.",
+        "",
+        "| Deterministic | Nondeterministic | Unverified | Total cases |",
+        "| ---: | ---: | ---: | ---: |",
+        f"| {counts[DETERMINISTIC]} | {counts[NONDETERMINISTIC]} | {counts[UNVERIFIED]} | {counts['total']} |",
+        "",
+    ]
+    if counts["total"]:
+        lines.append(
+            f"Deterministic coverage: {report['deterministic_percent']:.1f}%. "
+            f"Verification coverage: {report['verified_percent']:.1f}%."
+        )
+    else:
+        lines.append("No declared cases: coverage percentages are unavailable.")
+    lines.extend(["", "| Case | Operation | Status |", "| --- | --- | --- |"])
+    for case in report["cases"]:
+        name = case["case_id"].replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| `{name}` | `{case['op_id']}` | {case['status']} |")
+    gaps = report["inventory_without_declared_cases"]
+    lines.extend(
+        [
+            "",
+            f"{len(gaps)} registered operation families have no declared cases in this selection.",
+            "These families are outside the case percentage above; registration is not verification.",
+            "",
+        ]
+    )
+    for name, detail in sorted(gaps.items()):
+        reason = detail.get("exempt_reason") or "No annotated case selected"
+        lines.append(f"- `{name}`: {reason}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Combine per-rank JSON shards and write machine and human reports."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("shards", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--revision", help="Revision whose evidence is requested")
+    args = parser.parse_args(argv)
+    report = aggregate(
+        [json.loads(path.read_text()) for path in sorted(args.shards.glob("rank-*.json"))],
+        args.revision,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False) + "\n")
+    args.output.with_suffix(".md").write_text(markdown_report(report))
+    print(markdown_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/determinism/pytest_plugin.py
+++ b/tools/determinism/pytest_plugin.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Opt-in pytest producer for per-rank replay evidence.
+
+Load with ``-p tools.determinism.pytest_plugin --determinism-evidence-dir DIR``.
+Only tests marked ``determinism_case(op_id=..., implementation=...)`` contribute
+to the denominator. Numerical outcomes come from the replay harness, not xfail.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.determinism.coverage import SCHEMA_VERSION, collect_observations
+
+ENVIRONMENT_KEYS = (
+    "CUDA_DEVICE_MAX_CONNECTIONS",
+    "CUBLAS_WORKSPACE_CONFIG",
+    "NCCL_ALGO",
+    "NCCL_PROTO",
+    "NVTE_ALLOW_NONDETERMINISTIC_ALGO",
+    "MAMBA_DETERMINISTIC",
+    "CAUSAL_CONV1D_DETERMINISTIC",
+)
+
+
+def _context(root: Path) -> dict:
+    import torch
+
+    versions: dict[str, str | None] = {}
+    for name in (
+        "torch",
+        "triton",
+        "transformer-engine",
+        "causal-conv1d",
+        "mamba-ssm",
+        "flash-attn",
+    ):
+        try:
+            versions[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            versions[name] = None
+    revision = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    dirty = bool(
+        subprocess.check_output(
+            ["git", "status", "--porcelain", "--untracked-files=normal"], cwd=root
+        )
+    )
+    driver: list[str] | None
+    try:
+        driver = sorted(
+            set(
+                subprocess.check_output(
+                    ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"], text=True
+                )
+                .strip()
+                .splitlines()
+            )
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        driver = None
+    return {
+        "revision": revision,
+        "dirty": dirty,
+        "world_size": int(os.environ.get("WORLD_SIZE", "1")),
+        "python": platform.python_version(),
+        "versions": versions,
+        "cuda": torch.version.cuda,
+        "driver": driver,
+        "gpu": torch.cuda.get_device_name() if torch.cuda.is_available() else None,
+        "capability": (
+            list(torch.cuda.get_device_capability()) if torch.cuda.is_available() else None
+        ),
+        "environment": {key: os.environ.get(key) for key in ENVIRONMENT_KEYS},
+    }
+
+
+class EvidencePlugin:
+    """Persist planned cases before execution so interruptions retain unknowns."""
+
+    def __init__(self, directory: Path, root: Path):
+        self.directory = directory
+        self.root = root
+        self.data = None
+        self.path = directory / f"rank-{os.environ.get('RANK', '0')}-{os.getpid()}.json"
+
+    def _write(self):
+        self.directory.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(self.data, indent=2, allow_nan=False) + "\n")
+        temporary.replace(self.path)
+
+    def pytest_collection_finish(self, session):
+        cases = {}
+        for item in session.items:
+            marker = item.get_closest_marker("determinism_case")
+            if marker is None:
+                continue
+            declaration = dict(marker.kwargs)
+            if (
+                marker.args
+                or set(declaration) != {"op_id", "implementation"}
+                or not all(isinstance(value, str) and value for value in declaration.values())
+            ):
+                raise pytest.UsageError(
+                    "determinism_case requires op_id and implementation strings"
+                )
+            cases[item.nodeid] = {
+                "declaration": declaration,
+                "observations": [],
+                "test_complete": False,
+            }
+        if not cases:
+            return
+        manifest_path = self.root / "tests/unit_tests/determinism/kernels/manifest.py"
+        spec = importlib.util.spec_from_file_location(
+            "_determinism_evidence_manifest", manifest_path
+        )
+        manifest = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = manifest
+        spec.loader.exec_module(manifest)
+        inventory = {
+            entry.name: {"sources": entry.sources, "exempt_reason": entry.exempt_reason}
+            for entry in manifest.KERNELS
+        }
+        unknown = {case["declaration"]["op_id"] for case in cases.values()} - inventory.keys()
+        if unknown:
+            raise pytest.UsageError(f"Unregistered determinism operation IDs: {sorted(unknown)}")
+        self.data = {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": os.environ.get("DETERMINISM_EVIDENCE_RUN_ID", "local"),
+            "rank": int(os.environ.get("RANK", "0")),
+            "context": _context(self.root),
+            "complete": False,
+            "inventory": inventory,
+            "cases": cases,
+        }
+        self._write()
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtest_call(self, item):
+        if self.data is None or item.nodeid not in self.data["cases"]:
+            return (yield)
+        case = self.data["cases"][item.nodeid]
+
+        def record(observation):
+            observation["signature"].update(case["declaration"])
+            case["observations"].append(observation)
+            self._write()
+
+        with collect_observations(record):
+            return (yield)
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtest_makereport(self, item, call):
+        report = yield
+        if self.data is None or item.nodeid not in self.data["cases"]:
+            return report
+        case = self.data["cases"][item.nodeid]
+        if report.when == "call":
+            case["test_complete"] = report.passed
+        if report.failed or report.skipped:
+            case["test_complete"] = False
+            case["reason"] = f"{report.when}: {report.outcome}"
+        self._write()
+        return report
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        if self.data is not None:
+            self.data["complete"] = int(exitstatus) in (0, 1)
+            self.data["exit_status"] = int(exitstatus)
+            self._write()
+
+
+def pytest_addoption(parser):
+    """Register the opt-in output path."""
+    parser.addoption("--determinism-evidence-dir", type=Path, default=None)
+
+
+def pytest_configure(config):
+    """Register the marker and install the producer only when requested."""
+    config.addinivalue_line(
+        "markers", "determinism_case(op_id, implementation): measured kernel replay case"
+    )
+    directory = config.getoption("--determinism-evidence-dir")
+    if directory is not None:
+        config.pluginmanager.register(
+            EvidencePlugin(directory, Path(config.rootpath)), "determinism-evidence"
+        )


### PR DESCRIPTION
**Continued in #7317, targeting `main`.** GitHub cannot reopen this PR because its former base branch, `pull-request/7148`, was deleted.

Kernel registration identifies where replay tests live, but a registered or passing test file cannot establish numerical determinism coverage. This adds an opt-in producer and JSON/Markdown reports that distinguish verified deterministic, verified nondeterministic, and unverified cases using observations from the replay harness.

The report requires completed comparisons on every expected rank before assigning deterministic status. Typed replay mismatches remain negative evidence even under xfail; missing dependencies, skipped/failed phases, interrupted ranks, and stale or dirty source remain unverified. Reports retain source, software/GPU/driver context, input signatures, call-time precision settings, and the comparison protocol.

Initial onboarding covers local fused-activation cases. Other registered families remain visible outside the selected-case percentage. The dedicated H100 kernel recipe uploads the reports beside its logs, including on failure. Distributed cross-entropy is deliberately left unannotated until its process-group contract has an adapter.

This is scoped same-process output/gradient replay evidence. It does not establish independent-reference correctness, fresh-process replay, or complete model/checkpoint determinism.

## Context

Builds on the kernel replay infrastructure merged in #7148. This PR targets `main`.

Related to #5785. Complements the functional coverage in #7217.

## Validation

- 20 CPU contract tests pass on the rebased head, including a real nested pytest session exercising xfail, missing replay, and failed teardown.
- Synthetic producer/recipe-consumer compatibility check passes, including per-signature rank completeness.
- Both H100 recipe variants render through the repository parser and pass `bash -n`.
- Repository autoformatter and explicit Black/isort/Ruff checks pass. The autoformatter's advisory mypy step cannot resolve local Torch dependencies; targeted tool type checks pass with unavailable imports ignored.
- Draft: actual H100 replay/evidence generation remains pending GPU CI.
