### PR TITLE
Add mcore-determinism-debug skill

### DIFF
--- a/skills/mcore-determinism-debug/SKILL.md
+++ b/skills/mcore-determinism-debug/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: mcore-determinism-debug
+description: Root-cause method when two Megatron runs that should be bit-identical diverge: fingerprint every op, diff the two traces, first mismatch is the culprit.
+license: Apache-2.0
+when_to_use: Two identical training runs give different loss; a run is bit-exact at N nodes but not 2N; you need to know which op, layer or kernel first diverged; 'nondeterminism', 'not bit-exact', 'runs diverge', 'determinism trace', 'first divergence', 'which kernel is nondeterministic'.
+metadata:
+  author: Zhiyu Li <zhiyul@nvidia.com>
+---
+
+# Find the first op that diverges
+
+## Answer-First Constants
+
+- **The loss curve tells you where the difference got big enough to print, not
+  where it started.** Do not debug from the divergent iteration number.
+- **The method:** run the job twice with the same seeds, data and config. Each
+  rank writes its own trace. Fingerprint every op. Diff the two traces offline,
+  aligned op by op. **The first mismatch is the culprit.**
+- **The test at each record:**
+  `hash(in_A) == hash(in_B) && hash(out_A) != hash(out_B)` → that op did it.
+  Everything before it matched. If the inputs differ too, keep walking back.
+- **"First" is only exact within one rank.** Across ranks there is no global
+  clock — order them causally by the input test, not by sequence number.
+- **Two capture layers.** *Semantic* — hooks at known boundaries (collectives,
+  recompute, optimizer, P2P) name the phase that diverged. *Op* — fingerprints
+  every ATen op's output, so TE / Triton kernels that bypass PyTorch surface at
+  the first op that reads their output.
+- **Traces are rank-local JSONL.** No collectives, no cross-rank ordering added
+  to the step being observed — tracing cannot perturb what it measures.
+- **Digests are computed on the GPU** with an order-independent reduction, so the
+  same bytes digest identically on any rank, GPU or topology. Use
+  `torch.hash_tensor`; only a scalar per tensor reaches the host. Byte-viewing
+  makes it dtype-agnostic, so MXFP8 / NVFP4 payloads and their scale buffers are
+  covered.
+- **Scope the capture.** Chosen steps (start / end / every N-th) and chosen
+  ranks (all, or a list like `0,3,8-15`), plus budget caps — that is what keeps
+  a multi-node campaign bounded. Off by default; zero cost unless enabled.
+- **No hypothesis is required, and none should be formed before the first
+  divergent record is in hand.**
+
+This skill documents a method, not a shipped feature — expect to supply the
+tracer rather than find one. `references/tracing-setup.md` §1 covers that first.
+
+## What "first" means
+
+The method rests on the word *first*, and it is only well-defined inside one
+rank. Get this wrong and you will name the wrong site.
+
+Within a rank the stream is totally ordered by `seq`, so the earliest divergent
+record is unambiguous. Across ranks there is no global clock — ranks agree on the
+*iteration* number and nothing finer, so never compare `seq` between two ranks.
+Order them causally instead: take each rank's own first divergence and classify
+it by the input test.
+
+  | That rank's first divergence | Means | Verdict |
+  |---|---|---|
+  | inputs **matched** | it produced a bad value from good inputs | **origin** — a candidate site |
+  | inputs **differed** | it consumed a bad value from elsewhere | **receiver** — downstream, ignore |
+
+  Only origins are candidates. Receivers are consequences that arrived over a
+  collective or P2P, however early their `seq` looks.
+
+- **Read the pattern across origins**, which tells you the class of bug:
+  - *Many ranks, same op identity* → the operation itself is nondeterministic;
+    any one of those ranks is a valid site, and you are looking at a kernel.
+  - *One rank, or a subset* → the operation is fine and the input distribution
+    is not; suspect reduction order, topology, or rank placement.
+  - *No origins, only receivers* → the true origin is outside the traced window
+    or on an untraced rank. Widen before concluding anything.
+
+The corollary is that **tracing a subset of ranks can only ever find an origin
+that happens to be in the subset.** When you scope by rank to control cost, a
+"no divergence found" result means nothing about the ranks you skipped.
+
+## Before you trace: two cheap checks
+
+Not the subject of this skill, but skipping them wastes a week:
+
+1. Is the suspect operation already a **known unsupported case** in
+   `docs/developer/determinism/op-catalog.md`? Then it is a documented gap, not
+   a bug to trace.
+2. Are the two runs genuinely comparable — same seed, data order, global batch,
+   parallelism layout, image? And compare full-precision serialized metrics, not
+   console logs, which print at limited precision.
+
+Everything below assumes both pass.
+
+## The method in code
+
+Two independent topics. **Capture** decides what is recorded, where, and under
+what identity. **The hash** decides how a tensor becomes one comparable value.
+Swapping either does not touch the other — treat the hash as pluggable.
+
+### Topic 1 — capture and diff
+
+This is the method. Illustrative, not an API:
+
+```python
+# CAPTURE — one record per op, per rank, written to a local file.
+# The occurrence counter is load-bearing: it gives every record an identity that
+# does not depend on arrival order, which is the only reason two independent
+# runs can be aligned offline.
+seen[op_name] += 1
+trace.record("op", op_name, {
+    "id":  f"{op_name}:{seen[op_name]}",
+    "in":  [trace.stage(x) for x in inputs],    # stage() keeps the digest on
+    "out": [trace.stage(y) for y in outputs],   # device; resolved at flush
+})
+
+# DIFF — offline. Align by IDENTITY, never by arrival order: if control flow
+# skews, position i in A and position i in B are different operations.
+index_b = {(e["name"], e["payload"]["id"]): e for e in stream_B}
+for a in stream_A:                   # A's own order is causal within one rank
+    b = index_b.get((a["name"], a["payload"]["id"]))
+    if b is None:
+        break                        # no counterpart -> control flow diverged
+    if a["payload"]["out"] != b["payload"]["out"]:
+        inputs_matched = a["payload"]["in"] == b["payload"]["in"]
+        break                        # True -> this op did it; False -> walk back
+```
+
+### Topic 2 — the hash function
+
+**Use `torch.hash_tensor`, and do not spend design effort here.** It is
+GPU-resident, order-independent, 1-ULP sensitive, and returns a `uint64` *tensor*
+you can stage — everything the method needs, and far cheaper than a hand-written
+digest.
+
+Two rules carry the rest:
+
+- **Never** `hash(tensor.numpy().tobytes())`. It is salted by `PYTHONHASHSEED`,
+  so it differs between processes — silently wrong for a cross-launch comparison.
+- **Chunk it** (`dim=`) on tensors whose failure mode is reordering: routing
+  maps, MoE dispatch, sort indices. Whole-tensor xor is permutation-blind; per
+  row or per chunk is not, and costs the same.
+
+Carry `shape`/`dtype`/`numel` alongside the digest — that is what separates an
+all-zero tensor from the empty-tensor sentinel. The reasoning, the benchmarks,
+and the one case for a custom digest: `references/tracing-setup.md` §3.
+
+## Workflow
+
+### 1. Reproduce at the smallest scale that still breaks
+
+Cheapest first — do not start on a cluster:
+
+- **Module level.** `tests/unit_tests/determinism/` runs a model or block twice
+  under restored RNG state and asserts bit-identical outputs and gradients,
+  parametrized over model presets × parallelism cells × FP8/FP4 recipes. If your
+  break reproduces by adding a case to `configs.PARALLELISM_CONFIGS`, you never
+  need an allocation — and that case is the regression test you will need later.
+- **Job level.** One node, N tasks = N **independent** runs from identical
+  state. Any difference between arms is a determinism failure. Four arms lets
+  you run two broken and two fixed in the same allocation, on the same hardware,
+  at the same time — which removes "different node" as an explanation.
+
+Shrink layers, iterations and sequence length as long as the break survives.
+
+**Do not centre the trace window on the iteration where the loss split.** That is
+the one mistake this skill exists to prevent, and it is easy to make twice. Bit
+divergence precedes visible divergence, usually by many iterations — a loss that
+splits at iteration 6 routinely has its first differing byte in iteration 1.
+Start the window at the **first** iteration and widen only if nothing is found.
+
+If iterations 1–2 are clean, the cause is state that has to accumulate before it
+differs — optimizer moments, a checkpoint/resume boundary, a periodic
+all-reduce. Bisect with a cheap rung (metrics or collectives only) over a wide
+range to find the first iteration containing *any* divergence, then spend the op
+layer on that single iteration.
+
+### 2. Climb the capture ladder — one rung at a time
+
+Climb only when the previous rung's blind spot is implicated. The big jump is
+rung 1 → 2: collectives alone are hundreds of records per iteration, every ATen
+op is tens of thousands. Rung 3 is cheap by comparison — it adds a handful of
+probes to a stream you are already paying for.
+
+| Rung | Capture | Answers |
+|---|---|---|
+| 0 | Full-precision metrics | First divergent **iteration** |
+| 1 | **Semantic layer** — collectives, recompute pairs, optimizer, P2P, grad slices before bucket reduce | Which **phase/boundary** diverged; catches the classic cross-process reduction-order break |
+| 2 | **Op layer** — every ATen op output via `TorchDispatchMode` | The exact **compute op** between boundaries |
+| 3 | **Targeted probe** — a hook on the extension call rung 2 cannot see (TE GEMM, fused wgrad, MoE dispatch) | The **library call** and its operand bits |
+| 4 | **Below the dispatcher** — `CUBLASLT_LOG_LEVEL=5`, `nsys` + `NVTE_NVTX_ENABLED=1`, then `ncu` | The **kernel symbol** and algo descriptor |
+
+Rungs 1–3 write into the *same* ordered stream, so the offline diff walks them
+together and the first divergence is comparable across layers.
+
+Two-stage strategy for cost: trace **collectives only** first — cheap, and it
+catches the usual multi-node reduction-order break. Add the op layer only on the
+narrowed window, when you need to see *inside* the compute of the divergent
+phase.
+
+Practical rules:
+
+- Trace a **bounded iteration window** (e.g. `1-2`), not a whole job.
+- Streams go to a **shared filesystem** so one process can diff both runs.
+- A traced run is slower — raise `--distributed-timeout-minutes` so the NCCL
+  watchdog does not fire on the instrumented iterations.
+- The op layer is **incompatible with CUDA-graph capture**. Disable graphs.
+
+`references/tracing-setup.md` covers where the tracer lives, the call-site
+lifecycle, cost controls, read-only-container injection, and writing a rung-3
+probe.
+
+### 3. Read the first divergence correctly
+
+Three failure modes turn a correct trace into a wrong conclusion. Full versions
+in `references/reading-traces.md`:
+
+- **One hop later.** Kernels that bypass the torch dispatcher (TE GEMM and fused
+  attention, Triton/FLA, DeepEP/HybridEP dispatch) are invisible to the op
+  layer. A divergence born inside one surfaces at the **first ATen op that reads
+  its output**. When the first divergent record is an obviously deterministic op
+  — a `slice`, a `view`, an elementwise add — with matched inputs, the culprit
+  is the uninstrumented producer above it. Add a rung-3 probe there.
+- **Probe artifacts.** Uninitialized memory (`aten.empty*`), in-flight async
+  collective buffers, and tensors caught mid-DMA (`_to_copy` of a
+  `non_blocking=True` host copy) read as divergences and are not.
+- **Digest semantics.** An order-independent digest is a strong *screen* for
+  value divergence, not a collision-proof key; compare `shape`/`dtype` alongside
+  it, and never compare digests across schema versions.
+
+### 4. Turn a site into a mechanism
+
+A named op is not yet a cause. Build a **discriminator table**: hold the site
+fixed and vary one axis at a time across instances you already captured —
+output dtype, layout, operand dtype, accumulate flag, fused vs unfused path.
+The break lives in one cell. Every cell should come from records already in your
+streams — no new hypothesis, no new job. Only when the table points below the
+dispatcher do you climb to rung 4 and name the kernel.
+`references/reading-traces.md` has a worked discriminator table.
+
+### 5. Prove the fix, then report
+
+A fix is proven by a **paired run**, not by one clean run:
+
+- 2 arms with the fix, 2 without, same job, same seed, N iterations, compared on
+  full-precision metrics.
+- The unfixed pair **must diverge** — otherwise the repro is not live and the
+  run proves nothing — and the fixed pair must be bit-identical for all N.
+- Say whether the claim is within-allocation or **cross-allocation**; repeating
+  work inside one allocation exercises less than the contract promises.
+- State the measured cost and whether the fix is **principled** (it removes the
+  nondeterministic operation) or **incidental** (it steers off the
+  nondeterministic code path). Incidental fixes need a regression test, because
+  nothing stops a future heuristic from routing back onto a bad path.
+
+Write down what you **falsified**, not just what you found. Half the value of a
+determinism investigation is the list of levers that do not work.
+
+## Worked example
+
+A break in a low-precision weight-gradient path, compressed to show the method.
+
+```
+Rung 0   Arms diverge at iteration 6.
+Rung 1-3 One ordered stream, iterations 1-2: ~74K records/arm
+         (~71K aten + ~2.3K gemm + ~1K grad + ~150 collective).
+         The gemm and grad probes were rung-3 additions: the GEMM is a pybind
+         call that never reaches the dispatcher, and the fused wgrad writes its
+         buffer through a kernel that is equally invisible. Without them the
+         trace reports a downstream consumer, not the site.
+```
+
+First divergence, in execution order:
+
+```
+seq=2547  gemm:NT:acc0:grad1   inputs=MATCH
+  in : <low-precision operands + scale buffers>   all SAME
+       float32(M,N) accumulator, zeroed           SAME
+  out: float32(M,N)   A be0de2f5…  B 804b6328…    DIFFERENT
+```
+
+Before it: 2,445 ATen ops, 93 GEMMs, 9 collectives — all bit-identical. Same
+result in all six arm pairs. The known `_to_copy` mid-DMA artifact appears sixth
+in the divergence list, not first, so it is not confounding the verdict.
+
+Discriminator table, built entirely from records already captured:
+
+```
+gemm:TN:acc0:grad0   forward   D=bf16   CLEAN
+gemm:NN:acc0:grad1   dgrad     D=bf16   CLEAN
+gemm:NT:acc0:grad1   wgrad     D=fp32   DIVERGENT
+gemm:NT:acc1:grad1   wgrad     D=fp32   DIVERGENT
+```
+
+`accumulate=False` diverges too → accumulation is **not** the mechanism. Operand
+dtype is identical in all four rows → not the operands alone. The discriminator
+is **fp32 output on the wgrad GEMM**. Zero additional jobs were needed.
+
+Both wrong turns here were hypothesis-first: a probe built to test "it must be
+the accumulate epilogue", and a mechanism inferred from "flag X fixes it". The
+first-divergence walk falsified each in one command — the first divergent GEMM
+had `accumulate=False`, and flag X turned out to change two things at once.
+
+## Anti-patterns
+
+Each of these has cost real days.
+
+- **Designing an experiment around a hypothesis when the stream already has the
+  answer.** The first-divergence walk needs no theory and beats one.
+- **Inferring a mechanism from "flag X fixes it."** Read what flag X changes.
+  It usually changes more than one thing.
+- **Reporting a first divergence without checking the inputs matched.**
+- **Believing a divergence on a trivially deterministic op.** That is the
+  one-hop-later signature of an uninstrumented producer.
+- **Trusting a determinism env var without checking scope.** Verify the knob
+  reaches the path you care about: grep the symbol in the shipped library and
+  read the call site. `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0` governs TE's
+  *attention backend* selection — do not assume it covers GEMMs.
+- **Claiming a kernel name from reasoning.** Name it from two independent
+  instruments that agree on the launch count, or say you have not named it.
+- **Stopping at "it's nondeterministic."** Push to the ceiling of what is
+  observable from outside a closed binary — kernel symbol, algo descriptor,
+  problem descriptor, one-flag toggle — then say explicitly that the rest needs
+  `ncu` or the owning library team.
+
+## References
+
+- `references/tracing-setup.md` — where the tracer lives, the call-site
+  lifecycle, env knobs, cost controls, read-only-container injection, writing a
+  rung-3 probe.
+- `references/reading-traces.md` — anatomy of a divergence record, blind spots
+  and the one-hop rule, known probe artifacts, fingerprint semantics.
+- `docs/developer/determinism/op-catalog.md` — the known-unsupported list, for
+  the pre-trace check only.
+
+## Related skills
+
+- `mcore-run-on-slurm` — launching the multi-arm repro job.
+- `mcore-testing` — turning the verified fix into a regression test.

--- a/skills/mcore-determinism-debug/references/reading-traces.md
+++ b/skills/mcore-determinism-debug/references/reading-traces.md
@@ -1,0 +1,122 @@
+# Reading a divergence
+
+A correct trace plus a careless read produces a confident wrong answer. This
+file is the checklist between "I have a first divergence" and "I know the site".
+
+## Anatomy of a record
+
+```
+seq=2547  gemm:NT:acc0:grad1   inputs=MATCH
+  in : uint8(6144,9216)  uint8(6144,1152)  uint8(18432,3072)
+       uint8(6144,9216)  uint8(18432,384)  uint8(6144,1152)    all SAME
+       float32(6144,6144) digest 0000…0000                     SAME
+  out: float32(6144,6144)   A be0de2f5…   B 804b6328…          DIFFERENT
+```
+
+Read it in this order:
+
+1. **`inputs=MATCH`?** If no, you are downstream of the cause — keep walking
+   back. Only an inputs-matched / output-differs record is a root-cause
+   candidate.
+2. **Are the inputs actually fingerprinted, or trivially empty?** A record with
+   zero input entries "matches" vacuously. Confirm real digests on real shapes.
+3. **What is before it?** Report the count: "2,445 ATen ops, 93 GEMMs, 9
+   collectives, all bit-identical." That number is the claim's strength.
+4. **Does it reproduce across arm pairs?** Same first divergence in 0v1, 0v2,
+   0v3 is a property of the code. One pair is an anecdote.
+5. **Is this op plausibly nondeterministic?** If not, see "one hop later".
+
+## One hop later — the most common misread
+
+The op layer only sees the torch dispatcher. These bypass it entirely:
+
+| Bypass | Surfaces at |
+|---|---|
+| TE `general_gemm` (pybind → cuBLASLt) | first ATen op consuming the GEMM output |
+| Fused wgrad writing `main_grad` | the gradient at `optimizer.step()`, or a later reduce |
+| cuDNN / TE fused attention | validated example: the RoPE-backward `aten.slice` that reads the attention gradients |
+| Triton / FLA kernels | first ATen consumer |
+| DeepEP / HybridEP `fused_a2a`, `hybrid_ep_cpp` | first ATen op reading the dispatched tokens |
+
+**Rule:** when the first divergent record is an op that cannot itself be
+nondeterministic — a `slice`, `view`, `cat`, elementwise add — with matched
+inputs, do not report it. Read *up* to what produced its input and add a rung-3
+probe there. The trace is telling you the truth; it just cannot see the
+producer.
+
+Conversely, when the first divergent record *is* a heavy fused compute op with
+matched inputs, that is the site.
+
+## Known probe artifacts
+
+These read as divergences and are not. Exclude them before acting:
+
+- **`aten.empty*` family.** Returns uninitialized memory; its contents differ
+  run-to-run by definition. Good tracers skip this family — if yours reports it,
+  it is an artifact.
+- **`c10d` collective ops seen by the dispatch mode.** For async collectives the
+  dispatcher sees an in-flight buffer. Collectives belong to the semantic layer,
+  which records them at the consumer's `wait`.
+- **`aten._to_copy` of a small int64 count tensor where one side reads all-zero.**
+  This is the tracer catching a `maybe_move_tensor_to_cpu(non_blocking=True)`
+  mid-DMA. An observation error, not a divergence in training state.
+
+General test for an artifact: *would a difference here actually propagate into
+the next iteration's weights?* If the value is never read, or is read after a
+sync that the tracer preempted, it is an artifact.
+
+## What the fingerprint guarantees
+
+Know your digest before you argue from it:
+
+- **Order independence** is what makes a digest identical across processes, GPUs
+  and topologies — the property a cross-job key needs. Every recommended digest
+  has it; they differ in what else they catch.
+- A plain xor-style reduction (`torch.hash_tensor`) is order-independent and
+  1-ULP sensitive but **permutation-invariant** — see `tracing-setup.md` §3 for
+  what that does and does not cover.
+- **Byte-viewing rather than upcasting** keeps the digest dtype-agnostic, so
+  fp8/fp4 payloads, int64 routing maps and uint8 scale buffers are all covered.
+- **Never compare digests across schema versions.** A reweighted digest makes
+  every record look divergent.
+
+## Turning records into a discriminator table
+
+The stream already contains many instances of the divergent call under different
+configurations. Group them and read off the axis that discriminates:
+
+```
+gemm:TN:acc0:grad0   forward   D=bf16    CLEAN
+gemm:NN:acc0:grad1   dgrad     D=bf16    CLEAN
+gemm:NT:acc0:grad1   wgrad     D=fp32    DIVERGENT
+gemm:NT:acc1:grad1   wgrad     D=fp32    DIVERGENT
+```
+
+Here `accumulate` is ruled out (both `acc0` and `acc1` diverge) and operand
+dtype is ruled out (identical in all four rows). The discriminator is **fp32
+output on the NT wgrad**. That conclusion cost zero additional jobs.
+
+Then cross it against the other operand family to separate "selects the kernel
+family" from "breaks the kernel":
+
+```
+              D = bf16   D = fp32
+FP4 operands  clean      BREAKS
+BF16 operands clean      clean
+```
+
+Only the intersection breaks — so neither factor alone is the cause, and any fix
+that changes only one of them is incidental.
+
+## Before you report
+
+- [ ] Certification passed on at least one trace tree.
+- [ ] First divergence has `inputs=MATCH` with non-empty, real input digests.
+- [ ] It is not on the artifact list.
+- [ ] It is not a trivially-deterministic op standing in for an uninstrumented
+      producer.
+- [ ] It reproduces across all arm pairs.
+- [ ] The discriminator table names the axis, and you can say what each
+      candidate factor was *ruled out* by.
+- [ ] Any kernel name comes from two agreeing instruments, or is stated as not
+      yet named.

--- a/skills/mcore-determinism-debug/references/tracing-setup.md
+++ b/skills/mcore-determinism-debug/references/tracing-setup.md
@@ -1,0 +1,639 @@
+# Arming the tracer
+
+The method in `SKILL.md` needs one thing from the code: an ordered, per-rank
+stream of fingerprinted events. This file covers where that instrumentation
+lives, how to turn it on, what it costs, and what to do when it does not exist
+where you need it.
+
+## 1. Find the interface before assuming one
+
+A tracer is four pieces. Module names and paths have differed across branches and
+between repos, so **search for them rather than trusting a path from any
+document, including this one**:
+
+| Piece | What it does | Search for |
+|---|---|---|
+| Digest | tensor → one comparable value | `hash_tensor`, `signature`, `digest`, `fingerprint` |
+| Semantic layer | records collectives / recompute / optimizer boundaries | `collective_trace`, `record_collective` |
+| Op layer | fingerprints every ATen op output | `TorchDispatchMode`, `op_trace` |
+| Comparator | offline first-divergence diff | `diff_streams`, `compare_traces` |
+
+```bash
+# What exists, and how is it switched on?
+grep -rln "TorchDispatchMode\|hash_tensor" --include=*.py megatron/ src/ tools/ scripts/ 2>/dev/null
+grep -rn "DET_TRACE\|determinism.trace" --include=*.py megatron/ src/ tools/ scripts/ 2>/dev/null | head -40
+```
+
+Expect to find nothing. At the time of writing no Megatron repo ships this
+tracer on its main branch — it has existed only on feature branches — so the
+normal case is that you supply it. Three options, cheapest first:
+
+1. **Skip tracing entirely.** If the break reproduces in
+   `tests/unit_tests/determinism/`, you have a faster loop and a regression test
+   in one; take it.
+2. **Port a tracer onto your branch** from wherever the current implementation
+   lives — §2 and §3 describe what it has to do.
+3. **Inject it without touching the source tree**, via `PYTHONPATH` (§7). This is
+   the option for a read-only container.
+
+## 2. Capture — what goes into the stream
+
+> **Capture and hashing are separate concerns.** This section decides *what* is
+> recorded, *where*, and under *what identity* — that is the method, and it is
+> where the debugging value lives. §3 decides how a tensor becomes one comparable
+> value; it has a clear default (`torch.hash_tensor`) and you should not spend
+> design effort there. The two are genuinely decoupled — the same capture layer
+> sits above either digest — but decoupled does not mean equally worth your time.
+
+The snippets in §2–§4 are minimal but composable: a writer, an op layer, a
+digest (§3) and a comparator (§4) are a working tracer. Build that first, confirm
+it finds a divergence you already know about, then add semantic probes (§6).
+
+### The stream writer
+
+Everything else feeds this. Note what it does *not* do: no collectives, no
+cross-rank coordination, and no `.item()` per tensor.
+
+```python
+SCHEMA_VERSION = 1          # bump on ANY digest change; the comparator refuses
+                            # to diff across it (§4)
+_STAGED = re.compile(r"__staged_(\d+)__")
+
+class Trace:
+    """One rank's stream for one iteration. Append-only JSONL."""
+
+    def __init__(self, out_dir, rank, iteration, flush_every=256):
+        self.path = Path(out_dir) / f"rank{rank:05d}_iter{iteration:06d}.jsonl"
+        self.fh = self.path.open("w")
+        self.rank, self.iteration = rank, iteration
+        self.seq, self.events, self.staged = 0, [], []
+        self.flush_every = flush_every
+        self.is_open = True             # the op layer checks this before recording
+
+    def stage(self, t):
+        """Keep the digest on device; return a placeholder to substitute at flush."""
+        self.staged.append(fingerprint(t))          # device tensor, NOT .item()
+        return f"__staged_{len(self.staged) - 1}__"
+
+    def record(self, kind, name, payload):
+        self.events.append({"schema_version": SCHEMA_VERSION, "seq": self.seq,
+                            "rank": self.rank, "iteration": self.iteration,
+                            "kind": kind, "name": name, "payload": payload})
+        self.seq += 1
+        # Bound BOTH lists: one event can stage many tensors, so events alone
+        # is not a bound on how much device state is pending.
+        if len(self.events) >= self.flush_every or len(self.staged) >= 4 * self.flush_every:
+            self.flush()
+
+    def flush(self):
+        if not self.events:
+            return
+        # The ONE host sync: every pending digest resolves in a single transfer.
+        values = torch.stack(self.staged).tolist() if self.staged else []
+        blob = "\n".join(json.dumps(e, separators=(",", ":")) for e in self.events)
+        # One pass. Substituting in a loop rescans the whole blob per digest,
+        # which turns a larger flush_every into a quadratic cost.
+        blob = _STAGED.sub(lambda m: f"{values[int(m[1])] & 0xFFFFFFFFFFFFFFFF:016x}", blob)
+        self.fh.write(blob + "\n")
+        self.fh.flush()                 # a crashed run still has everything prior
+        self.events, self.staged = [], []
+
+    def close(self):
+        self.flush()                    # the tail is lost without this
+        self.is_open = False
+        self.fh.close()
+```
+
+Helpers the snippets assume you supply: `active_trace()` (returns the trace for
+the current rank/iteration, or `None`), `_tensors(x)` (flatten a tensor / tuple /
+list to its tensors), `signature(trace, t)` (`shape`/`dtype`/`numel` plus
+`trace.stage(t)`), and `_op_identity(trace, name)` (a per-`(trace, name)`
+occurrence counter). None are subtle; all must be consistent across every layer
+that writes into one stream.
+
+`SCHEMA_VERSION` is not decoration — bump it whenever the digest definition
+changes, and have the comparator refuse to diff across it (§4).
+
+### The op layer, distilled
+
+```python
+class OpTraceMode(TorchDispatchMode):
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        out = func(*args, **(kwargs or {}))
+        if _SUSPENDED.value or (trace := active_trace()) is None or not trace.is_open:
+            return out
+        name = str(func)
+        if any(tok in name for tok in ("empty", "c10d")):
+            return out              # uninitialized memory; collectives belong to
+                                    # the semantic layer (async = in-flight buffer)
+        _SUSPENDED.value = True     # the tracer itself runs tensor ops
+        try:
+            sigs = [signature(trace, t) for t in _tensors(out) if t.numel() > 0]
+            if sigs:
+                with _LOCK:                        # backward ops arrive from
+                    i = _op_identity(trace, name)  # autograd engine threads
+                trace.record("op", name, {
+                    "id": f"aten:{name}:{i}",   # run-independent identity; the
+                                                # comparator (§4) keys on this
+                    "scope": current_scope(),   # decoder.layers.7.mlp -- see below
+                    "out": sigs,                # "in" too, if you fingerprint inputs
+                })
+        finally:
+            _SUSPENDED.value = False
+        return out
+
+# signature() = shape/dtype/numel plus trace.stage(t) for the digest placeholder.
+# Carry shape/dtype/numel alongside the digest: it is what distinguishes an
+# all-zero tensor from the empty-tensor sentinel (§3).
+```
+
+The per-`(trace, op-name)` occurrence counter is the load-bearing part: it gives
+every record an identity that does not depend on arrival order, which is what
+lets the offline comparator align two runs semantically. Signatures cover
+**every** dtype — integer and bool divergences (routing indices, argmax results)
+are real non-determinism and must not be dropped. Oversize outputs record
+`digest: "skipped_oversize"` with shape and dtype intact, so a divergence
+surfaces at the first under-cap tensor downstream instead of vanishing.
+
+### Name scope — where to attach it
+
+Without this, a divergence reads `aten.slice#4417`, which tells you nothing. With
+it, it reads `decoder.layers.7.mlp / aten.slice#12`, which tells you where to
+look. The scope is cheap and it is the difference between an actionable finding
+and a record id.
+
+Hook it on the **module**, not the op — `nn.Module` forward hooks are the only
+place that knows the name:
+
+```python
+_SCOPE = contextvars.ContextVar("scope", default=())   # NOT a global: backward
+                                                       # runs on autograd threads
+
+def register(root, prefix=""):
+    for name, mod in root.named_modules():
+        if not name:
+            continue
+        label = prefix + name
+        # Pre-hook pushes, post-hook pops -> the stack is exact even with
+        # nesting, early returns, and recursion.
+        mod.register_forward_pre_hook(
+            lambda m, a, l=label: _SCOPE.set(_SCOPE.get() + (l,)))
+        mod.register_forward_hook(
+            lambda m, a, o: _SCOPE.set(_SCOPE.get()[:-1]))
+
+def current_scope():
+    return "/".join(_SCOPE.get())      # record this on every event
+```
+
+Three rules that are easy to get wrong:
+
+- **Prefix per model chunk.** With VPP or any multi-chunk model, two chunks have
+  modules with identical relative names (`decoder.layers.0...`). Without a
+  `chunk{i}.` prefix the offline diff cannot tell them apart and alignment
+  silently breaks.
+- **Use a `ContextVar`, not a module-level global.** Backward executes on
+  autograd engine threads; a plain global gives you one thread's scope stamped
+  onto another thread's records.
+- **Do not extend scope into backward by hooking module outputs.** Backward
+  hooks that alias module outputs break pipeline-parallel output deallocation.
+  Backward divergences are still captured — they just carry the forward scope
+  rather than a `[bwd]` label. If you want true backward labels, keep it to
+  TP-only debugging runs.
+
+Two interface styles exist. Check which one you have:
+
+- **Config/argument-driven** — the training loop opens a trace for chosen
+  iterations. A context-manager API makes the wiring a few lines at the top of
+  the step:
+
+  ```python
+  with trace_iteration(trace_dir, iteration, hash_tensors=True):
+      with op_trace_mode(enable_op_layer):   # rung 2; omit for rung 1 only
+          ...                                # the existing train_step body
+  ```
+
+  If your checkout has the core module but no call site, that wiring is the
+  piece you add. Keep it gated so `trace_dir=None` is a no-op.
+
+- **Environment-driven** — the tracer self-installs and reads env vars. The
+  names below are **illustrative, not an interface that exists in this repo** —
+  they show which knobs are worth having, not what to type:
+
+  | Env var | Effect |
+  |---|---|
+  | `DET_TRACE_OUT_DIR` | Stream directory; **setting it enables the tracer**. Use a shared FS. |
+  | `DET_TRACE_ITERS` | Window: `all`, `a-b`, or a list `1,5,40-44`. Default `1`. |
+  | `DET_TRACE_OPS=1` | Rung 2 — fingerprint every ATen op output. |
+  | `DET_TRACE_OP_MAXNUMEL=N` | Skip outputs above N elements (0 = no cap). |
+  | `DET_TRACE_FLUSH_EVERY=N` | Digest resolve/flush batch size. |
+
+  Repo-specific probes may add more (`DET_TRACE_GEMM`, `DET_TRACE_GRADS`,
+  `DET_TRACE_MOE`, …) — see §6.
+
+### The call-site lifecycle
+
+Whichever style you have, the wiring the training loop owns is the same four
+moves. Condensed from the Megatron-Bridge `train.py` wiring:
+
+```python
+# --- once, before the loop: install capture, inert if the env var is unset ---
+if out_dir := os.environ.get("DET_TRACE_OUT_DIR"):
+    collective_trace.enable(out_dir=out_dir)
+    for i, chunk in enumerate(model):
+        # Per-chunk prefix, or VPP / multi-chunk runs collide on identical
+        # relative module names and the offline diff cannot align them.
+        module_scope.register(chunk.module, prefix=f"chunk{i}." if len(model) > 1 else "")
+    if os.environ.get("DET_TRACE_OPS"):
+        op_trace.enable()                      # rung 2
+
+# --- per iteration: scope the window ---
+on = trace_iters is None or step in trace_iters
+if on:
+    collective_trace.set_active(True, window=step)
+try:
+    train_step(...)
+finally:
+    if on:
+        collective_trace.set_active(False)     # must be try/finally: a recovered
+                                               # exception would otherwise leave
+                                               # tracing armed for later iterations
+
+# --- after the loop: flush streams and restore the patched call sites ---
+op_trace.disable(); module_scope.unregister(); collective_trace.disable()
+trace.close()        # flushes the tail; without it you lose the last partial batch
+```
+
+The three details that are easy to get wrong and expensive to debug: the
+**per-chunk prefix** (alignment), the **`try`/`finally`** (a leaked active window
+silently changes what later iterations capture), and **teardown order** (op layer
+first, stream last, so the last records still have somewhere to go).
+
+## 3. The hash function — use `torch.hash_tensor`
+
+Independent of §2. Capture decides what to record; this decides how a tensor
+becomes one comparable value. **Use the native op.** The comparison below is why.
+
+### Why an xor reduction at all
+
+The digest reduces millions of lanes on the GPU, and the reduction tree order is
+not fixed — it varies with block count, occupancy, chunk size and device. So the
+combining operation must be **associative and commutative in exact arithmetic**.
+That one requirement eliminates most candidates before any quality argument:
+
+| Reduction | Order-independent? | Verdict |
+|---|---|---|
+| **Floating-point sum** | **No** — fp addition is not associative | Disqualified. This is the exact bug you are hunting; the instrument would manufacture its own false divergences. |
+| **XOR** | Yes — exact, no carries | What `torch.hash_tensor` uses. Cheapest possible; every bit independent, so it tree-reduces trivially. |
+| **Integer sum mod 2^64** | Yes — wraps exactly | Also valid, and can be made permutation-sensitive by weighting each lane by its position first. Costs real time and memory (measured below). |
+| **Multiply mod 2^64** | Yes, but zero-absorbing | Useless — one zero lane destroys the digest. |
+| **SHA-256 / crypto hash** | **No** — needs a canonical byte order | Requires a host copy per tensor, which makes it **orders of magnitude slower** than any device-side digest. Reserve for settling a suspected collision; never the hot path. |
+
+### The recommendation
+
+```python
+def fingerprint(t):
+    x = t.detach()
+    if x.is_complex():
+        x = torch.view_as_real(x)     # hash_tensor has no complex support
+    x = x.contiguous()
+    # xor_sum has no UNSIGNED CUDA kernel (uint8/16/32/64 -> "xor_sum_cuda not
+    # implemented for UInt64"). Bitcast unsigned -> signed of the SAME width:
+    # identical bytes, and both jobs bitcast the same way, so still stable.
+    x = x.view(_UINT_TO_INT.get(x.dtype, x.dtype))
+    return torch.hash_tensor(x)       # uint64 TENSOR on x's device -> stageable
+```
+
+It returns a `uint64` **tensor**, not a host int, so the caller stages it and
+defers the single `.item()` to the step boundary — nothing but an 8-byte scalar
+crosses to host, and never mid-iteration.
+
+Do **not** use `hash(tensor.numpy().tobytes())`: it is salted by
+`PYTHONHASHSEED`, so it differs between processes and is silently wrong for
+exactly the cross-launch comparison this method rests on.
+
+### What each variant costs
+
+Benchmarked on a single Blackwell GPU across tensors from tens to hundreds of
+megabytes. Absolute timings are not portable and are omitted deliberately — the
+**ordering** is the durable result, and it held at every size tested.
+
+| Variant | Speed | Scratch memory | Catches permutations |
+|---|---|---|---|
+| whole tensor, native xor | fastest | none measurable | no |
+| chunked `dim=-1` | same as whole tensor | negligible | across granules |
+| two-level (chunk + position-weighted reduce) | slightly slower | negligible | across granules |
+| full custom digest over raw bytes | ~an order of magnitude slower | **3x the input tensor** | within a granule too |
+
+Two things drive the recommendation:
+
+- **Chunking is free.** Reducing per granule costs the same as reducing the whole
+  tensor, so permutation coverage at granule scope is not a performance trade at
+  all. Its real price is trace size, since you store a vector of digests.
+- **The full custom digest's cost is memory, not time.** It materialises a
+  position ramp and several intermediates totalling 3x the input tensor. On a
+  memory-tight run during the live-activation forward, that is what OOMs a rank —
+  and it is the reason to reach for chunking or the two-level form first.
+
+> **Beware microbenchmarks near the floor.** A digest of a small tensor is
+> dominated by kernel-launch overhead, not compute, and at that scale the
+> variants are indistinguishable — a finer-grained digest can even measure
+> *faster* than a coarse one. Compare them on tensors large enough to clear that
+> floor, or you will draw the wrong conclusion.
+
+### What xor costs you
+
+Measured on the same run — both blind spots are real, not theoretical:
+
+| Property | `hash_tensor` | position-weighted sum |
+|---|---|---|
+| all-zero tensor digests to 0 | **yes** | no |
+| all-zero len 4096 == all-zero len 8192 | **yes** | no |
+| `[a, a]` collides with `[b, b]` | **yes** | no |
+| detects a permutation | **no** | yes |
+| detects a 1-ULP change | yes | yes |
+
+XOR is involutive (`x ^ x == 0`), so duplicate lanes annihilate in pairs — and
+this workload is full of repeats: routing maps, masks, one-hot rows,
+zero-initialised buffers. It is also linear over GF(2)⁶⁴, so its collisions are
+algebraically describable rather than merely rare.
+
+**Mitigate rather than replace.** Compare `shape`, `dtype` and `numel` alongside
+the digest — the comparators already do, which is exactly how an all-zero tensor
+is told apart from the empty-tensor sentinel that shares its digest. That closes
+the length and dtype collisions for free.
+
+### Permutations: fix the granularity, not the hash function
+
+The obvious reading of that table is "xor is permutation-blind, so swap the hash
+function." **That is the wrong lever.** The blindness is a property of the
+*scope* of the reduction, not of xor: `hash_tensor` accepts `dim=`, so reducing
+per-row or per-chunk makes any permutation that moves values **across** granules
+visible immediately. Measured on a 64K permutation array and a `[4096, 128]` MoE
+dispatch tensor:
+
+| Case | whole-tensor | chunked (`dim=-1`) | full custom digest |
+|---|---|---|---|
+| Permutation array `0..n-1` | **blind** | detected at every granule 4096→8 | detected |
+| MoE dispatch, rows permuted | **blind** | detected per-row (G=128) | detected |
+| Routing map, swap 10↔3000 | **blind** | detected (G≤16) | detected |
+| Routing map, **adjacent** swap | **blind** | **blind at every G, incl. G=2** | detected |
+| 1-ULP value change | detected | detected | detected |
+
+So the rule is: **granularity bounds the blind spot; it does not remove it.**
+A permutation entirely *within* one granule stays invisible to xor at any
+granule size — only a position-weighted reduction catches that.
+
+Why the whole-tensor row is so stark: **xor over any permutation of `0..n-1` is
+identically zero.** Three unrelated permutations of `0..65535` all digest to
+`0000000000000000`, colliding with the all-zero tensor and the empty-tensor
+sentinel at once. And hashing the index tensor alongside the values does not
+rescue it — an index array is itself a permutation, so xor is invariant to any
+change in it.
+
+Chunking is free in time (see the measurement table above), which is what makes
+it the right first move. Its price is **trace size** — you now store a vector of
+digests rather than one value. When that matters, use the **two-level** form:
+native xor per granule, then a position-weighted reduce over the small digest
+vector. That restores a single stored value for a small, near-flat time cost and
+negligible scratch, where the full raw-byte digest costs both.
+
+The full raw-byte custom digest only earns its keep when you need
+**within-granule** permutation sensitivity.
+
+### The position-weighted digest
+
+A 128-bit, position-weighted, raw-byte digest that is permutation-sensitive and
+does not cancel duplicates. Its shape, condensed:
+
+```python
+lanes = x.reshape(-1).view(torch.uint8).view(torch.int64)   # raw bytes, any dtype
+idx   = torch.arange(lanes.numel(), device=lanes.device)    # absolute position
+acc  += torch.stack((                       # two accumulators, both value- AND
+    _mix64(lanes ^ _mix64(idx + 1)).sum(),   # position-sensitive, so a permutation
+    _mix64(lanes ^ _mix64(idx + K)).sum()    # must collide in both to hide
+                                             # (K = any second distinct constant)
+))   # integer adds wrap mod 2**64 exactly -> chunk size, GPU and rank irrelevant
+```
+
+Price of that property, from the table above: roughly an order of magnitude more
+time, and **3x the input tensor in scratch**. That is why you reach for chunking
+or the two-level form first, and scope this one to the tensors that need
+within-granule sensitivity. Do not hand-roll a variant — a digest change makes old and new
+traces incomparable, which is why records carry a schema version the comparator
+refuses to diff across.
+
+### Resolution — the seam back to capture
+
+The one place the two topics touch. Capture records a
+`__staged_digest_N__` placeholder; `finalize_digests` stacks every pending
+accumulator into **one host transfer per device** and the trace substitutes real
+values at flush time (default every 256 events). This is the only point the
+digest path touches the host, which is what keeps per-tensor fingerprinting off
+the critical path — and it bounds crash loss to the trailing unflushed events.
+
+## 4. Offline comparison
+
+This is the payoff step, and it is about 20 lines. Align **by identity, not by
+arrival order** — that is what the per-op occurrence counter in §2 bought you:
+
+```python
+def first_divergence(dir_a, dir_b):
+    """Walk A in execution order; return the first record whose output differs."""
+    for fa, fb in zip(sorted(Path(dir_a).glob("*.jsonl")),
+                      sorted(Path(dir_b).glob("*.jsonl"))):   # pair by rank+iter
+        # Stream A; index B lazily. Loading both files whole would parse tens of
+        # GB to answer a question that is usually settled in the first thousand
+        # records -- the opposite of what "stop at the first divergence" means.
+        by_id_b, lines_b = {}, (json.loads(line) for line in fb.open())
+        for a in (json.loads(line) for line in fa.open()):
+            if a["schema_version"] != SCHEMA_VERSION:
+                raise ValueError("schema bump: digests are not comparable")
+            key = (a["name"], a["payload"].get("id"))
+            while key not in by_id_b:               # advance B only as far as needed
+                e = next(lines_b, None)
+                if e is None:
+                    break
+                by_id_b[(e["name"], e["payload"].get("id"))] = e
+            b = by_id_b.get(key)
+            if b is None:
+                # No counterpart at all -> control flow diverged, not just values.
+                return {"kind": "missing_in_b", "file": fa.name, "record": a}
+            if a["payload"]["out"] != b["payload"]["out"]:
+                return {"file": fa.name, "seq": a["seq"], "name": a["name"],
+                        # True  -> this op is the root cause.
+                        # False -> cause is upstream; keep walking back.
+                        "inputs_matched": a["payload"].get("in") == b["payload"].get("in"),
+                        "a": a, "b": b}
+    return None          # every output matched
+```
+
+A missing counterpart is a *different* finding from a value mismatch: it means
+the two runs took different code paths, so compare configs before reading it as
+numerical nondeterminism.
+
+Two tools, whatever they are called in your implementation:
+
+```bash
+compare_traces <trace_dir_A> <trace_dir_B>    # first divergence, causal order
+certify_traces <trace_dir_A> [<trace_dir_B>]  # trace invariants hold?
+```
+
+`compare_traces` walks both trees by semantic event identity and reports
+divergences in causal order. `certify_traces` checks the invariants a
+determinism run assumes — deterministic algorithms enabled, recompute matching
+its forward, contiguous sequences, no collective begun without an end, no
+pending collectives at window close, expected rank/iteration coverage. **Certify
+one tree before you trust a diff between two.**
+
+> **Gotcha — schema version.** The writer stamps `schema_version` on every record
+> and the comparator accepts exactly one value. When they drift apart the
+> comparator rejects every record, which looks like a broken tool — check the
+> constant on both sides first. Never diff across a schema bump: the digest
+> definition changed, so *every* record differs and the "first divergence" is
+> meaningless.
+
+## 5. Cost and scale
+
+The design goal is a tool that survives a 3,000+ GPU campaign. The properties
+that make that work, and the knobs you control:
+
+- **Rank-local JSONL.** Each rank writes its own file. Tracing adds **no
+  collectives and no cross-rank ordering** to the step being observed, so it
+  cannot itself perturb the thing you are measuring.
+- **Digests computed on the GPU.** Bytes are reduced on the tensor's own device
+  with an order-independent reduction; only a scalar per tensor reaches the host
+  (two, if you use the 128-bit position-weighted variant of §3). Digests stage as device accumulators and resolve one batch per
+  flush, so the step is never stalled to read a hash back. Host-side byte
+  hashing (`sha256`) is hundreds of times more expensive (§3) — use it only to
+  settle a digest-collision question.
+- **Scoped capture.** Trace chosen steps (start / end / every N-th) and chosen
+  ranks (all, or a list like `0,3,8-15`). A bounded window is the difference
+  between a 40 GB campaign and an unusable one.
+- **Budget caps.** Skip oversize tensors (`DET_TRACE_OP_MAXNUMEL`), cap event
+  counts, or run summary-only. A skipped output still records shape/dtype, so a
+  divergence surfaces at the first under-cap tensor downstream.
+- **Quantized-aware.** MXFP8 / NVFP4 tensors are digested through their raw data
+  plus scale buffers, so a low-precision operand is a first-class fingerprint
+  rather than an opaque `uint8` blob.
+
+Operational consequences:
+
+- Raise `--distributed-timeout-minutes`; traced iterations are slower and the
+  NCCL watchdog does not know that.
+- Rung 2 runs Python per ATen op and **cannot run inside `torch.cuda.graph`
+  capture**. Disable CUDA graphs for the traced run.
+- Collective outputs must be fingerprinted at the consumer's **wait**, never at
+  the launch point, or the digest races the NCCL kernel still writing the
+  buffer. If you add a collective probe yourself, respect this.
+
+## 6. When a boundary is not covered
+
+The op layer only sees the torch dispatcher. Anything that bypasses it — a
+Transformer Engine GEMM (a pybind call), a fused wgrad writing `main_grad`,
+cuDNN fused attention, Triton/FLA kernels, DeepEP/HybridEP token dispatch — is a
+blind spot. A divergence inside one surfaces one hop later (see
+`reading-traces.md`).
+
+To close a blind spot, add a probe that writes into the **same ordered stream**.
+That is the whole contract — a probe is about 20 lines:
+
+```python
+# Wrap the extension entry point; record operands and result as one event.
+import transformer_engine.pytorch.cpp_extensions.gemm as te_gemm
+
+_orig = te_gemm.general_gemm
+_seen = collections.Counter()
+
+def _traced(*args, **kwargs):
+    out = _orig(*args, **kwargs)
+    trace = active_trace()
+    if trace is not None:
+        # Name it by the axes you will want in a discriminator table later
+        # (layout, accumulate, grad vs forward, output dtype) -- that naming is
+        # what turns step 4 of SKILL.md into a table lookup instead of a new job.
+        name = f"gemm:{kwargs.get('layout')}:acc{int(bool(kwargs.get('accumulate')))}"
+        _seen[name] += 1
+        trace.record("op", name, {
+            "id": f"{name}:{_seen[name]}",                     # same identity rule as §2
+            "in":  [signature(trace, t) for t in _tensors(args) if t.numel() > 0],
+            "out": [signature(trace, t) for t in _tensors(out) if t.numel() > 0],
+        })
+    return out
+
+te_gemm.general_gemm = _traced
+```
+
+Name events so instances are distinguishable by the axes you will later want in
+a discriminator table (layout, accumulate, grad/forward, output dtype). That
+naming is what lets step 4 of `SKILL.md` be a table lookup instead of a new job.
+
+Probes that have paid for themselves: **TE `general_gemm`** (operand bits,
+accumulator, output), **per-parameter gradient at `optimizer.step()` entry**
+(catches fused wgrad writes the dispatcher never sees), **MoE dispatch/combine
+boundaries**.
+
+## 7. Inject the tracer; do not rebuild the image
+
+This is a determinism constraint, not a convenience. **Rebuilding the image to
+add instrumentation changes the artifact under test.** A different build of TE,
+cuBLAS, NCCL or torch can change numerics on its own, so a traced run from a new
+image is not comparable to the untraced run that showed the break, and you can
+spend days chasing a divergence you introduced by instrumenting. Keep the image
+bit-identical across both arms and both runs; add the tracer beside it.
+
+CPython auto-imports `sitecustomize` from `PYTHONPATH` at interpreter startup, so
+the bootstrap goes there, installs a post-import hook on the training module, and
+wraps `train_step`:
+
+```bash
+PYTHONPATH=/path/to/dettrace_bootstrap:$PYTHONPATH \
+DET_TRACE_OUT_DIR=/lustre/.../streams/run_A \
+DET_TRACE_ITERS=1-8 DET_TRACE_OPS=1 \
+  <your existing launch command>
+```
+
+The bootstrap must be **inert unless the trace directory is set** — it runs in
+every Python process in the container, including ones you did not mean to trace.
+
+This is also how you port a tracer between repos: the capture modules are plain
+Python with no Megatron dependency beyond the wrap points, so a tracer developed
+in one repo can be dropped into another as a standalone package on `PYTHONPATH`.
+
+## 8. Below the dispatcher (rung 4)
+
+The trace stops at the last line of code you can read. When the first divergence
+is inside a closed kernel, these are the only instruments left — and you are not
+profiling for speed, you are hunting **the reduction mechanism**, because
+reduction order is what makes a kernel order-dependent.
+
+Only after the discriminator table points at a closed kernel:
+
+```bash
+CUBLASLT_LOG_LEVEL=5   # which algo was selected, and the problem descriptor.
+                       # Look for reductionScheme / numSplitsK: a split-K
+                       # reduction is a nondeterminism mechanism you can name.
+                       # Their ABSENCE is also a finding — it rules out the
+                       # classic split-K explanation and the workspace knob.
+
+NVTE_NVTX_ENABLED=1 nsys profile --trace=cuda,nvtx …
+                       # the kernel SYMBOL, attributed to a library NVTX range
+                       # so you know which call site it belongs to.
+
+ncu …                  # atomics / reduction metrics — the only way to explain
+                       # *why* a kernel is order-dependent, once it is named.
+```
+
+Two rules that matter more than the commands:
+
+- **Separate selection from execution.** If two runs select the *same* algo and
+  still disagree, the nondeterminism is inside the kernel, not in autotune or
+  heuristic choice — which is a completely different bug report. Log the
+  selection on both runs before blaming either.
+- **Require two independent instruments to agree** before naming a kernel — e.g.
+  the cuBLASLt log's dispatch count and nsys's launch count for the same
+  workload. One instrument is an assertion; two is evidence.
+
+Know the ceiling. From outside a closed binary you can reach the kernel symbol,
+the algo descriptor, the exact problem descriptor, and a flag that toggles the
+behaviour. *Why* the kernel is order-dependent internally needs `ncu` or the
+owning library team — say that explicitly rather than speculating.


### PR DESCRIPTION
Two runs of a deterministic recipe that disagree give one number to work from: the iteration where the loss curves split. That is where the difference grew large enough to print, not where it started. This skill documents the method that answers which op first diverged.

The method: run the job twice, fingerprint every op into a rank-local ordered stream, diff the two streams offline. The first record whose output differs while its inputs matched is the root cause -- everything before it matched byte for byte, so no hypothesis is needed, and forming one before that record is in hand is the most common way these investigations go wrong.

SKILL.md carries the method: the capture ladder (loss curve -> semantic boundaries -> ATen ops -> targeted probe -> below the dispatcher), the multi-arm repro harness, how to read a first divergence, and how to turn a site into a mechanism with a discriminator table.

references/tracing-setup.md covers arming the tracer: the capture layer, the call-site lifecycle, cost controls, read-only-container injection, and the hash function. references/reading-traces.md covers the three ways a correct trace yields a wrong conclusion -- the one-hop-later rule for kernels that bypass the dispatcher, known probe artifacts, and digest semantics.

On hashing, the guidance is to use torch.hash_tensor and not design there: it is far faster than a hand-written position-weighted digest and allocates no measurable scratch, where the custom digest needs three times the input tensor in temporaries. Its one real gap is permutations -- xor over any permutation of 0..n-1 is identically zero, so routing maps and MoE dispatch outputs are invisible when reduced whole-tensor. The fix is granularity, not a different hash: hash_tensor takes dim=, and chunked reduction costs the same as whole-tensor while catching any permutation that crosses a granule.

Benchmark constants are deliberately left out of the docs. They came from one GPU and one torch build; the ordering is the durable result.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
