### PR TITLE
Fix FlashInfer NVLS routing buffer race

### DIFF
--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -469,13 +469,14 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
     def update_metadata(self, local_tokens: int) -> None:
         """Per-step metadata update; invoked from the first instance's token_dispatch.
 
-        Fires the fused NVLS allgather+reduce to publish
-        [valid_tokens, rank_token_offset, ep_max_tokens] into _step_metadata, then
-        (for FlashInfer) pre-masks the routing buffer with -1 so rows beyond
-        valid_tokens are ignored by the GEMM; the AGV below overwrites
-        [0, valid_tokens) in-place.
+        For FlashInfer, first masks the routing buffer with -1 so rows beyond
+        valid_tokens are ignored by the GEMM. The fused NVLS metadata update then
+        provides the cross-rank fence which prevents a late local clear from erasing
+        an early peer AGV write. The AGV overwrites [0, valid_tokens) in-place.
         """
         cls = NVLSAllGatherVDispatcher
+        if self.config.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.FLASHINFER:
+            cls._symm_agv_routing["tensor"].fill_(-1)
         fused_metadata_update(
             local_tokens=local_tokens,
             local_buf=cls._symm_metadata["tensor"],
@@ -483,8 +484,6 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             step_metadata=cls._step_metadata,
         )
         InferenceAllGatherDispatcherBase._host_valid_tokens_estimate = local_tokens * self.ep_size
-        if self.config.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.FLASHINFER:
-            cls._symm_agv_routing["tensor"].fill_(-1)
 
     def __init__(
         self,

--- a/tests/unit_tests/inference/test_flashinfer_mxfp8.py
+++ b/tests/unit_tests/inference/test_flashinfer_mxfp8.py
@@ -178,3 +178,39 @@ def test_bf16_flashinfer_nvls_uses_dispatcher_copy_fallback(monkeypatch):
     assert output is expected
     assert bias is None
     assert captured["output"] is None
+
+
+def test_flashinfer_nvls_clears_routing_before_metadata_fence(monkeypatch):
+    from megatron.core.inference.moe import InferenceGroupedGemmBackend
+    from megatron.core.transformer.moe import token_dispatcher_inference
+
+    dispatcher_cls = token_dispatcher_inference.NVLSAllGatherVDispatcher
+    base_cls = token_dispatcher_inference.InferenceAllGatherDispatcherBase
+    calls = []
+
+    class RoutingTensor:
+        def fill_(self, value):
+            calls.append(("clear", value))
+
+    monkeypatch.setattr(dispatcher_cls, "_symm_agv_routing", {"tensor": RoutingTensor()})
+    monkeypatch.setattr(
+        dispatcher_cls, "_symm_metadata", {"tensor": object(), "handle": object()}, raising=False
+    )
+    monkeypatch.setattr(dispatcher_cls, "_step_metadata", object())
+    monkeypatch.setattr(base_cls, "_host_valid_tokens_estimate", 0)
+    monkeypatch.setattr(
+        token_dispatcher_inference,
+        "fused_metadata_update",
+        lambda **kwargs: calls.append(("metadata", kwargs["local_tokens"])),
+    )
+    dispatcher = SimpleNamespace(
+        config=SimpleNamespace(
+            inference_grouped_gemm_backend=InferenceGroupedGemmBackend.FLASHINFER
+        ),
+        ep_size=4,
+    )
+
+    dispatcher_cls.update_metadata(dispatcher, local_tokens=7)
+
+    assert calls == [("clear", -1), ("metadata", 7)]
+    assert base_cls._host_valid_tokens_estimate == 28


### PR DESCRIPTION
## What does this PR do?

Clear the FlashInfer NVLS routing buffer before the fused metadata synchronization fence. Clearing it afterwards can race with an early peer all-gather write and replace valid routing entries with `-1`.

This fix applies to the ordinary FlashInfer + NVLS inference path and is independent of batch-invariant mode.

## Testing

- Focused unit regression: 1 passed
- Black, isort, and Ruff checks passed for both changed files