### PR TITLE
fix(tests): stop the PP-agnostic model from shadowing SwigluFactoryModel

### DIFF
--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -144,7 +144,9 @@ class SwigluFactoryModel(torch.nn.Module):
         return sharded_state_dict
 
 
-class SwigluFactoryModel(torch.nn.Module):
+class PPAgnosticModel(torch.nn.Module):
+    """Like SwigluFactoryModel, but the linear weight is TP-replicated (no sharded axis)."""
+
     def __init__(self, pp_separate_model: bool = False):
         super().__init__()
         self.linear = torch.nn.Linear(5, 64, bias=False)
@@ -358,7 +360,7 @@ def initialize_pp_agnostic_model(pre_process=True, post_process=True, seed=0, **
     torch.manual_seed(seed)
     model_parallel_cuda_manual_seed(seed)
 
-    return SwigluFactoryModel(False)
+    return PPAgnosticModel(False)
 
 
 def initialize_pp_agnostic_gpt_model(pre_process=True, post_process=True, seed=0, **config_kwargs):


### PR DESCRIPTION
## What

`tests/unit_tests/dist_checkpointing/test_optimizer.py` defines **two module-level classes named `SwigluFactoryModel`** (L103 and L147). The second one wins, so the first is dead and one of the initializers silently lost its model.

| | `SwigluFactoryModel` L103 (dead) | `SwigluFactoryModel` L147 (wins) |
|---|---|---|
| linear | `Linear(5, 64 // tp_world_size)` | `Linear(5, 64)` |
| `from_rank_offsets` | axis-0 offsets `(0, tp_rank, tp_world_size)` | **no offsets** (TP-replicated) |
| `apply_swiglu_sharded_factory` | applied | **never called** |

Both were touched by the same commit (`!3532`, "Implement new optimizer checkpoint formats for DistOpt"): it edited the original in place (adding `pp_separate_model`, `bf16=True`, `add_prefix_for_sharding`) *and* added a second, TP-replicated copy next to the new `initialize_pp_agnostic_model` — the copy just kept the original's name.

## Why it matters

`initialize_small_model` predates `!3532` and is used only by `TestFP32Optimizer::test_fp32_optimizer_resharding`, which reshards `TP 2->4` and `8->1`. Because of the shadowing it now builds a weight that is identical on every rank with no sharded axis, so **that test no longer exercises the swiglu sharded factory across TP resharding at all** — the one thing the model is named for. It still passes, silently.

## The fix

Rename the second class to `PPAgnosticModel`, matching its only caller and the existing `initialize_X_model` / `XModel` convention in this file (`initialize_multi_bucket_model` / `MultiBucketModel`, `initialize_1d_flatten_tensor_model` / `Model1dFlattenTensor`).

The class body is untouched, so `initialize_pp_agnostic_model` returns the exact same model as before. Only `initialize_small_model` changes — back to what it returned before `!3532`, which is what `test_fp32_optimizer_resharding` was green with (the test body is unchanged by `!3532` apart from passing `metadata={'distrib_optim_sharding_type': 'fully_reshardable'}`).

## Verification

I do not have a multi-GPU box, so this is a static / stubbed verification — please run the dist-checkpointing job.

Extracted both class bodies and both initializers with `ast`, executed them against stubs (`tp_world_size=8`, `tp_rank=3`), and recorded what each initializer returns:

```
BEFORE (main)
  initialize_pp_agnostic_model() -> class=SwigluFactoryModel  out_features=64  swiglu_factory_applied=False  rank_offsets=NONE
  initialize_small_model()       -> class=SwigluFactoryModel  out_features=64  swiglu_factory_applied=False  rank_offsets=NONE

AFTER (this PR)
  initialize_pp_agnostic_model() -> class=PPAgnosticModel     out_features=64  swiglu_factory_applied=False  rank_offsets=NONE   <- unchanged
  initialize_small_model()       -> class=SwigluFactoryModel  out_features=8   swiglu_factory_applied=True   rank_offsets=axis-0 <- restored
```

Also:
- `pyflakes` before: `test_optimizer.py:147:1: redefinition of unused 'SwigluFactoryModel' from line 103`; after: clean.
- `black==26.3.0` (the pinned `.pre-commit-config.yaml` rev) with the repo `pyproject.toml`: `1 file would be left unchanged`.

Happy to instead delete the dead class if you'd rather drop that coverage, but restoring it looked like the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
