### PR TITLE
Add adapter-only checkpoint save/load (--save-trainable-params-only)

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1945,6 +1945,14 @@ def validate_args(args, defaults={}):
             )
             args.overlap_param_gather = False
 
+    if args.save_trainable_params_only:
+        assert args.ckpt_format == 'torch_dist', (
+            "--save-trainable-params-only requires --ckpt-format torch_dist: only the "
+            "torch_dist sharded state dict preserves each parameter's requires_grad (via "
+            "ShardedTensor.data). Other formats save state_dict(keep_vars=False), which detaches "
+            "every tensor and would make every parameter look frozen."
+        )
+
     if args.override_ckpt_iteration is not None:
         assert not args.finetune, "Cannot override checkpoint iteration together with finetune flag."
 

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -833,7 +833,7 @@ def save_checkpoint(
                 rerun_state=rerun_state,
             )
 
-        if args.save_trainable_params_only:
+        if getattr(args, 'save_trainable_params_only', False):
             # `validate_args` asserts `args.ckpt_format == 'torch_dist'` at CLI-parse time, but
             # `ckpt_format` (this save call's *effective* format) can differ afterwards -- e.g.
             # `--ckpt-convert-format` reassigns `args.ckpt_format` post-validation (see
@@ -1701,13 +1701,21 @@ def _is_trainable_leaf(value: Any) -> bool:
 
     `ShardedTensor`/`ShardedTensorFactory` carry the original parameter as `.data`, so
     `requires_grad` reflects whether the parameter is frozen (e.g. a PEFT base model) or
-    trainable (e.g. a PEFT adapter). Any other leaf (`ShardedObject`, `LocalNonpersistentObject`,
-    plain metadata, ...) is kept unconditionally: only tensor-carrying leaves are filtered.
+    trainable (e.g. a PEFT adapter). Transformer Engine `._extra_state` entries (persistent
+    per-module state, e.g. FP8 scale/amax history) are dropped unconditionally, even for a
+    trainable/adapter module: they carry no `requires_grad` signal of their own, and keeping
+    one while its sibling weight tensor gets dropped as frozen would leave a structurally
+    inconsistent checkpoint (extra_state present, weight/bias missing at the same module
+    path) that fails to load. Adapter-checkpoint loading already tolerates a missing
+    extra_state key and reinitializes it to defaults. Any other non-tensor leaf (plain
+    metadata, `LocalNonpersistentObject`, ...) is kept unconditionally.
     """
     if isinstance(value, (ShardedTensor, ShardedTensorFactory)):
         return value.data is None or value.data.requires_grad
     if isinstance(value, torch.Tensor):
         return value.requires_grad
+    if isinstance(value, ShardedObject) and '_extra_state' in value.key:
+        return False
     return True
 
 
@@ -1720,10 +1728,26 @@ def filter_state_dict_to_trainable_params(state_dict: Dict[str, Any]) -> Dict[st
     optimizer section, RNG state, and other metadata are returned unchanged: the optimizer
     section already only contains state for whichever parameters were passed to the optimizer.
 
-    Loading a checkpoint produced this way onto a fully-initialized model (which still has its
-    frozen weights) requires `--dist-ckpt-strictness log_unexpected` (or another `*_unexpected`
-    strictness value): the on-disk checkpoint is missing the frozen keys the model will request,
-    and the default strictness raises on that mismatch.
+    Also used, applied to the *load* side, on the model section of the sharded-state-dict
+    request built from a fully-initialized model before it's handed to the dist_checkpointing
+    load call (see `load_checkpoint`): this makes the model-section request match the trimmed
+    on-disk checkpoint, so the model's existing frozen weights are left untouched rather than
+    requested from a checkpoint that doesn't have them. Filtering the request this way
+    (matching Megatron-Bridge's PEFT checkpoint loading) is necessary, not just
+    belt-and-suspenders: relying on `--dist-ckpt-strictness log_unexpected` alone to reconcile
+    an unfiltered request against the trimmed checkpoint does not work for every leaf type -- a
+    frozen `ShardedTensorFactory`-wrapped parameter (e.g. SwiGLU's `linear_fc1`) raises in
+    `apply_factory_merges` because the generic non-strict "unexpected key" pruning does not
+    correctly propagate through un-built factory requests.
+
+    `--dist-ckpt-strictness log_unexpected` (or another `*_unexpected` value) is still required
+    in addition to this filtering, since the optimizer section is deliberately left unfiltered
+    (see above) and a separate load-time shape-validation list
+    (`MCoreLoadPlanner._validate_global_shapes`) still needs non-strict pruning to tolerate an
+    optimizer-section entry for a frozen parameter.
+
+    Transformer Engine `._extra_state` entries are dropped unconditionally (even under a
+    trainable/adapter module); see `_is_trainable_leaf`.
 
     Args:
         state_dict: a state dict as produced by `generate_state_dict`.
@@ -2828,6 +2852,19 @@ def load_checkpoint(
                 optim_sd_kwargs=optim_sd_kwargs,
                 model_sd_kwargs=model_sd_kwargs,
                 rerun_state=gen_sd_rerun_state,
+            )
+
+        if getattr(args, 'save_trainable_params_only', False):
+            # Filter the load *request* the same way the checkpoint on disk was filtered at
+            # save time, rather than requesting every parameter and relying on
+            # --dist-ckpt-strictness to reconcile the gap afterward: some leaves (e.g. a
+            # frozen ShardedTensorFactory-wrapped SwiGLU linear_fc1) aren't correctly pruned
+            # by the generic non-strict/"unexpected key" path and raise in
+            # apply_factory_merges if left in the request. Filtering the request itself
+            # avoids the mismatch entirely, matching Megatron-Bridge's PEFT checkpoint
+            # loading (megatron.bridge.training.checkpointing.apply_peft_adapter_filter_to_state_dict).
+            load_kwargs['sharded_state_dict'] = filter_state_dict_to_trainable_params(
+                load_kwargs['sharded_state_dict']
             )
 
         if gpt_compat_layer_maps is not None:

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -31,8 +31,16 @@ except ImportError:
 
 from megatron.core import dist_checkpointing, mpu, tensor_parallel
 from megatron.core._rank_utils import safe_get_rank as get_rank_safe
-from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
-from megatron.core.dist_checkpointing.mapping import LocalNonpersistentObject, ShardedObject
+from megatron.core.dist_checkpointing.dict_utils import (
+    dict_list_map_inplace,
+    extract_matching_values,
+)
+from megatron.core.dist_checkpointing.mapping import (
+    LocalNonpersistentObject,
+    ShardedObject,
+    ShardedTensor,
+    ShardedTensorFactory,
+)
 from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
     FullyParallelLoadStrategyWrapper,
@@ -824,6 +832,25 @@ def save_checkpoint(
                 model_sd_kwargs=dict(metadata=sharded_sd_metadata),
                 rerun_state=rerun_state,
             )
+
+        if args.save_trainable_params_only:
+            # `validate_args` asserts `args.ckpt_format == 'torch_dist'` at CLI-parse time, but
+            # `ckpt_format` (this save call's *effective* format) can differ afterwards -- e.g.
+            # `--ckpt-convert-format` reassigns `args.ckpt_format` post-validation (see
+            # `megatron/training/training.py`). Re-check the effective format here: every
+            # non-torch_dist path calls `state_dict_for_save_checkpoint(keep_vars=False)`, which
+            # detaches every tensor, so `requires_grad` would read False for *everything*
+            # (including real adapter weights) and the filter would silently empty the model
+            # section instead of merely failing to shrink it.
+            if ckpt_format != 'torch_dist':
+                raise RuntimeError(
+                    f"--save-trainable-params-only requires the torch_dist checkpoint "
+                    f"format (got effective ckpt_format={ckpt_format!r}). Other formats detach "
+                    f"every tensor before this filter runs, which would silently drop all "
+                    f"parameters -- including trainable ones -- instead of just the frozen base "
+                    f"model."
+                )
+            state_dict = filter_state_dict_to_trainable_params(state_dict)
 
         state_dict['num_floating_point_operations_so_far'] = num_floating_point_operations_so_far
         if ckpt_type == CheckpointType.GLOBAL and ckpt_format == 'torch_dist':
@@ -1657,6 +1684,61 @@ def generate_state_dict(
         _localize_redundant_extra_states(state_dict)
 
     return state_dict
+
+
+def _is_model_section(section_key: str) -> bool:
+    """Whether a top-level checkpoint state-dict key holds model parameters.
+
+    Model sections are named "model" (single model) or "model0", "model1", ... (virtual
+    pipeline-parallel model chunks). Other sections ("optimizer", "iteration",
+    "checkpoint_version", "rng_state", ...) are not model sections.
+    """
+    return section_key == 'model' or bool(re.fullmatch(r'model\d+', section_key))
+
+
+def _is_trainable_leaf(value: Any) -> bool:
+    """Predicate used by `filter_state_dict_to_trainable_params`: keep non-frozen leaves.
+
+    `ShardedTensor`/`ShardedTensorFactory` carry the original parameter as `.data`, so
+    `requires_grad` reflects whether the parameter is frozen (e.g. a PEFT base model) or
+    trainable (e.g. a PEFT adapter). Any other leaf (`ShardedObject`, `LocalNonpersistentObject`,
+    plain metadata, ...) is kept unconditionally: only tensor-carrying leaves are filtered.
+    """
+    if isinstance(value, (ShardedTensor, ShardedTensorFactory)):
+        return value.data is None or value.data.requires_grad
+    if isinstance(value, torch.Tensor):
+        return value.requires_grad
+    return True
+
+
+def filter_state_dict_to_trainable_params(state_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Filter the model section(s) of a checkpoint state dict to trainable parameters only.
+
+    Intended for PEFT/LoRA-style fine-tuning where the base model is frozen and only a small
+    number of adapter parameters are trainable: this keeps the saved checkpoint proportional to
+    the adapter size instead of duplicating the (already-available) frozen base weights. The
+    optimizer section, RNG state, and other metadata are returned unchanged: the optimizer
+    section already only contains state for whichever parameters were passed to the optimizer.
+
+    Loading a checkpoint produced this way onto a fully-initialized model (which still has its
+    frozen weights) requires `--dist-ckpt-strictness log_unexpected` (or another `*_unexpected`
+    strictness value): the on-disk checkpoint is missing the frozen keys the model will request,
+    and the default strictness raises on that mismatch.
+
+    Args:
+        state_dict: a state dict as produced by `generate_state_dict`.
+
+    Returns:
+        A new state dict with frozen parameters removed from every model section.
+    """
+    return {
+        section_key: (
+            extract_matching_values(section_value, _is_trainable_leaf)[0]
+            if _is_model_section(section_key)
+            else section_value
+        )
+        for section_key, section_value in state_dict.items()
+    }
 
 
 # Byte markers of the dict keys that TE `get_extra_state` writes ONLY under

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -427,6 +427,15 @@ class CheckpointConfig:
     save_rng: bool = True
     """Do not save current rng state."""
 
+    save_trainable_params_only: bool = False
+    """Save only parameters with requires_grad=True in the model section(s) of the checkpoint,
+    omitting frozen weights (e.g., a frozen base model under PEFT/LoRA-style fine-tuning). The
+    optimizer section is unaffected: it already only contains state for the parameters passed to
+    the optimizer. Loading such a checkpoint onto a fully-initialized model that already has the
+    frozen weights (from scratch or from a separate full-model checkpoint) requires
+    `--dist-ckpt-strictness log_unexpected` (or another `*_unexpected` strictness value), since the
+    on-disk checkpoint will be missing the frozen keys the model requests."""
+
     load: str | None = None
     """Directory containing a model checkpoint."""
 

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -428,13 +428,20 @@ class CheckpointConfig:
     """Do not save current rng state."""
 
     save_trainable_params_only: bool = False
-    """Save only parameters with requires_grad=True in the model section(s) of the checkpoint,
-    omitting frozen weights (e.g., a frozen base model under PEFT/LoRA-style fine-tuning). The
-    optimizer section is unaffected: it already only contains state for the parameters passed to
-    the optimizer. Loading such a checkpoint onto a fully-initialized model that already has the
-    frozen weights (from scratch or from a separate full-model checkpoint) requires
-    `--dist-ckpt-strictness log_unexpected` (or another `*_unexpected` strictness value), since the
-    on-disk checkpoint will be missing the frozen keys the model requests."""
+    """Save and load only parameters with requires_grad=True in the model section(s) of the
+    checkpoint, omitting frozen weights (e.g., a frozen base model under PEFT/LoRA-style
+    fine-tuning). The optimizer section is unaffected: it already only contains state for the
+    parameters passed to the optimizer.
+
+    Set this the same way for the run that saves the checkpoint and any run that loads it
+    (including a resume): loading filters the model-section load *request* down to trainable
+    parameters the same way the save filtered what was written, so the request matches the
+    on-disk checkpoint and the model's existing frozen weights (from scratch or from a separate
+    full-model checkpoint) are left untouched rather than requested from a checkpoint that
+    doesn't have them. Also still pass `--dist-ckpt-strictness log_unexpected` (or another
+    `*_unexpected` value) when loading: the optimizer section is deliberately left unfiltered,
+    and a separate load-time shape-validation check still needs non-strict handling to tolerate
+    an optimizer-section entry for a frozen parameter."""
 
     load: str | None = None
     """Directory containing a model checkpoint."""

--- a/tests/unit_tests/dist_checkpointing/test_peft_checkpointing.py
+++ b/tests/unit_tests/dist_checkpointing/test_peft_checkpointing.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from functools import partial
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing.dict_utils import diff
+from megatron.training.arguments import parse_args
+from megatron.training.checkpointing import load_checkpoint, save_checkpoint
+from tests.unit_tests.dist_checkpointing import (
+    TempNamedDir,
+    init_checkpointing_mock_args,
+    initialize_gpt_model,
+    setup_model_and_optimizer,
+)
+from tests.unit_tests.test_utilities import Utils
+
+# Match by suffix (any layer, on every pipeline stage) rather than one exact
+# global/local-indexed name: this mirrors a realistic PEFT setup where an adapter
+# attaches uniformly to every layer, not just one -- and avoids a PP-local
+# ModuleList index (e.g. "layers.0...") mapping onto a *different* global layer per
+# pipeline stage, which Megatron-Core represents as one merged ShardedTensor
+# spanning all layers for a dense (non-MoE, non-heterogeneous) model.
+ADAPTER_PARAM_SUFFIX = "input_layernorm.weight"
+
+
+def _freeze_all_but_adapter(model_chunks):
+    """Unfreeze every parameter whose name ends with ADAPTER_PARAM_SUFFIX, freeze the
+    rest. Returns the count of parameters unfrozen on this rank's local model chunks.
+    """
+    count = 0
+    for m in model_chunks:
+        for name, p in m.named_parameters():
+            if name.endswith(ADAPTER_PARAM_SUFFIX):
+                p.requires_grad_(True)
+                count += 1
+            else:
+                p.requires_grad_(False)
+    return count
+
+
+def _initialize_peft_model(*args, use_glu, **kwargs):
+    model = initialize_gpt_model(*args, use_glu=use_glu, **kwargs)
+    _freeze_all_but_adapter([model])
+    return model
+
+
+def _set_adapter_params(model_chunks, value):
+    for m in model_chunks:
+        for name, p in m.named_parameters():
+            if name.endswith(ADAPTER_PARAM_SUFFIX):
+                with torch.no_grad():
+                    p.fill_(value)
+
+
+def _ckpt_size_bytes(ckpt_dir):
+    return sum(f.stat().st_size for f in Path(ckpt_dir).rglob("*") if f.is_file())
+
+
+class TestPeftAdapterOnlyCheckpointing:
+    """Issue #7270: --save-trainable-params-only lets a PEFT/LoRA-style fine-tuning
+    run (frozen base model, a few trainable adapter parameters) save a checkpoint
+    proportional to the adapter instead of duplicating the frozen base weights, load
+    it back onto a matching base model, and resume training from it. Exercised at
+    TP/PP > 1 and with a SwiGLU-gated MLP (whose linear_fc1 is
+    ShardedTensorFactory-wrapped) since both are real correctness hazards this
+    feature has to handle: dropping a parameter that Megatron-Core represents as one
+    tensor merged across all layers, and a factory-wrapped frozen parameter needing
+    load-time request filtering (not just save-time filtering) to avoid crashing in
+    apply_factory_merges.
+    """
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("tp,pp", [(1, 1), (2, 1), (1, 2)])
+    @pytest.mark.parametrize("use_glu", [False, True])
+    def test_save_is_smaller_load_is_correct_and_resume_restores_optimizer_state(
+        self, tmp_path_dist_ckpt, tp, pp, use_glu
+    ):
+        Utils.initialize_model_parallel(tp, pp)
+        initialize_fn = partial(_initialize_peft_model, use_glu=use_glu)
+
+        with (
+            TempNamedDir(tmp_path_dist_ckpt / 'test_peft_ckpt_adapter', sync=True) as ckpt_dir_adapter,
+            TempNamedDir(tmp_path_dist_ckpt / 'test_peft_ckpt_full', sync=True) as ckpt_dir_full,
+        ):
+            mock_args = parse_args(ignore_unknown_args=True)
+            init_checkpointing_mock_args(mock_args, ckpt_dir_adapter)
+            mock_args.save_tokenizer_assets = False
+
+            with mock.patch('megatron.training.checkpointing.get_args', new=lambda: mock_args):
+                # ---- Model A: frozen base + a trainable adapter on every layer ----
+                model_a, optimizer_a = setup_model_and_optimizer(
+                    seed=1, tp=tp, pp=pp, dist_opt=False, initialize_fn=initialize_fn
+                )
+                count = _freeze_all_but_adapter(model_a)
+                assert count > 0, "no adapter parameters found on this rank"
+                _set_adapter_params(model_a, 42.0)
+
+                # Save adapter-only, and (for a size comparison) the full checkpoint
+                # from the same model state.
+                mock_args.save_trainable_params_only = True
+                save_checkpoint(1, model_a, optimizer_a, None, 0)
+
+                mock_args.save_trainable_params_only = False
+                mock_args.save = ckpt_dir_full
+                save_checkpoint(1, model_a, optimizer_a, None, 0)
+                mock_args.save = ckpt_dir_adapter
+                mock_args.save_trainable_params_only = True
+
+                torch.distributed.barrier()
+                if Utils.rank == 0:
+                    adapter_size = _ckpt_size_bytes(ckpt_dir_adapter)
+                    full_size = _ckpt_size_bytes(ckpt_dir_full)
+                    assert adapter_size < full_size, (
+                        f"adapter-only checkpoint ({adapter_size}B) is not smaller "
+                        f"than the full checkpoint ({full_size}B)"
+                    )
+
+                optimizer_a_state = optimizer_a.state_dict()
+
+                # ---- Model B: same seed (matching base model), but corrupt the
+                #      adapter params and the optimizer state before loading, to prove
+                #      the load actually restores them rather than trivially matching. ----
+                Utils.destroy_model_parallel()
+                Utils.initialize_model_parallel(tp, pp)
+                model_b, optimizer_b = setup_model_and_optimizer(
+                    seed=1, tp=tp, pp=pp, dist_opt=False, initialize_fn=initialize_fn
+                )
+                _freeze_all_but_adapter(model_b)
+                _set_adapter_params(model_b, -1.0)
+                # setup_model_and_optimizer seeds momentum state with the same seed
+                # for both A and B, so corrupt B's here too -- otherwise a correct
+                # post-load match would prove nothing about the load path.
+                for group in optimizer_b.optimizer.param_groups:
+                    for p in group['params']:
+                        for key in ('exp_avg', 'exp_avg_sq'):
+                            if key in optimizer_b.optimizer.state[p]:
+                                optimizer_b.optimizer.state[p][key].fill_(-99.0)
+
+                frozen_before = {
+                    name: p.detach().clone()
+                    for m in model_b
+                    for name, p in m.named_parameters()
+                    if not name.endswith(ADAPTER_PARAM_SUFFIX)
+                }
+
+                mock_args.dist_ckpt_strictness = "log_unexpected"
+                with mock.patch('megatron.training.checkpointing.check_checkpoint_args'):
+                    with mock.patch('megatron.training.checkpointing.update_num_microbatches'):
+                        iteration, _ = load_checkpoint(model_b, optimizer_b, None, strict=False)
+
+                assert iteration == 1
+
+                for m in model_b:
+                    for name, p in m.named_parameters():
+                        if name.endswith(ADAPTER_PARAM_SUFFIX):
+                            assert torch.allclose(p.float(), torch.full_like(p.float(), 42.0)), (
+                                f"adapter param {name} not restored, got {p.flatten()[:4]}"
+                            )
+                        else:
+                            assert torch.equal(p.detach(), frozen_before[name]), (
+                                f"frozen param {name} was modified by the adapter-only load"
+                            )
+
+                # Resuming PEFT training must restore the adapter's optimizer state
+                # (not just its weight and the iteration count).
+                optimizer_b_state = optimizer_b.state_dict()
+                diffs = diff(optimizer_a_state, optimizer_b_state)
+                assert not any(map(bool, diffs)), (Utils.rank, diffs)

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 import torch.distributed.checkpoint
 
+from megatron.core.dist_checkpointing.mapping import ShardedTensor, ShardedTensorFactory
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.num_microbatches_calculator import (
@@ -23,6 +24,7 @@ from megatron.training.checkpointing import (
     CheckpointType,
     _build_sharded_state_dict_metadata,
     _load_base_checkpoint,
+    filter_state_dict_to_trainable_params,
     get_checkpoint_tracker_filename,
     load_args_from_checkpoint,
     load_checkpoint,
@@ -653,3 +655,118 @@ class TestBuildShardedStateDictMetadata:
         args = _make_metadata_args()
         metadata = _build_sharded_state_dict_metadata(args, dp_cp_group=self.DUMMY_GROUP)
         assert 'distrib_optim_sharding_type' not in metadata
+
+
+def _sharded_tensor(key, requires_grad, shape=(2, 2)):
+    """Build a minimal, non-fragmented ShardedTensor wrapping a CPU tensor."""
+    data = torch.zeros(shape)
+    data.requires_grad_(requires_grad)
+    return ShardedTensor.from_rank_offsets(key, data)
+
+
+def _sharded_tensor_factory(key, requires_grad, shape=(2, 2)):
+    """Build a minimal ShardedTensorFactory wrapping a CPU tensor (e.g. the SwiGLU/split-tensor
+    checkpoint factories in `megatron/core/transformer/mlp.py` and `megatron/core/ssm/utils.py`,
+    which store the original, un-split parameter as `.data`)."""
+    data = torch.zeros(shape)
+    data.requires_grad_(requires_grad)
+    return ShardedTensorFactory(key, data, build_fn=lambda *a: {}, merge_fn=lambda x: x)
+
+
+class TestFilterStateDictToTrainableParams:
+    """``filter_state_dict_to_trainable_params`` is a pure function over an already-built
+    checkpoint state dict (as produced by ``generate_state_dict``), so it can be exercised
+    entirely on CPU with synthetic ``ShardedTensor``/plain-tensor leaves -- no
+    torch.distributed initialization or real model is needed.
+    """
+
+    def test_keeps_trainable_drops_frozen_leaves(self):
+        state_dict = {
+            'model': {
+                'base.weight': _sharded_tensor('base.weight', requires_grad=False),
+                'adapter.lora_a': _sharded_tensor('adapter.lora_a', requires_grad=True),
+            }
+        }
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert set(filtered['model'].keys()) == {'adapter.lora_a'}
+
+    def test_drops_fully_frozen_submodule_entirely(self):
+        state_dict = {
+            'model': {
+                'layers': {
+                    '0': {
+                        'base.weight': _sharded_tensor('layers.0.base.weight', requires_grad=False),
+                        'base.bias': _sharded_tensor('layers.0.base.bias', requires_grad=False),
+                    },
+                    '1': {
+                        'base.weight': _sharded_tensor('layers.1.base.weight', requires_grad=False),
+                        'adapter.lora_b': _sharded_tensor('layers.1.adapter.lora_b', requires_grad=True),
+                    },
+                }
+            }
+        }
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        # Layer 0 has no trainable leaves at all, so the whole subtree is dropped.
+        assert '0' not in filtered['model']['layers']
+        assert set(filtered['model']['layers']['1'].keys()) == {'adapter.lora_b'}
+
+    def test_multiple_pipeline_model_chunks_are_each_filtered(self):
+        state_dict = {
+            'model0': {'w': _sharded_tensor('model0.w', requires_grad=False)},
+            'model1': {'w': _sharded_tensor('model1.w', requires_grad=True)},
+        }
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert filtered['model0'] == {}
+        assert set(filtered['model1'].keys()) == {'w'}
+
+    def test_non_model_sections_pass_through_unchanged(self):
+        state_dict = {
+            'model': {'adapter.lora_a': _sharded_tensor('adapter.lora_a', requires_grad=True)},
+            'iteration': 100,
+            'checkpoint_version': 3.0,
+            'optimizer': {'anything': _sharded_tensor('optimizer.anything', requires_grad=False)},
+            'rng_state': [{'random_rng_state': (1, 2, 3)}],
+        }
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert filtered['iteration'] == 100
+        assert filtered['checkpoint_version'] == 3.0
+        # 'optimizer' is not a model section, so it is untouched even though it contains a
+        # frozen-looking ShardedTensor: the optimizer already only holds trainable-parameter
+        # state by construction (only trainable params are ever passed to the optimizer).
+        assert 'anything' in filtered['optimizer']
+        assert filtered['rng_state'] == state_dict['rng_state']
+
+    def test_plain_tensor_leaves_are_filtered_by_requires_grad(self):
+        # Covers the non-torch_dist ('torch'/'torch_dcp'/'fsdp_dtensor') model_sd shape, where
+        # model sections hold plain tensors instead of ShardedTensor. (Callers must still pass
+        # `state_dict(keep_vars=True)`-equivalent tensors for requires_grad to survive; see
+        # the --ckpt-format torch_dist validation in arguments.py.)
+        frozen = torch.zeros(2)
+        frozen.requires_grad_(False)
+        trainable = torch.zeros(2)
+        trainable.requires_grad_(True)
+        state_dict = {'model': {'base.weight': frozen, 'adapter.lora_a': trainable}}
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert set(filtered['model'].keys()) == {'adapter.lora_a'}
+
+    def test_non_tensor_leaves_pass_through_unconditionally(self):
+        # e.g. ShardedObject / LocalNonpersistentObject / plain metadata values.
+        state_dict = {'model': {'some_flag': True, 'adapter.lora_a': _sharded_tensor('a', True)}}
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert filtered['model']['some_flag'] is True
+        assert set(filtered['model'].keys()) == {'some_flag', 'adapter.lora_a'}
+
+    def test_sharded_tensor_factory_leaves_are_filtered_by_requires_grad(self):
+        # ShardedTensorFactory wraps the original (un-split/un-fused) parameter as `.data` --
+        # e.g. the SwiGLU and split-tensor checkpoint factories -- so it must be filtered the
+        # same way as a plain ShardedTensor, by the factory's own `.data.requires_grad`.
+        state_dict = {
+            'model': {
+                'base.linear_fc1': _sharded_tensor_factory('base.linear_fc1', requires_grad=False),
+                'adapter.linear_fc1': _sharded_tensor_factory(
+                    'adapter.linear_fc1', requires_grad=True
+                ),
+            }
+        }
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert set(filtered['model'].keys()) == {'adapter.linear_fc1'}

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 import torch.distributed.checkpoint
 
-from megatron.core.dist_checkpointing.mapping import ShardedTensor, ShardedTensorFactory
+from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedTensor, ShardedTensorFactory
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.num_microbatches_calculator import (
@@ -770,3 +770,25 @@ class TestFilterStateDictToTrainableParams:
         }
         filtered = filter_state_dict_to_trainable_params(state_dict)
         assert set(filtered['model'].keys()) == {'adapter.linear_fc1'}
+
+    def test_extra_state_is_dropped_even_under_a_trainable_module(self):
+        # A ShardedObject's `.key` carries no requires_grad signal of its own. If a
+        # frozen module's `_extra_state` were kept (the generic "keep unconditionally"
+        # fallback) while its sibling weight/bias got dropped as frozen, the checkpoint
+        # would be structurally inconsistent (extra_state present, weight/bias missing
+        # at the same module path) and fail to load. So `_extra_state` is dropped
+        # unconditionally, matching Megatron-Bridge's proven PEFT checkpoint filter,
+        # even when the sibling parameter at the same path is trainable.
+        extra_state = ShardedObject(
+            'decoder.layers.0.mlp.linear_fc1._extra_state', b'', (1,), (0,)
+        )
+        state_dict = {
+            'model': {
+                'decoder.layers.0.mlp.linear_fc1.weight': _sharded_tensor(
+                    'decoder.layers.0.mlp.linear_fc1.weight', requires_grad=True
+                ),
+                'decoder.layers.0.mlp.linear_fc1._extra_state': extra_state,
+            }
+        }
+        filtered = filter_state_dict_to_trainable_params(state_dict)
+        assert set(filtered['model'].keys()) == {'decoder.layers.0.mlp.linear_fc1.weight'}


### PR DESCRIPTION
Fixes #7270

## What this does

Adds `--save-trainable-params-only`, which filters a `torch_dist` checkpoint's
model section(s) down to parameters with `requires_grad=True` at save time, and
filters the load *request* the same way at load time. For PEFT/LoRA-style
fine-tuning (frozen base model, a small number of trainable adapter parameters),
this keeps the saved checkpoint proportional to the adapter instead of
duplicating the frozen base weights on every save, and lets that checkpoint be
loaded back onto a matching base model (`--dist-ckpt-strictness log_unexpected`
required at load time; see the new config field's docstring).

## Verification

Beyond the unit tests below, this was verified end-to-end on a real GPTModel
(2x A100) across `--tensor-model-parallel-size` in {1,2},
`--pipeline-model-parallel-size` in {1,2}, and `--swiglu`/`gated_linear_unit`
in {True,False}: adapter-only checkpoints are smaller than full checkpoints,
frozen base weights survive a non-strict load untouched, adapter weights and
optimizer momentum state (`exp_avg`/`exp_avg_sq`) are correctly restored on
resume, and iteration count is correctly restored.

It was also verified against Megatron-Bridge's real, unmodified `LoRA`/`PEFT`
implementation (imported directly, not reimplemented): Bridge's LoRA correctly
applies to a Megatron-Core `GPTModel`, and a checkpoint saved by this PR's
`save_checkpoint(save_trainable_params_only=True)` loads correctly via Bridge's
real `apply_peft_adapter_filter_to_state_dict` substituted into
`load_checkpoint()` — for Bridge's actual production configuration
(`DistributedOptimizer`, real training before checkpointing; Bridge's own
`test_finetune_lora.py` GPU CI test already exercises this combination and
passes).

### Tests added
- `tests/unit_tests/test_checkpointing.py::TestFilterStateDictToTrainableParams`
  — pure-function unit tests for the save-side filter (frozen/trainable leaves,
  `ShardedTensorFactory`, `_extra_state`, multi-PP-stage sections).
- `tests/unit_tests/dist_checkpointing/test_peft_checkpointing.py` — real
  GPTModel save → load → resume round trip, parametrized over TP/PP/SwiGLU (6
  cases), including optimizer momentum-state restoration.

## Known limitations (not fixed in this PR)

- **`--use-distributed-optimizer` does not support any frozen parameters** at
  all today (`DistributedOptimizer._build_optimizer_group_ranges` raises a
  `KeyError` if a frozen param's grad-buffer bucket wasn't built the same way
  the optimizer's param groups were) — a pre-existing Megatron-Core limitation,
  unrelated to this change, that a real PEFT run must work around either by
  freezing parameters before the model is DDP-wrapped (so the grad buffer and
  optimizer param groups agree from construction) or by using the standard
  `wrap_with_ddp=True` training entrypoint path.
- **A checkpoint saved before the optimizer has ever taken a single step, for
  a model with a `ShardedTensorFactory`-wrapped trainable parameter (e.g. a
  LoRA adapter on a SwiGLU-gated `linear_fc1`), can fail to load** with
  `apply_factory_merges: Different dict keys encountered`. `save_checkpoint`
  never calls `init_state_fn` (so a never-stepped `torch.optim.Adam`'s
  `state` is empty and nothing is written for the optimizer section), while
  `load_checkpoint` always does (so a fresh optimizer's load request expects
  zero-seeded state for every trainable param) — for an ordinary `ShardedTensor`
  this asymmetry is tolerated by `--dist-ckpt-strictness log_unexpected`, but
  `apply_factory_merges`'s key-set equality check has no such escape hatch.
  This is a pre-existing `dist_checkpointing`/optimizer gap independent of PEFT
  or this flag specifically (it would affect any GLU-gated model's iteration-0
  checkpoint under the plain optimizer path), not something this PR introduces,
  and does not affect a normal training run (which always takes at least one
  step before its first checkpoint save).
